### PR TITLE
Add AllHookPayloads + MergeHookPayloads foundation

### DIFF
--- a/generator/src/main_zig.zig
+++ b/generator/src/main_zig.zig
@@ -90,6 +90,11 @@ pub fn generateMainZig(
         try w.writeByte('\n');
     }
 
+    // HookPayload — the unified hook event type for the game.
+    // MergeHookPayloads is available in engine.core for games that want to
+    // manually merge plugin hook payloads. Auto-merging is planned (#64).
+    try w.writeAll("const AllHookPayloads = engine.HookPayload(EcsBackend.Entity);\n\n");
+
     // GameHooks — merge all hook files from hooks/ folder.
     if (hook_names.len == 0) {
         try w.writeAll("const GameHooks = struct {};\n\n");
@@ -100,7 +105,7 @@ pub fn generateMainZig(
         try w.print("const GameHooks = {s}.{s};\n\n", .{ ident0, pascal });
     } else {
         var pascal_buf: [128]u8 = undefined;
-        try w.writeAll("const GameHooks = engine.MergeHooks(engine.HookPayload(EcsBackend.Entity), .{");
+        try w.writeAll("const GameHooks = engine.MergeHooks(AllHookPayloads, .{");
         for (hook_names) |name| {
             const ident = pathToIdent(name, &ident_buf);
             const pascal = snakeToPascal(ident, &pascal_buf);


### PR DESCRIPTION
## Summary

Lays the groundwork for plugin hook payload merging (#64):

- Generated main.zig now defines \`AllHookPayloads\` (used by MergeHooks)
- \`MergeHookPayloads\` added to labelle-core (PR labelle-toolkit/labelle-core#4)
- Re-exported through engine (PR labelle-toolkit/labelle-engine#373)

## Current state

- \`AllHookPayloads\` = engine payload only (no auto-merging yet)
- Plugins use function pointer callbacks (\`on_collision_begin\`) or Touching component
- \`MergeHookPayloads\` is available for manual use in game code

## What's next for auto-merging

The missing piece is comptime filtering of plugins that export \`HookPayload\`. This requires either a convention (all plugins must export it) or a helper function that builds a comptime tuple dynamically. Tracked in #64.

Part of #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)