### PR TITLE
feat: add --engine-path flag for local engine development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Build and Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: Build and Test (${{ matrix.os }})
 
     steps:
       - name: Checkout

--- a/src/engine_resolver.zig
+++ b/src/engine_resolver.zig
@@ -205,7 +205,7 @@ pub fn fetchPackageHash(allocator: std.mem.Allocator, url: []const u8) ![]const 
     defer allocator.free(output);
 
     const result = try child.wait();
-    if (result.Exited != 0) {
+    if (result != .Exited or result.Exited != 0) {
         return VersionError.FetchFailed;
     }
 
@@ -218,7 +218,7 @@ pub fn fetchPackageHash(allocator: std.mem.Allocator, url: []const u8) ![]const 
     return try allocator.dupe(u8, hash);
 }
 
-/// Create a bootstrap build.zig.zon for the given engine version
+/// Create a bootstrap build.zig.zon for the given engine version (remote)
 fn createBootstrapBuildZon(allocator: std.mem.Allocator, dir: std.fs.Dir, version: []const u8, hash: []const u8) !void {
     const content = try std.fmt.allocPrint(allocator,
         \\.{{
@@ -243,9 +243,158 @@ fn createBootstrapBuildZon(allocator: std.mem.Allocator, dir: std.fs.Dir, versio
     try file.writeAll(content);
 }
 
+/// Convert backslashes to forward slashes for use in build.zig.zon
+/// Zig's build system accepts forward slashes on all platforms
+fn normalizeToForwardSlashes(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+    if (std.fs.path.sep == '/') {
+        // Already using forward slashes
+        return try allocator.dupe(u8, path);
+    }
+
+    // Replace backslashes with forward slashes
+    const result = try allocator.alloc(u8, path.len);
+    for (path, 0..) |c, i| {
+        result[i] = if (c == '\\') '/' else c;
+    }
+    return result;
+}
+
+/// Create a bootstrap build.zig.zon using a local engine path.
+/// The path needs to be relative to the bootstrap directory.
+fn createBootstrapBuildZonWithLocalPath(allocator: std.mem.Allocator, dir: std.fs.Dir, local_path: []const u8) !void {
+    // Convert to relative path from .labelle-bootstrap directory
+    // Since bootstrap is in .labelle-bootstrap/, we need to compute the relative path
+    // from cwd/.labelle-bootstrap to the engine path
+    var relative_path: []const u8 = undefined;
+    var needs_free = false;
+
+    if (std.fs.path.isAbsolute(local_path)) {
+        // For absolute paths, compute relative path from bootstrap dir to engine
+        // Get current working directory
+        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const cwd = std.fs.cwd().realpath(".", &cwd_buf) catch {
+            std.debug.print("Error: Could not determine current directory\n", .{});
+            return error.InvalidPath;
+        };
+
+        // Resolve engine path to absolute - propagate error if path doesn't exist
+        var engine_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const engine_abs = std.fs.cwd().realpath(local_path, &engine_buf) catch {
+            std.debug.print("Error: Engine path does not exist: {s}\n", .{local_path});
+            return error.InvalidPath;
+        };
+
+        // Compute relative path from cwd to engine
+        const rel_from_cwd = try computeRelativePath(allocator, cwd, engine_abs);
+        defer allocator.free(rel_from_cwd);
+
+        // Add parent dir prefix to go up from .labelle-bootstrap to cwd
+        // Always use forward slashes in build.zig.zon (Zig handles this on all platforms)
+        const normalized = try normalizeToForwardSlashes(allocator, rel_from_cwd);
+        defer allocator.free(normalized);
+        relative_path = try std.fmt.allocPrint(allocator, "../{s}", .{normalized});
+        needs_free = true;
+    } else {
+        // Already relative - just add parent dir prefix to go up from bootstrap dir
+        // Always use forward slashes in build.zig.zon (Zig handles this on all platforms)
+        const normalized = try normalizeToForwardSlashes(allocator, local_path);
+        defer allocator.free(normalized);
+        relative_path = try std.fmt.allocPrint(allocator, "../{s}", .{normalized});
+        needs_free = true;
+    }
+
+    defer if (needs_free) allocator.free(relative_path);
+
+    const content = try std.fmt.allocPrint(allocator,
+        \\.{{
+        \\    .fingerprint = 0x3dda308fa396ad7d,
+        \\    .name = .labelle_bootstrap,
+        \\    .version = "0.0.0",
+        \\    .minimum_zig_version = "0.15.2",
+        \\    .dependencies = .{{
+        \\        .@"labelle-engine" = .{{
+        \\            .path = "{s}",
+        \\        }},
+        \\    }},
+        \\    .paths = .{{ "build.zig", "build.zig.zon" }},
+        \\}}
+        \\
+    , .{relative_path});
+    defer allocator.free(content);
+
+    var file = try dir.createFile("build.zig.zon", .{});
+    defer file.close();
+    try file.writeAll(content);
+}
+
+/// Compute relative path from `from` directory to `to` path.
+/// Both paths must be absolute. Uses platform-specific path separator.
+fn computeRelativePath(allocator: std.mem.Allocator, from: []const u8, to: []const u8) ![]const u8 {
+    const sep = std.fs.path.sep;
+
+    // Find common prefix
+    var common_len: usize = 0;
+    var last_sep: usize = 0;
+
+    const min_len = @min(from.len, to.len);
+    for (0..min_len) |i| {
+        if (from[i] != to[i]) break;
+        if (from[i] == sep) last_sep = i;
+        common_len = i + 1;
+    }
+
+    // If one is prefix of the other, last_sep should be at the end of the shorter one
+    if (common_len == min_len) {
+        if (from.len == min_len and (to.len == min_len or to[min_len] == sep)) {
+            last_sep = min_len;
+        } else if (to.len == min_len and from[min_len] == sep) {
+            last_sep = min_len;
+        }
+    }
+
+    // Count how many directories to go up from `from`
+    var up_count: usize = 0;
+    if (last_sep < from.len) {
+        for (from[last_sep..]) |c| {
+            if (c == sep) up_count += 1;
+        }
+    }
+
+    // Build the relative path
+    var result: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer result.deinit(allocator);
+
+    // Add ../ (or ..\) for each directory to go up
+    for (0..up_count) |_| {
+        try result.appendSlice(allocator, "..");
+        try result.append(allocator, sep);
+    }
+
+    // Add the remaining path from `to`
+    if (last_sep < to.len) {
+        var suffix = to[last_sep..];
+        // Skip leading separator
+        if (suffix.len > 0 and suffix[0] == sep) {
+            suffix = suffix[1..];
+        }
+        try result.appendSlice(allocator, suffix);
+    }
+
+    // Handle edge case: same directory
+    if (result.items.len == 0) {
+        try result.appendSlice(allocator, ".");
+    }
+
+    // Remove trailing separator if present
+    if (result.items.len > 1 and result.items[result.items.len - 1] == sep) {
+        _ = result.pop();
+    }
+
+    return try result.toOwnedSlice(allocator);
+}
+
 /// Create a bootstrap build.zig that runs the engine's generator
-fn createBootstrapBuildZig(dir: std.fs.Dir, project_path: []const u8) !void {
-    _ = project_path;
+fn createBootstrapBuildZig(dir: std.fs.Dir) !void {
     const content =
         \\const std = @import("std");
         \\
@@ -282,7 +431,7 @@ fn createBootstrapBuildZig(dir: std.fs.Dir, project_path: []const u8) !void {
 }
 
 /// Run the engine's generator with the given arguments.
-pub fn runEngineGenerator(allocator: std.mem.Allocator, version: []const u8, project_path: []const u8) !void {
+pub fn runEngineGenerator(allocator: std.mem.Allocator, version: []const u8) !void {
     const bootstrap_dir_path = try getBootstrapDir(allocator);
     defer allocator.free(bootstrap_dir_path);
 
@@ -317,7 +466,7 @@ pub fn runEngineGenerator(allocator: std.mem.Allocator, version: []const u8, pro
 
     // Create bootstrap build files
     try createBootstrapBuildZon(allocator, bootstrap_dir, version, hash);
-    try createBootstrapBuildZig(bootstrap_dir, project_path);
+    try createBootstrapBuildZig(bootstrap_dir);
 
     std.debug.print("Running generator...\n", .{});
 
@@ -330,8 +479,70 @@ pub fn runEngineGenerator(allocator: std.mem.Allocator, version: []const u8, pro
     child.cwd = bootstrap_dir_path;
 
     const result = try child.spawnAndWait();
-    if (result.Exited != 0) {
-        std.debug.print("Generator failed with exit code {}\n", .{result.Exited});
+    const exit_code = switch (result) {
+        .Exited => |code| code,
+        .Signal => |sig| {
+            std.debug.print("Generator killed by signal {}\n", .{sig});
+            return error.GeneratorFailed;
+        },
+        else => {
+            std.debug.print("Generator terminated abnormally\n", .{});
+            return error.GeneratorFailed;
+        },
+    };
+    if (exit_code != 0) {
+        std.debug.print("Generator failed with exit code {}\n", .{exit_code});
+        return error.GeneratorFailed;
+    }
+
+    std.debug.print("Generation complete!\n", .{});
+}
+
+/// Run the engine's generator using a local engine path.
+/// This is useful for CI testing against a local checkout.
+pub fn runEngineGeneratorWithLocalPath(allocator: std.mem.Allocator, local_path: []const u8) !void {
+
+    const bootstrap_dir_path = try getBootstrapDir(allocator);
+    defer allocator.free(bootstrap_dir_path);
+
+    // Create bootstrap directory
+    std.fs.cwd().makeDir(bootstrap_dir_path) catch |err| {
+        if (err != error.PathAlreadyExists) return err;
+    };
+
+    var bootstrap_dir = try std.fs.cwd().openDir(bootstrap_dir_path, .{});
+    defer bootstrap_dir.close();
+
+    std.debug.print("Using local engine at: {s}\n", .{local_path});
+
+    // Create bootstrap build files with local path
+    try createBootstrapBuildZonWithLocalPath(allocator, bootstrap_dir, local_path);
+    try createBootstrapBuildZig(bootstrap_dir);
+
+    std.debug.print("Running generator...\n", .{});
+
+    // Run the generator from the bootstrap directory
+    var child = std.process.Child.init(&.{
+        "zig",
+        "build",
+        "run",
+    }, allocator);
+    child.cwd = bootstrap_dir_path;
+
+    const result = try child.spawnAndWait();
+    const exit_code = switch (result) {
+        .Exited => |code| code,
+        .Signal => |sig| {
+            std.debug.print("Generator killed by signal {}\n", .{sig});
+            return error.GeneratorFailed;
+        },
+        else => {
+            std.debug.print("Generator terminated abnormally\n", .{});
+            return error.GeneratorFailed;
+        },
+    };
+    if (exit_code != 0) {
+        std.debug.print("Generator failed with exit code {}\n", .{exit_code});
         return error.GeneratorFailed;
     }
 
@@ -354,4 +565,45 @@ test "resolveVersion returns version as-is for non-latest without validation" {
     const resolved = try resolveVersion(std.testing.allocator, "0.33.0", false);
     try std.testing.expectEqualStrings("0.33.0", resolved.version);
     try std.testing.expect(!resolved.allocated);
+}
+
+// Helper to build platform-specific test paths
+fn testPath(comptime path: []const u8) []const u8 {
+    comptime {
+        var result: [path.len]u8 = undefined;
+        for (path, 0..) |c, i| {
+            result[i] = if (c == '/') std.fs.path.sep else c;
+        }
+        return &result;
+    }
+}
+
+test "computeRelativePath: engine is ancestor of project" {
+    // Project: /a/b/engine/ci/test, Engine: /a/b/engine
+    // Expected: ../.. (up from test, up from ci)
+    const result = try computeRelativePath(std.testing.allocator, testPath("/a/b/engine/ci/test"), testPath("/a/b/engine"));
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings(testPath("../.."), result);
+}
+
+test "computeRelativePath: engine is sibling of project" {
+    // Project: /a/b/project, Engine: /a/b/engine
+    // Expected: ../engine
+    const result = try computeRelativePath(std.testing.allocator, testPath("/a/b/project"), testPath("/a/b/engine"));
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings(testPath("../engine"), result);
+}
+
+test "computeRelativePath: same directory" {
+    const result = try computeRelativePath(std.testing.allocator, testPath("/a/b/c"), testPath("/a/b/c"));
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings(".", result);
+}
+
+test "computeRelativePath: engine is deeper than project" {
+    // Project: /a/b, Engine: /a/b/c/d
+    // Expected: c/d
+    const result = try computeRelativePath(std.testing.allocator, testPath("/a/b"), testPath("/a/b/c/d"));
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings(testPath("c/d"), result);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,6 +48,7 @@ const Options = struct {
     project_path: []const u8 = ".",
     project_name: ?[]const u8 = null,
     engine_version: ?[]const u8 = null,
+    engine_path: ?[]const u8 = null, // Local engine path (for development/CI)
     main_only: bool = false,
     release: bool = false,
     backend: ?[]const u8 = null,
@@ -75,7 +76,15 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    const options = parseArgs(args);
+    var options = parseArgs(args);
+
+    // Check for LABELLE_ENGINE_PATH environment variable (cross-platform)
+    var env_engine_path: ?[]const u8 = null;
+    if (options.engine_path == null) {
+        env_engine_path = std.process.getEnvVarOwned(allocator, "LABELLE_ENGINE_PATH") catch null;
+        options.engine_path = env_engine_path;
+    }
+    defer if (env_engine_path) |p| allocator.free(p);
 
     if (options.show_help) {
         printCommandHelp(options.command);
@@ -167,6 +176,8 @@ fn parseArgs(args: []const []const u8) Options {
             options.upgrade_force = true;
         } else if (std.mem.startsWith(u8, arg, "--engine=")) {
             options.engine_version = arg["--engine=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--engine-path=")) {
+            options.engine_path = arg["--engine-path=".len..];
         } else if (std.mem.startsWith(u8, arg, "--backend=")) {
             options.backend = arg["--backend=".len..];
         } else if (std.mem.startsWith(u8, arg, "--ecs=")) {
@@ -261,8 +272,17 @@ fn runInit(allocator: std.mem.Allocator, options: Options) !void {
 }
 
 fn runGenerate(allocator: std.mem.Allocator, options: Options) !void {
-    _ = options;
     std.debug.print("Generating project files...\n", .{});
+
+    // Check if using local engine path
+    if (options.engine_path) |local_path| {
+        // Use local engine path (for development/CI)
+        engine_resolver.runEngineGeneratorWithLocalPath(allocator, local_path) catch |err| {
+            std.debug.print("Error running generator with local path: {}\n", .{err});
+            return;
+        };
+        return;
+    }
 
     // Read project.labelle to get engine version
     const config = project_config.readProjectConfig(allocator, ".") catch |err| {
@@ -284,7 +304,7 @@ fn runGenerate(allocator: std.mem.Allocator, options: Options) !void {
     std.debug.print("Using labelle-engine {s}\n", .{resolved.version});
 
     // Fetch engine and run its generator
-    engine_resolver.runEngineGenerator(allocator, resolved.version, ".") catch |err| {
+    engine_resolver.runEngineGenerator(allocator, resolved.version) catch |err| {
         if (err == engine_resolver.VersionError.FetchFailed) {
             return; // Error already printed
         }
@@ -615,9 +635,13 @@ fn printHelp() void {
         \\  version         Show CLI version
         \\
         \\Options:
-        \\  --engine=VER    Specify labelle-engine version (default: from project.labelle)
-        \\  --release, -r   Build in release mode
-        \\  --help, -h      Show help for a command
+        \\  --engine=VER        Specify labelle-engine version (default: from project.labelle)
+        \\  --engine-path=PATH  Use local engine path instead of fetching from registry
+        \\  --release, -r       Build in release mode
+        \\  --help, -h          Show help for a command
+        \\
+        \\Environment Variables:
+        \\  LABELLE_ENGINE_PATH   Path to local labelle-engine checkout (for development/CI)
         \\
         \\Examples:
         \\  labelle init my-game
@@ -631,6 +655,10 @@ fn printHelp() void {
         \\  labelle wasm serve
         \\  labelle android build
         \\  labelle android install
+        \\
+        \\  # Using local engine (for development/CI)
+        \\  labelle build --engine-path=/path/to/labelle-engine
+        \\  LABELLE_ENGINE_PATH=/path/to/engine labelle build
         \\
     , .{cli_version});
 }
@@ -658,8 +686,12 @@ fn printCommandHelp(command: Command) void {
             \\Usage: labelle generate [options]
             \\
             \\Options:
-            \\  --main-only     Only regenerate main.zig
-            \\  --no-fetch      Skip fetching dependency hashes
+            \\  --main-only         Only regenerate main.zig
+            \\  --no-fetch          Skip fetching dependency hashes
+            \\  --engine-path=PATH  Use local engine instead of fetching from registry
+            \\
+            \\Environment Variables:
+            \\  LABELLE_ENGINE_PATH   Path to local labelle-engine checkout
             \\
         , .{}),
         .upgrade => std.debug.print(

--- a/src/project_config.zig
+++ b/src/project_config.zig
@@ -5,6 +5,12 @@
 
 const std = @import("std");
 
+pub const WindowConfig = struct {
+    title: ?[]const u8 = null,
+    width: ?i32 = null,
+    height: ?i32 = null,
+};
+
 pub const ProjectConfig = struct {
     name: ?[]const u8 = null,
     engine_version: ?[]const u8 = null,
@@ -15,6 +21,7 @@ pub const ProjectConfig = struct {
     window_width: ?i32 = null,
     window_height: ?i32 = null,
     window_title: ?[]const u8 = null,
+    window: ?WindowConfig = null,
     raw_content: []const u8,
 
     pub fn deinit(self: *const ProjectConfig, allocator: std.mem.Allocator) void {
@@ -50,6 +57,15 @@ pub fn readProjectConfig(allocator: std.mem.Allocator, project_path: []const u8)
     config.window_width = extractIntField(content, ".width");
     config.window_height = extractIntField(content, ".height");
     config.window_title = extractStringField(content, ".title");
+
+    // Create WindowConfig if any window field is set
+    if (config.window_width != null or config.window_height != null or config.window_title != null) {
+        config.window = WindowConfig{
+            .width = config.window_width,
+            .height = config.window_height,
+            .title = config.window_title,
+        };
+    }
 
     return config;
 }


### PR DESCRIPTION
## Summary

Add support for using a local labelle-engine checkout instead of fetching from the package registry. This is useful for:

- CI testing against the current branch of labelle-engine
- Local development with modified engine code

## Changes

- Add `--engine-path=PATH` option to CLI
- Add `LABELLE_ENGINE_PATH` environment variable support
- Create bootstrap `build.zig.zon` with `.path` instead of `.url/.hash` when using local engine
- Compute relative path from bootstrap dir to engine path automatically

## Usage

```bash
# Using flag
labelle build --engine-path=/path/to/labelle-engine

# Using environment variable
LABELLE_ENGINE_PATH=/path/to/engine labelle build
```

## Example CI Usage

```yaml
- name: Build with CLI
  env:
    LABELLE_ENGINE_PATH: ${{ github.workspace }}
  run: |
    labelle build -Dtarget=aarch64-linux-android
```

## Test plan

- [x] Build CLI successfully
- [x] Test `--engine-path` flag with absolute path
- [x] Test `LABELLE_ENGINE_PATH` environment variable
- [x] Verify generated `build.zig.zon` has correct relative path
- [x] Verify project builds with local engine

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)