### PR TITLE
fix: use apple_a14 CPU model for iOS simulator NEON support

### DIFF
--- a/src/ios/ios_commands.zig
+++ b/src/ios/ios_commands.zig
@@ -978,11 +978,12 @@ fn generateIosBuildZig(allocator: std.mem.Allocator, ios_config: IosConfig) ![]c
         \\    }});
         \\
         \\    // iOS Simulator Target (Apple Silicon Macs)
+        \\    // Use apple_a14 to enable NEON SIMD features required by box2d physics
         \\    const ios_sim_target = b.resolveTargetQuery(.{{
         \\        .cpu_arch = .aarch64,
         \\        .os_tag = .ios,
         \\        .abi = .simulator,
-        \\        .cpu_model = .{{ .explicit = &std.Target.aarch64.cpu.apple_m1 }},
+        \\        .cpu_model = .{{ .explicit = &std.Target.aarch64.cpu.apple_a14 }},
         \\    }});
         \\
         \\    // iOS Device build


### PR DESCRIPTION
## Summary
- Changed iOS simulator target CPU model from `apple_m1` to `apple_a14`
- Ensures NEON SIMD intrinsics work correctly for box2d physics

## Context
This was discovered during labelle-engine PR #248 (mobile CI work). The box2d physics library uses NEON SIMD intrinsics that require specific ARM features enabled. Using `apple_a14` ensures these features are available.

## Related
- labelle-toolkit/labelle-engine#248 - Mobile CI workflow
- labelle-toolkit/labelle-engine#250 - Mobile CLI support issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)