### PR TITLE
Inject all engine subsystems into plugins

### DIFF
--- a/generator/src/build_files.zig
+++ b/generator/src/build_files.zig
@@ -33,16 +33,6 @@ pub fn generateBuildZig(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]con
         try w.print("    const plugin_{s}_mod = plugin_{s}_dep.module(\"labelle_{s}\");\n", .{ plugin.name, plugin.name, plugin.name });
     }
 
-    // Shared framework dep overrides — ensures plugins use the same package
-    // instances as the game, preventing type mismatches (RFC #42).
-    if (cfg.plugins.len > 0) {
-        try w.writeByte('\n');
-        for (cfg.plugins) |plugin| {
-            try w.print("    plugin_{s}_mod.addImport(\"labelle-core\", core_mod);\n", .{plugin.name});
-            try w.print("    plugin_{s}_mod.addImport(\"labelle-gfx\", gfx_mod);\n", .{plugin.name});
-        }
-    }
-
     // Backend dep — always the standard backend (never a merged GUI+backend package)
     switch (cfg.backend) {
         .raylib => try tpl.writeSection(build_zig_tmpl, "backend_raylib", w),
@@ -68,6 +58,34 @@ pub fn generateBuildZig(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]con
     // GUI plugin dep (manifest-driven — no switch on GUI type)
     if (cfg.resolved_gui != null) {
         try tpl.renderSection(build_zig_tmpl, "gui_backend", .{ .gui_dep_name = "labelle_gui" }, w);
+    }
+
+    // Inject shared modules into plugins — ensures all plugins use the same
+    // package instances and have access to engine subsystems (#42, #61).
+    if (cfg.plugins.len > 0) {
+        try w.writeByte('\n');
+        for (cfg.plugins) |plugin| {
+            // Core + gfx — always available
+            try w.print("    plugin_{s}_mod.addImport(\"labelle-core\", core_mod);\n", .{plugin.name});
+            try w.print("    plugin_{s}_mod.addImport(\"labelle-gfx\", gfx_mod);\n", .{plugin.name});
+            try w.print("    plugin_{s}_mod.addImport(\"labelle-engine\", engine_mod);\n", .{plugin.name});
+
+            // ECS backend — gives plugins Ecs(Backend) access for entity queries
+            if (cfg.ecs != .mock) {
+                try w.print("    plugin_{s}_mod.addImport(\"ecs_backend\", ecs_mod);\n", .{plugin.name});
+            }
+
+            // Backend modules — rendering, input, audio, window
+            try w.print("    plugin_{s}_mod.addImport(\"backend_gfx\", backend_gfx);\n", .{plugin.name});
+            try w.print("    plugin_{s}_mod.addImport(\"backend_input\", backend_input);\n", .{plugin.name});
+            try w.print("    plugin_{s}_mod.addImport(\"backend_audio\", backend_audio);\n", .{plugin.name});
+            try w.print("    plugin_{s}_mod.addImport(\"backend_window\", backend_window);\n", .{plugin.name});
+
+            // GUI backend — if a GUI plugin is active
+            if (cfg.hasGui()) {
+                try w.print("    plugin_{s}_mod.addImport(\"gui_backend\", gui_mod);\n", .{plugin.name});
+            }
+        }
     }
 
     if (cfg.platform == .wasm) {

--- a/generator/test/tests.zig
+++ b/generator/test/tests.zig
@@ -361,6 +361,79 @@ pub const PLUGINS = struct {
         try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod") != null);
     }
 
+    test "plugins receive all engine subsystem imports" {
+        const build_zig = try generate.generateBuildZig(std.testing.allocator, .{
+            .name = "test-game",
+            .backend = .raylib,
+            .ecs = .zig_ecs,
+            .plugins = &.{
+                .{ .name = "physics", .repo = "github.com/labelle-toolkit/labelle-physics", .version = "0.1.0" },
+            },
+        });
+        defer std.testing.allocator.free(build_zig);
+
+        // Core + gfx + engine (always injected)
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"labelle-core\", core_mod)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"labelle-gfx\", gfx_mod)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"labelle-engine\", engine_mod)") != null);
+
+        // ECS backend (injected when ecs != mock)
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"ecs_backend\", ecs_mod)") != null);
+
+        // Backend modules (always injected)
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"backend_gfx\", backend_gfx)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"backend_input\", backend_input)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"backend_audio\", backend_audio)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"backend_window\", backend_window)") != null);
+    }
+
+    test "plugins with mock ecs omit ecs_backend import" {
+        const build_zig = try generate.generateBuildZig(std.testing.allocator, .{
+            .name = "test-game",
+            .backend = .raylib,
+            .ecs = .mock,
+            .plugins = &.{
+                .{ .name = "physics", .repo = "github.com/labelle-toolkit/labelle-physics", .version = "0.1.0" },
+            },
+        });
+        defer std.testing.allocator.free(build_zig);
+
+        // Should NOT have ecs_backend when using mock
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "addImport(\"ecs_backend\"") == null);
+        // But should still have core, gfx, engine
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"labelle-core\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"labelle-engine\"") != null);
+    }
+
+    test "plugins receive gui_backend when gui is active" {
+        const build_zig = try generate.generateBuildZig(std.testing.allocator, .{
+            .name = "test-game",
+            .backend = .raylib,
+            .ecs = .mock,
+            .resolved_gui = testGuiRenderInterface("clay"),
+            .plugins = &.{
+                .{ .name = "physics", .repo = "github.com/labelle-toolkit/labelle-physics", .version = "0.1.0" },
+            },
+        });
+        defer std.testing.allocator.free(build_zig);
+
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "plugin_physics_mod.addImport(\"gui_backend\", gui_mod)") != null);
+    }
+
+    test "plugins omit gui_backend when no gui" {
+        const build_zig = try generate.generateBuildZig(std.testing.allocator, .{
+            .name = "test-game",
+            .backend = .raylib,
+            .ecs = .mock,
+            .plugins = &.{
+                .{ .name = "physics", .repo = "github.com/labelle-toolkit/labelle-physics", .version = "0.1.0" },
+            },
+        });
+        defer std.testing.allocator.free(build_zig);
+
+        try std.testing.expect(std.mem.indexOf(u8, build_zig, "addImport(\"gui_backend\"") == null);
+    }
+
     test "single plugin only includes that plugin" {
         const zon = try generate.generateBuildZigZon(std.testing.allocator, .{
             .name = "test-game",


### PR DESCRIPTION
## Summary

Plugins now receive the full set of engine modules, making them true "microengines" as described in the v2 RFC.

## What changed

Moved the plugin `addImport` block after ECS/GUI declarations and expanded it from 2 imports to up to 9:

| Module | Condition | Purpose |
|--------|-----------|---------|
| `labelle-core` | always | Types, interfaces |
| `labelle-gfx` | always | Render interface |
| `labelle-engine` | always | Game lifecycle, scenes |
| `ecs_backend` | ecs != mock | Entity queries, component access |
| `backend_gfx` | always | Low-level rendering |
| `backend_input` | always | Keyboard/mouse input |
| `backend_audio` | always | Sound playback |
| `backend_window` | always | Window management |
| `gui_backend` | GUI active | GUI rendering |

Previously only `labelle-core` and `labelle-gfx` were injected.

## What this enables

A physics plugin can now query the ECS directly:

```zig
const core = @import("labelle-core");
const EcsBackend = @import("ecs_backend");
const Ecs = core.Ecs(EcsBackend);
// Query entities with RigidBody + Position, sync automatically
```

No game-side script needed — the plugin owns the system entirely.

## Test plan

- [x] 4 new tests: full injection, mock ECS omission, GUI active/inactive
- [x] All existing tests pass
- [x] Box2D test project builds and runs with new imports

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
