### PR TITLE
feat: opt-in subprocess invocation of labelle-assembler (Phase 2 of #122)

### DIFF
--- a/generator/build.zig
+++ b/generator/build.zig
@@ -24,6 +24,27 @@ pub fn build(b: *std.Build) void {
     });
     generator_module.addOptions("build_options", options);
 
+    // ── Standalone assembler binary (Phase 1 of RFC #122) ───────────────
+    // Coexists with the in-process module above. The `labelle` CLI still
+    // imports the module directly today; this binary exposes the same
+    // generator behind a subprocess protocol so future CLI versions can
+    // invoke an out-of-process assembler pinned by `project.labelle`.
+    const assembler_exe = b.addExecutable(.{
+        .name = "labelle-assembler",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    assembler_exe.root_module.addOptions("build_options", options);
+    b.installArtifact(assembler_exe);
+
+    const assembler_run = b.addRunArtifact(assembler_exe);
+    if (b.args) |args| assembler_run.addArgs(args);
+    const assembler_run_step = b.step("run-assembler", "Run the standalone labelle-assembler binary");
+    assembler_run_step.dependOn(&assembler_run.step);
+
     // ── Tests ───────────────────────────────────────────────────────────
     const test_step = b.step("test", "Run generator tests");
 

--- a/generator/src/gui_resolve.zig
+++ b/generator/src/gui_resolve.zig
@@ -1,11 +1,17 @@
 /// GUI plugin resolver — reads gui.labelle manifest and populates resolved_gui on ProjectConfig.
+///
+/// Lives in the generator package because the fields it produces
+/// (`resolved_gui`) are consumed by the generator's `generate()` function.
+/// Both the in-process CLI import path and the standalone
+/// `labelle-assembler` binary call this through `root.zig`'s re-export.
 const std = @import("std");
-const gen = @import("generator");
+const config = @import("config.zig");
+const cache = @import("cache.zig");
 
 /// Resolve the GUI plugin reference in the config.
 /// Reads gui.labelle from the plugin directory, validates the bridge for
 /// the selected backend, and populates cfg.resolved_gui.
-pub fn resolveGuiPlugin(allocator: std.mem.Allocator, cfg: *gen.ProjectConfig, project_dir: []const u8) !void {
+pub fn resolveGuiPlugin(allocator: std.mem.Allocator, cfg: *config.ProjectConfig, project_dir: []const u8) !void {
     const gui_ref = cfg.gui orelse return; // null = no GUI
 
     // Resolve plugin directory
@@ -80,7 +86,7 @@ pub fn resolveGuiPlugin(allocator: std.mem.Allocator, cfg: *gen.ProjectConfig, p
 }
 
 /// Resolve the plugin directory from a GuiPlugin reference.
-fn resolvePluginDir(allocator: std.mem.Allocator, ref: gen.GuiPlugin, cfg: gen.ProjectConfig, project_dir: []const u8) ![]const u8 {
+fn resolvePluginDir(allocator: std.mem.Allocator, ref: config.GuiPlugin, cfg: config.ProjectConfig, project_dir: []const u8) ![]const u8 {
     if (ref.path) |rel_path| {
         // Local path — resolve relative to project directory
         return std.fs.path.resolve(allocator, &.{ project_dir, rel_path });
@@ -89,7 +95,7 @@ fn resolvePluginDir(allocator: std.mem.Allocator, ref: gen.GuiPlugin, cfg: gen.P
         // Reference a declared plugin by name — resolve from the plugin cache
         for (cfg.plugins) |plugin| {
             if (std.mem.eql(u8, plugin.name, name)) {
-                return gen.resolvePlugin(allocator, plugin, project_dir);
+                return cache.resolvePlugin(allocator, plugin, project_dir);
             }
         }
         std.debug.print("labelle: GUI references plugin '{s}', but no plugin with that name is declared in .plugins\n", .{name});
@@ -122,12 +128,12 @@ const LibraryDef = struct {
 const GuiLabelle = struct {
     name: []const u8,
     library: LibraryDef = .{},
-    rendering: gen.RenderingMode,
-    lifecycle: gen.GuiLifecycle = .{},
+    rendering: config.RenderingMode,
+    lifecycle: config.GuiLifecycle = .{},
     bridges: ?Bridges = null,
 };
 
-fn getBridgeForBackend(bridges: Bridges, backend: gen.Backend) ?BridgeDef {
+fn getBridgeForBackend(bridges: Bridges, backend: config.Backend) ?BridgeDef {
     return switch (backend) {
         .raylib => bridges.raylib,
         .sokol => bridges.sokol,

--- a/generator/src/main.zig
+++ b/generator/src/main.zig
@@ -1,0 +1,158 @@
+//! labelle-assembler — standalone binary entry point.
+//!
+//! Phase 1 of the assembler split (RFC #122 / PR #123). This binary
+//! coexists with the in-process generator that the `labelle` CLI imports
+//! as a Zig module via `b.dependency("generator", .{})`. Adding it here
+//! is purely additive — no existing code path changes.
+//!
+//! The binary exposes a subprocess protocol the CLI launcher will adopt
+//! in Phase 2 (opt-in via `LABELLE_ASSEMBLER` env var) and Phase 3
+//! (project-pinned `assembler_version` in `project.labelle`).
+//!
+//! Cache prerequisite: this binary assumes the package cache is already
+//! populated (engine/core/gfx packages available where the generator
+//! expects them). The CLI handles cache management before invoking the
+//! assembler. Running the binary directly is intended for testing the
+//! CLI ↔ assembler boundary and for power users who manage their own
+//! cache.
+
+const std = @import("std");
+const gen = @import("root.zig");
+
+/// Wire protocol version for CLI ↔ assembler subprocess communication.
+/// Bump when the command surface or output format changes in a way the
+/// CLI launcher needs to detect. The launcher reads this via
+/// `labelle-assembler --protocol-version` before invoking any subcommand.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+const usage =
+    \\labelle-assembler — code generator for the labelle game toolkit
+    \\
+    \\Usage:
+    \\  labelle-assembler --protocol-version
+    \\  labelle-assembler --help
+    \\  labelle-assembler generate --project-root <path> [options]
+    \\
+    \\Subcommands:
+    \\  generate    Materialize .labelle/<target>/ from project.labelle
+    \\
+    \\Generate options:
+    \\  --project-root <path>   Path to game project (containing project.labelle)
+    \\  --scene <name>          Override initial scene from project.labelle
+    \\
+    \\Notes:
+    \\  This binary assumes the package cache is already populated. The
+    \\  `labelle` CLI handles cache management before invoking the
+    \\  assembler.
+    \\
+    \\See: https://github.com/labelle-toolkit/labelle-assembler
+    \\
+;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var args = try std.process.argsWithAllocator(allocator);
+    defer args.deinit();
+    _ = args.skip(); // program name
+
+    const first = args.next() orelse {
+        std.debug.print("{s}", .{usage});
+        std.process.exit(1);
+    };
+
+    if (std.mem.eql(u8, first, "--protocol-version")) {
+        // Protocol version goes to stdout so callers can capture it via
+        // a normal pipe. Everything else goes to stderr.
+        const stdout = std.fs.File.stdout();
+        var buf: [16]u8 = undefined;
+        const msg = try std.fmt.bufPrint(&buf, "{d}\n", .{PROTOCOL_VERSION});
+        try stdout.writeAll(msg);
+        return;
+    }
+
+    if (std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h") or std.mem.eql(u8, first, "help")) {
+        std.debug.print("{s}", .{usage});
+        return;
+    }
+
+    if (std.mem.eql(u8, first, "generate")) {
+        try cmdGenerate(allocator, &args);
+        return;
+    }
+
+    std.debug.print("labelle-assembler: unknown subcommand '{s}'\n\n{s}", .{ first, usage });
+    std.process.exit(2);
+}
+
+fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+    var project_root: ?[]const u8 = null;
+    var scene_override: ?[]const u8 = null;
+
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--project-root")) {
+            project_root = args.next() orelse {
+                std.debug.print("labelle-assembler: --project-root requires a value\n", .{});
+                std.process.exit(2);
+            };
+        } else if (std.mem.startsWith(u8, arg, "--project-root=")) {
+            project_root = arg["--project-root=".len..];
+        } else if (std.mem.eql(u8, arg, "--scene")) {
+            scene_override = args.next() orelse {
+                std.debug.print("labelle-assembler: --scene requires a value\n", .{});
+                std.process.exit(2);
+            };
+        } else if (std.mem.startsWith(u8, arg, "--scene=")) {
+            scene_override = arg["--scene=".len..];
+        } else {
+            std.debug.print("labelle-assembler generate: unknown flag '{s}'\n", .{arg});
+            std.process.exit(2);
+        }
+    }
+
+    const root = project_root orelse {
+        std.debug.print("labelle-assembler generate: --project-root is required\n", .{});
+        std.process.exit(2);
+    };
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var cfg = readProjectConfig(arena_alloc, root) catch |err| {
+        std.debug.print("labelle-assembler: failed to read project.labelle in '{s}': {s}\n", .{ root, @errorName(err) });
+        std.process.exit(1);
+    };
+
+    if (scene_override) |s| cfg.initial_scene = s;
+
+    const output_dir = try std.fs.path.join(allocator, &.{ root, ".labelle" });
+    defer allocator.free(output_dir);
+
+    gen.generate(allocator, cfg, output_dir, root) catch |err| {
+        std.debug.print("labelle-assembler: generate failed: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(cfg.backend), @tagName(cfg.platform) });
+    defer allocator.free(target_name);
+    std.debug.print("labelle-assembler: generated .labelle/{s}/\n", .{target_name});
+}
+
+/// Inline copy of `cli/config.zig:readProjectConfig`. Lives here so the
+/// assembler binary doesn't pull in CLI-side modules. The CLI's version
+/// will route through this binary in Phase 2; this duplication is
+/// intentional and temporary.
+fn readProjectConfig(allocator: std.mem.Allocator, project_dir: []const u8) !gen.ProjectConfig {
+    @setEvalBranchQuota(10000);
+    const labelle_path = try std.fs.path.join(allocator, &.{ project_dir, "project.labelle" });
+    defer allocator.free(labelle_path);
+
+    const source_raw = try std.fs.cwd().readFileAlloc(allocator, labelle_path, 1024 * 1024);
+    defer allocator.free(source_raw);
+
+    const source = try allocator.dupeZ(u8, source_raw);
+    return try std.zon.parse.fromSlice(gen.ProjectConfig, allocator, source, null, .{});
+}

--- a/generator/src/main.zig
+++ b/generator/src/main.zig
@@ -128,6 +128,14 @@ fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !vo
 
     if (scene_override) |s| cfg.initial_scene = s;
 
+    // Resolve GUI plugin (reads gui.labelle manifest from plugin directory)
+    // and populates cfg.resolved_gui. Must run before gen.generate so the
+    // generated build.zig/zon and main.zig include the GUI module wiring.
+    gen.resolveGuiPlugin(arena_alloc, &cfg, root) catch |err| {
+        std.debug.print("labelle-assembler: failed to resolve GUI plugin: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
     const output_dir = try std.fs.path.join(allocator, &.{ root, ".labelle" });
     defer allocator.free(output_dir);
 
@@ -139,6 +147,15 @@ fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !vo
     const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(cfg.backend), @tagName(cfg.platform) });
     defer allocator.free(target_name);
     std.debug.print("labelle-assembler: generated .labelle/{s}/\n", .{target_name});
+
+    // NOTE: build.zig.zon's `.fingerprint` field is left at the placeholder
+    // value emitted by the generator template. The CLI patches it via a
+    // post-generate `runner.fixFingerprint` pass that runs `zig build`,
+    // parses Zig's "use this value: 0x..." error from stderr, and rewrites
+    // the field. Until Phase 2 wires the launcher to do that post-step
+    // around the subprocess invocation, callers of this binary must run
+    // an equivalent fixFingerprint pass before `zig build` will succeed
+    // against the generated tree. Tracked for follow-up.
 }
 
 /// Inline copy of `cli/config.zig:readProjectConfig`. Lives here so the

--- a/generator/src/main.zig
+++ b/generator/src/main.zig
@@ -39,6 +39,8 @@ const usage =
     \\Generate options:
     \\  --project-root <path>   Path to game project (containing project.labelle)
     \\  --scene <name>          Override initial scene from project.labelle
+    \\  --platform <name>       Override target platform (desktop, wasm, ios, android)
+    \\  --backend <name>        Override graphics backend (raylib, sokol, sdl, bgfx, wgpu)
     \\
     \\Notes:
     \\  This binary assumes the package cache is already populated. The
@@ -90,6 +92,8 @@ pub fn main() !void {
 fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     var project_root: ?[]const u8 = null;
     var scene_override: ?[]const u8 = null;
+    var platform_override: ?gen.Platform = null;
+    var backend_override: ?gen.Backend = null;
 
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--project-root")) {
@@ -106,6 +110,22 @@ fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !vo
             };
         } else if (std.mem.startsWith(u8, arg, "--scene=")) {
             scene_override = arg["--scene=".len..];
+        } else if (std.mem.eql(u8, arg, "--platform")) {
+            const val = args.next() orelse {
+                std.debug.print("labelle-assembler: --platform requires a value\n", .{});
+                std.process.exit(2);
+            };
+            platform_override = parsePlatform(val) orelse std.process.exit(2);
+        } else if (std.mem.startsWith(u8, arg, "--platform=")) {
+            platform_override = parsePlatform(arg["--platform=".len..]) orelse std.process.exit(2);
+        } else if (std.mem.eql(u8, arg, "--backend")) {
+            const val = args.next() orelse {
+                std.debug.print("labelle-assembler: --backend requires a value\n", .{});
+                std.process.exit(2);
+            };
+            backend_override = parseBackend(val) orelse std.process.exit(2);
+        } else if (std.mem.startsWith(u8, arg, "--backend=")) {
+            backend_override = parseBackend(arg["--backend=".len..]) orelse std.process.exit(2);
         } else {
             std.debug.print("labelle-assembler generate: unknown flag '{s}'\n", .{arg});
             std.process.exit(2);
@@ -127,6 +147,8 @@ fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !vo
     };
 
     if (scene_override) |s| cfg.initial_scene = s;
+    if (platform_override) |p| cfg.platform = p;
+    if (backend_override) |b| cfg.backend = b;
 
     // Resolve GUI plugin (reads gui.labelle manifest from plugin directory)
     // and populates cfg.resolved_gui. Must run before gen.generate so the
@@ -156,6 +178,34 @@ fn cmdGenerate(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !vo
     // around the subprocess invocation, callers of this binary must run
     // an equivalent fixFingerprint pass before `zig build` will succeed
     // against the generated tree. Tracked for follow-up.
+}
+
+/// Parse a --platform value into the Platform enum, or print an error
+/// listing accepted values and return null. Caller is expected to exit
+/// with code 2 on null.
+fn parsePlatform(val: []const u8) ?gen.Platform {
+    if (std.meta.stringToEnum(gen.Platform, val)) |p| return p;
+    std.debug.print("labelle-assembler: unknown platform '{s}'\n", .{val});
+    std.debug.print("  expected one of:", .{});
+    inline for (@typeInfo(gen.Platform).@"enum".fields) |f| {
+        std.debug.print(" {s}", .{f.name});
+    }
+    std.debug.print("\n", .{});
+    return null;
+}
+
+/// Parse a --backend value into the Backend enum, or print an error
+/// listing accepted values and return null. Caller is expected to exit
+/// with code 2 on null.
+fn parseBackend(val: []const u8) ?gen.Backend {
+    if (std.meta.stringToEnum(gen.Backend, val)) |b| return b;
+    std.debug.print("labelle-assembler: unknown backend '{s}'\n", .{val});
+    std.debug.print("  expected one of:", .{});
+    inline for (@typeInfo(gen.Backend).@"enum".fields) |f| {
+        std.debug.print(" {s}", .{f.name});
+    }
+    std.debug.print("\n", .{});
+    return null;
 }
 
 /// Inline copy of `cli/config.zig:readProjectConfig`. Lives here so the

--- a/generator/src/root.zig
+++ b/generator/src/root.zig
@@ -11,6 +11,7 @@ pub const script_scanner = @import("script_scanner.zig");
 const build_files = @import("build_files.zig");
 pub const template = @import("template.zig");
 pub const plugin_manifest = @import("plugin_manifest.zig");
+const gui_resolve = @import("gui_resolve.zig");
 
 // Force test discovery for files that aren't transitively reached by
 // any compiled function path during `addTest` runs.
@@ -38,6 +39,8 @@ pub const CORE_VERSION = config.CORE_VERSION;
 pub const ENGINE_VERSION = config.ENGINE_VERSION;
 pub const GFX_VERSION = config.GFX_VERSION;
 pub const isLocalVersion = config.isLocalVersion;
+
+pub const resolveGuiPlugin = gui_resolve.resolveGuiPlugin;
 
 pub const generateMainZigFromTemplate = main_zig.generateMainZigFromTemplate;
 pub const generateBuildZig = build_files.generateBuildZig;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,6 +25,7 @@ const compatibility = @import("cli/compatibility.zig");
 const lockfile = @import("cli/lockfile.zig");
 const cache = @import("cli/cache.zig");
 const runner = @import("cli/runner.zig");
+const assembler = @import("cli/assembler.zig");
 const docker = @import("cli/docker.zig");
 const serve = @import("cli/serve.zig");
 const ios = @import("cli/ios.zig");
@@ -468,7 +469,24 @@ pub fn main() !void {
     const effective_optimize = parsed_args.optimize_override orelse
         if (parsed.platform == .wasm) @as(?[]const u8, "ReleaseSafe") else null;
 
-    try gen.generate(allocator, parsed, output_dir, project_dir);
+    // Phase 2 of RFC #122: optionally route through the standalone
+    // labelle-assembler binary instead of the in-process generator.
+    // Opt-in via the LABELLE_ASSEMBLER env var pointing at a binary path.
+    // When unset, the existing in-process call path is used unchanged.
+    if (try assembler.lookupOverride(allocator)) |asm_path| {
+        defer allocator.free(asm_path);
+        std.debug.print("  using out-of-process assembler: {s}\n", .{asm_path});
+        try assembler.spawnGenerate(
+            allocator,
+            asm_path,
+            project_dir,
+            parsed_args.scene_override,
+            parsed.platform,
+            parsed.backend,
+        );
+    } else {
+        try gen.generate(allocator, parsed, output_dir, project_dir);
+    }
 
     // Target subdir: .labelle/raylib_desktop/, etc.
     const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(parsed.backend), @tagName(parsed.platform) });

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -23,7 +23,6 @@ const clean = @import("cli/clean.zig");
 const config = @import("cli/config.zig");
 const compatibility = @import("cli/compatibility.zig");
 const lockfile = @import("cli/lockfile.zig");
-const gui_resolve = @import("cli/gui_resolve.zig");
 const cache = @import("cli/cache.zig");
 const runner = @import("cli/runner.zig");
 const docker = @import("cli/docker.zig");
@@ -453,7 +452,7 @@ pub fn main() !void {
     compatibility.validateCompatibility(parsed);
 
     // Resolve GUI plugin (reads gui.labelle manifest from plugin directory)
-    try gui_resolve.resolveGuiPlugin(arena.allocator(), &parsed, project_dir);
+    try gen.resolveGuiPlugin(arena.allocator(), &parsed, project_dir);
 
     // Generate into .labelle/
     const output_dir = try std.fs.path.join(allocator, &.{ project_dir, ".labelle" });

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -1,0 +1,70 @@
+/// Subprocess wrapper for the standalone labelle-assembler binary.
+///
+/// Phase 2 of the assembler split (RFC #122). Lets the CLI optionally
+/// invoke an out-of-process assembler binary instead of importing the
+/// generator module in-process. Selection is opt-in via the
+/// `LABELLE_ASSEMBLER` environment variable — when unset, the CLI keeps
+/// using the existing in-process call path with no behaviour change.
+///
+/// In Phase 3 this resolution will move from "env var" to "version pin
+/// in project.labelle" via the launcher manifest parser, and the env
+/// var will become the local-development override.
+const std = @import("std");
+const gen = @import("generator");
+
+/// Look up the override path. Returns null if `LABELLE_ASSEMBLER` is
+/// unset, in which case the CLI should use the in-process generator.
+/// Returns the heap-allocated path string on success — caller owns it.
+pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
+    return std.process.getEnvVarOwned(allocator, "LABELLE_ASSEMBLER") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+}
+
+/// Spawn `labelle-assembler generate` against the given project and
+/// inherit stdio so the user sees the binary's diagnostics directly.
+/// Forwards the same overrides the in-process path applies (scene,
+/// platform, backend) so the binary produces identical output.
+///
+/// On a non-zero exit code, returns `error.AssemblerFailed`. The
+/// binary's stderr already explains what went wrong.
+pub fn spawnGenerate(
+    allocator: std.mem.Allocator,
+    exe_path: []const u8,
+    project_dir: []const u8,
+    scene_override: ?[]const u8,
+    platform: gen.Platform,
+    backend: gen.Backend,
+) !void {
+    var argv: std.ArrayList([]const u8) = .{};
+    defer argv.deinit(allocator);
+
+    try argv.appendSlice(allocator, &.{ exe_path, "generate", "--project-root", project_dir });
+
+    if (scene_override) |s| try argv.appendSlice(allocator, &.{ "--scene", s });
+
+    // Always forward platform/backend so the binary doesn't have to
+    // re-derive what the CLI may have already mutated (e.g. for the
+    // `labelle ios` subcommand which forces sokol+ios).
+    try argv.appendSlice(allocator, &.{ "--platform", @tagName(platform) });
+    try argv.appendSlice(allocator, &.{ "--backend", @tagName(backend) });
+
+    var child: std.process.Child = .init(argv.items, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    try child.spawn();
+
+    const term = try child.wait();
+    switch (term) {
+        .Exited => |code| if (code != 0) {
+            std.debug.print("labelle: assembler '{s}' exited with code {d}\n", .{ exe_path, code });
+            return error.AssemblerFailed;
+        },
+        else => {
+            std.debug.print("labelle: assembler '{s}' terminated abnormally\n", .{exe_path});
+            return error.AssemblerFailed;
+        },
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [assembler split RFC](https://github.com/labelle-toolkit/labelle-cli/blob/rfc/split-assembler/RFC-split-assembler.md) (#122). The CLI now optionally routes through the standalone `labelle-assembler` binary instead of importing the generator module in-process. **Opt-in via the `LABELLE_ASSEMBLER` environment variable** — when unset, the existing in-process call path runs unchanged. **Default behaviour for users is unchanged.**

> **Stacked on #124 (Phase 1).** This PR's commit history starts from the Phase 1 branch. Once #124 merges to main, GitHub will rebase this onto main with no conflicts.

## How to try it

```bash
# Build both binaries from this branch
cd labelle-cli && zig build
cd labelle-cli/generator && zig build -Dcli_version=1.28.0 -Dcore_version=1.8.0 -Dengine_version=1.16.0 -Dgfx_version=1.2.0

# Use the in-process path (default, unchanged)
labelle generate

# Use the subprocess path
LABELLE_ASSEMBLER=/path/to/labelle-cli/generator/zig-out/bin/labelle-assembler labelle generate
```

The subprocess path prints an extra line so you can see which binary is doing the work:

```
labelle: generating 'flying_platform'...
  backend: raylib  platform: desktop  ecs: zig_ecs  gui: imgui  window: 1024x768
  using out-of-process assembler: /home/.../labelle-assembler
labelle-assembler: generated .labelle/raylib_desktop/
  generated .labelle/raylib_desktop/
```

## What's in this PR

### `generator/src/main.zig` — extended `generate` subcommand

Adds `--platform <name>` and `--backend <name>` flags so the CLI can forward in-memory mutations the in-process path applies — specifically `platform_override` from the user's `--platform=` flag and the `labelle ios` subcommand's forced \`sokol+ios\`. Without these, the binary would re-parse `project.labelle` from disk and miss any CLI-side overrides.

New `parsePlatform`/`parseBackend` helpers print accepted enum values on bad input:

```
$ labelle-assembler generate --project-root . --platform foo
labelle-assembler: unknown platform 'foo'
  expected one of: desktop ios android wasm
$ echo \$?
2
```

### `src/cli/assembler.zig` — new subprocess wrapper

```zig
pub fn lookupOverride(allocator) !?[]u8       // reads LABELLE_ASSEMBLER env var
pub fn spawnGenerate(...) !void               // spawns labelle-assembler generate
```

`spawnGenerate` inherits stdio so users see the binary's diagnostics directly, and translates non-zero exit into `error.AssemblerFailed`.

### `src/cli.zig` — branch at the call site

```zig
if (try assembler.lookupOverride(allocator)) |asm_path| {
    defer allocator.free(asm_path);
    std.debug.print(\"  using out-of-process assembler: {s}\\n\", .{asm_path});
    try assembler.spawnGenerate(
        allocator, asm_path, project_dir,
        parsed_args.scene_override, parsed.platform, parsed.backend,
    );
} else {
    try gen.generate(allocator, parsed, output_dir, project_dir);
}
```

`gen.resolveGuiPlugin` still runs on the CLI side regardless of which path is taken, because `lockfile.writeLockFile` reads `cfg.resolved_gui` downstream. The binary independently re-resolves in the subprocess case — harmless and trivially cheap.

`runner.fixFingerprint` runs after both paths, so the resulting tree is buildable in either mode.

## End-to-end verification

Compared in-process vs subprocess output against `flying-platform-labelle`:

```bash
rm -rf .labelle/raylib_desktop
labelle generate                                       # in-process
cp -a .labelle/raylib_desktop /tmp/inproc

rm -rf .labelle/raylib_desktop
LABELLE_ASSEMBLER=\$ASM labelle generate               # subprocess
cp -a .labelle/raylib_desktop /tmp/subproc

diff -r --brief /tmp/inproc /tmp/subproc
```

Result: **byte-identical** across `build.zig`, `main.zig`, and every copied component/script/prefab/scene/asset. The only diff is `build.zig.zon`'s `.fingerprint` field, and that turns out to be **non-deterministic across `runner.fixFingerprint` runs** — three back-to-back in-process invocations produced three different fingerprints with the same `0xa8ee77a3` prefix:

```
.fingerprint = 0xa8ee77a3e5a8bb8c,
.fingerprint = 0xa8ee77a34ea328e9,
.fingerprint = 0xa8ee77a3c75b98c1,
```

So the in-process vs subprocess fingerprint diff is noise from the existing post-step, not a Phase 2 regression. With the `.fingerprint` line excluded, the two trees are identical.

## What this PR does NOT ship (deferred)

- `assembler_version` field in `project.labelle` — Phase 3
- Launcher-side `LauncherManifest` parser — Phase 3 (RFC section [\"New: launcher-side manifest parser\"](https://github.com/labelle-toolkit/labelle-cli/blob/rfc/split-assembler/RFC-split-assembler.md#new-launcher-side-manifest-parser))
- `--assembler-path` CLI flag (env var is sufficient for internal testing)
- `--compatibility-info-json` protocol command (RFC open question with tentative answer)
- Cache-resolved binary fetching / GitHub releases — Phase 4
- Removal of the bundled in-process generator — Phase 5

## Test plan

- [x] `cd generator && zig build` clean
- [x] `cd generator && zig build test` clean
- [x] `cd labelle-cli && zig build` clean
- [x] `cd labelle-cli && zig build test` clean
- [x] `labelle-assembler --help` shows new `--platform`/`--backend` flags
- [x] `labelle-assembler generate --project-root . --platform foo` exits 2 with valid platform list
- [x] `labelle generate` (no env var) — in-process path, unchanged behavior
- [x] `LABELLE_ASSEMBLER=\$ASM labelle generate` — subprocess path, prints assembler path, byte-identical output (modulo non-deterministic fingerprint)
- [ ] `LABELLE_ASSEMBLER=/nonexistent/path labelle generate` — error path (manual; should fail at child.spawn)
- [ ] End-to-end \`zig build\` against the subprocess-generated tree (manual; verifies fixFingerprint still works on the binary's output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)