### PR TITLE
Fix Nuklear widget adapter: layout, windows, tables

### DIFF
--- a/plugins/debug/src/root.zig
+++ b/plugins/debug/src/root.zig
@@ -187,7 +187,7 @@ fn drawEntityDetail(game: anytype, comptime Gui: type) void {
 
         Gui.separator();
 
-        // Position (always show)
+        // Position (always show, not in registry)
         if (game.ecs_backend.getComponent(entity, Position)) |pos| {
             if (Gui.treeNode("Position")) {
                 var buf: [64]u8 = undefined;
@@ -198,7 +198,7 @@ fn drawEntityDetail(game: anytype, comptime Gui: type) void {
             }
         }
 
-        // Each registered component
+        // Each registered component (skip if name matches a built-in we already showed)
         inline for (comp_names) |name| {
             const T = Reg.getType(name);
             if (game.ecs_backend.getComponent(entity, T)) |comp| {

--- a/plugins/nuklear/src/adapter.zig
+++ b/plugins/nuklear/src/adapter.zig
@@ -39,47 +39,72 @@ pub fn wantsKeyboard() bool {
 
 // ── Standard widget API ────────────────────────────────────
 
+// Window position offset — each new window gets a different position
+var window_count: f32 = 0;
+var in_table: bool = false;
+var table_columns: i32 = 1;
+var table_col_idx: i32 = 0;
+
 pub fn beginWindow(name: [*:0]const u8) bool {
     const ctx = nk_bridge_get_context();
-    return c.nk_begin(ctx, name, .{ .x = 20, .y = 20, .w = 400, .h = 500 }, c.NK_WINDOW_BORDER | c.NK_WINDOW_MOVABLE | c.NK_WINDOW_SCALABLE | c.NK_WINDOW_TITLE | c.NK_WINDOW_MINIMIZABLE);
+    // Offset each window so they don't overlap
+    const offset = window_count * 30;
+    window_count += 1;
+    return c.nk_begin(ctx, name, .{ .x = 20 + offset, .y = 20 + offset, .w = 400, .h = 500 }, c.NK_WINDOW_BORDER | c.NK_WINDOW_MOVABLE | c.NK_WINDOW_SCALABLE | c.NK_WINDOW_TITLE | c.NK_WINDOW_MINIMIZABLE);
 }
 
 pub fn endWindow() void {
     c.nk_end(nk_bridge_get_context());
+    if (window_count > 0) window_count -= 1;
 }
 
 pub fn separator() void {
+    if (in_table) return;
     const ctx = nk_bridge_get_context();
     c.nk_layout_row_dynamic(ctx, 5, 1);
     c.nk_spacing(ctx, 1);
 }
 
 pub fn spacing() void {
+    if (in_table) return;
     const ctx = nk_bridge_get_context();
     c.nk_layout_row_dynamic(ctx, 5, 1);
     c.nk_spacing(ctx, 1);
 }
 
 pub fn sameLine() void {
-    // Nuklear doesn't have sameLine — layout is row-based.
-    // Next widget goes in the same row if layout has columns.
+    // No-op in Nuklear — use tables for multi-column layouts
 }
 
 pub fn label(str: [*:0]const u8) void {
     const ctx = nk_bridge_get_context();
-    c.nk_layout_row_dynamic(ctx, 20, 1);
+    if (!in_table) {
+        c.nk_layout_row_dynamic(ctx, 20, 1);
+    }
     c.nk_label(ctx, str, c.NK_TEXT_LEFT);
+}
+
+pub fn textFmt(fmt: [*:0]const u8, args: anytype) void {
+    const ctx = nk_bridge_get_context();
+    if (!in_table) {
+        c.nk_layout_row_dynamic(ctx, 20, 1);
+    }
+    @call(.auto, c.nk_labelf, .{ ctx, c.NK_TEXT_LEFT, fmt } ++ args);
 }
 
 pub fn button(str: [*:0]const u8) bool {
     const ctx = nk_bridge_get_context();
-    c.nk_layout_row_dynamic(ctx, 30, 1);
+    if (!in_table) {
+        c.nk_layout_row_dynamic(ctx, 30, 1);
+    }
     return c.nk_button_label(ctx, str);
 }
 
 pub fn checkbox(str: [*:0]const u8, val: *bool) bool {
     const ctx = nk_bridge_get_context();
-    c.nk_layout_row_dynamic(ctx, 25, 1);
+    if (!in_table) {
+        c.nk_layout_row_dynamic(ctx, 25, 1);
+    }
     const old = val.*;
     _ = c.nk_checkbox_label(ctx, str, val);
     return val.* != old;
@@ -102,7 +127,6 @@ pub fn treeNode(str: [*:0]const u8) bool {
     while (str[i] != 0) : (i += 1) {
         hash = hash *% 33 +% str[i];
     }
-    // Use nk_tree_push_hashed to avoid __FILE__ macro issues
     return c.nk_tree_push_hashed(ctx, c.NK_TREE_NODE, str, c.NK_MINIMIZED, "debug", 5, @as(c_int, @intCast(hash % 0x7FFFFFFF)));
 }
 
@@ -112,19 +136,26 @@ pub fn treePop() void {
 
 pub fn beginTable(_: [*:0]const u8, columns: i32) bool {
     const ctx = nk_bridge_get_context();
+    in_table = true;
+    table_columns = columns;
+    table_col_idx = 0;
     c.nk_layout_row_dynamic(ctx, 20, columns);
     return true;
 }
 
 pub fn endTable() void {
-    // Nuklear tables are just layout rows — nothing to end
+    in_table = false;
+    table_columns = 1;
+    table_col_idx = 0;
 }
 
 pub fn tableNextRow() void {
-    // Next row is automatic when columns fill up
+    const ctx = nk_bridge_get_context();
+    table_col_idx = 0;
+    c.nk_layout_row_dynamic(ctx, 20, table_columns);
 }
 
 pub fn tableNextColumn() bool {
-    // Columns advance automatically in Nuklear's row layout
+    table_col_idx += 1;
     return true;
 }


### PR DESCRIPTION
Fixes #69. Windows auto-offset, table-aware layout, textFmt support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)