### PR TITLE
Fix update fallback message to not suggest sudo

### DIFF
--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -197,11 +197,17 @@ pub fn cmdUpdate(allocator: std.mem.Allocator, cmd_args: []const []const u8) !vo
                 },
                 else => {
                     std.debug.print("labelle: could not move binary to {s}\n", .{bin_path});
+                    std.debug.print("  downloaded v{s} to {s}\n", .{ target_version, tmp_path });
+                    std.debug.print("  to complete the update, run:\n", .{});
+                    std.debug.print("    mv '{s}' '{s}'\n", .{ tmp_path, bin_path });
                     return;
                 },
             }
         } else |_| {
             std.debug.print("labelle: could not move binary to {s}\n", .{bin_path});
+            std.debug.print("  downloaded v{s} to {s}\n", .{ target_version, tmp_path });
+            std.debug.print("  to complete the update, run:\n", .{});
+            std.debug.print("    mv '{s}' '{s}'\n", .{ tmp_path, bin_path });
             return;
         }
 


### PR DESCRIPTION
## Summary
- When the automatic `mv` fails during `labelle update`, the error message now shows the exact `mv` command without `sudo`, since `~/.labelle/bin/` is user-owned
- The old message just said "move it manually" without showing the command

## Test plan
- [ ] Run `labelle update` on a system where the automatic `mv` would fail (e.g. permission issue on temp file)
- [ ] Verify the fallback message shows `mv /tmp/labelle-update ~/.labelle/bin/labelle` without `sudo`

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)