### PR TITLE
Wire SystemRegistry into generated game loop

### DIFF
--- a/generator/src/main_zig.zig
+++ b/generator/src/main_zig.zig
@@ -370,6 +370,7 @@ fn buildSetupCode(allocator: std.mem.Allocator, cfg: ProjectConfig, scene_names:
 
     if (cfg.plugins.len > 0) {
         try w.writeAll("    PluginSystems.setup(&g);\n");
+        try w.writeAll("    defer PluginSystems.deinit();\n");
     }
 
     return buf.toOwnedSlice(allocator);


### PR DESCRIPTION
## Summary

Wires the engine's new `SystemRegistry` into the generated `main.zig` game loop, enabling plugins to run autonomous systems without game scripts.

## What changed

When `cfg.plugins.len > 0`, the generated code now includes:

```zig
const PluginSystems = engine.SystemRegistry(.{
    @import("labelle-gfx"),
    @import("box2d"),
});
```

Called at each lifecycle phase:
- `PluginSystems.setup(&g)` — after runner.setup
- `PluginSystems.tick(&g, dt)` + `PluginSystems.postTick(&g, dt)` — after runner.tick
- `PluginSystems.drawGui(&g)` — inside guiBegin/guiEnd (only when GUI is active)
- `PluginSystems.deinit()` — during cleanup (callback lifecycle)

## Dependencies

Requires labelle-engine PR labelle-toolkit/labelle-engine#371 (SystemRegistry).

## Test plan

- [x] All generator tests pass
- [x] Box2D test project builds and runs with SystemRegistry wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)
