### PR TITLE
feat: project-pinned assembler resolution (Phase 3 of #122)

### DIFF
--- a/generator/src/config.zig
+++ b/generator/src/config.zig
@@ -167,6 +167,12 @@ pub const ProjectConfig = struct {
     /// Defaults to null (derived from project name/title when absent).
     ios: ?IosConfig = null,
 
+    /// Pinned assembler version (Phase 3 of RFC #122).
+    /// When set, the CLI resolves the assembler binary from the cache at
+    /// `~/.labelle/assembler/<version>/labelle-assembler` instead of using
+    /// the in-process generator. The LABELLE_ASSEMBLER env var overrides this.
+    assembler_version: ?[]const u8 = null,
+
     /// Resolved GUI plugin — populated by the CLI after reading gui.labelle manifest.
     /// NOT parsed from ZON. Generators check this field, not `gui`.
     resolved_gui: ?ResolvedGui = null,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -469,13 +469,13 @@ pub fn main() !void {
     const effective_optimize = parsed_args.optimize_override orelse
         if (parsed.platform == .wasm) @as(?[]const u8, "ReleaseSafe") else null;
 
-    // Phase 2 of RFC #122: optionally route through the standalone
+    // Phase 2-3 of RFC #122: optionally route through the standalone
     // labelle-assembler binary instead of the in-process generator.
-    // Opt-in via the LABELLE_ASSEMBLER env var pointing at a binary path.
-    // When unset, the existing in-process call path is used unchanged.
-    if (try assembler.lookupOverride(allocator)) |asm_path| {
+    // Resolution order: LABELLE_ASSEMBLER env var > assembler_version
+    // in project.labelle > in-process fallback.
+    if (try assembler.resolveAssembler(allocator, project_dir)) |asm_path| {
         defer allocator.free(asm_path);
-        std.debug.print("  using out-of-process assembler: {s}\n", .{asm_path});
+        std.debug.print("  using assembler: {s}\n", .{asm_path});
         try assembler.spawnGenerate(
             allocator,
             asm_path,

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -35,14 +35,17 @@ pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !
     if (try lookupOverride(allocator)) |path| return path;
 
     // 2. Check project.labelle for assembler_version.
-    const manifest = try launcher_manifest.readLauncherManifest(allocator, project_dir) orelse return null;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const manifest = try launcher_manifest.readLauncherManifest(arena.allocator(), project_dir) orelse return null;
     const pinned_version = manifest.assembler_version orelse return null;
 
     // Resolve from cache: ~/.labelle/assembler/<version>/labelle-assembler
     const cache_root = try gen.getCacheRoot(allocator);
     defer allocator.free(cache_root);
 
-    const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", pinned_version, "labelle-assembler" });
+    const exe_name = "labelle-assembler" ++ if (comptime @import("builtin").os.tag == .windows) ".exe" else "";
+    const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", pinned_version, exe_name });
 
     // Verify the binary exists.
     std.fs.cwd().access(asm_path, .{}) catch {

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -1,16 +1,18 @@
 /// Subprocess wrapper for the standalone labelle-assembler binary.
 ///
-/// Phase 2 of the assembler split (RFC #122). Lets the CLI optionally
-/// invoke an out-of-process assembler binary instead of importing the
-/// generator module in-process. Selection is opt-in via the
-/// `LABELLE_ASSEMBLER` environment variable — when unset, the CLI keeps
-/// using the existing in-process call path with no behaviour change.
+/// Phase 2-3 of the assembler split (RFC #122). Resolves the external
+/// assembler binary via three-tier priority:
 ///
-/// In Phase 3 this resolution will move from "env var" to "version pin
-/// in project.labelle" via the launcher manifest parser, and the env
-/// var will become the local-development override.
+///   1. `LABELLE_ASSEMBLER` env var — local dev override (always wins)
+///   2. `assembler_version` in project.labelle — pinned version resolved
+///      from the cache at `~/.labelle/assembler/<version>/labelle-assembler`
+///   3. Absent — fall back to the bundled in-process generator
+///
+/// When an `assembler_version` is pinned but the cached binary is missing,
+/// the CLI prints an actionable error and returns `error.AssemblerNotCached`.
 const std = @import("std");
 const gen = @import("generator");
+const launcher_manifest = @import("launcher_manifest.zig");
 
 /// Look up the override path. Returns null if `LABELLE_ASSEMBLER` is
 /// unset, in which case the CLI should use the in-process generator.
@@ -20,6 +22,41 @@ pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
         error.EnvironmentVariableNotFound => null,
         else => return err,
     };
+}
+
+/// Resolve the assembler binary path using three-tier priority:
+///   1. LABELLE_ASSEMBLER env var (local dev override)
+///   2. assembler_version from project.labelle (pinned, resolved from cache)
+///   3. null (use in-process generator)
+///
+/// Caller owns the returned slice and must free it.
+pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !?[]u8 {
+    // 1. Env var override always takes priority.
+    if (try lookupOverride(allocator)) |path| return path;
+
+    // 2. Check project.labelle for assembler_version.
+    const manifest = try launcher_manifest.readLauncherManifest(allocator, project_dir) orelse return null;
+    const pinned_version = manifest.assembler_version orelse return null;
+
+    // Resolve from cache: ~/.labelle/assembler/<version>/labelle-assembler
+    const cache_root = try gen.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+
+    const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", pinned_version, "labelle-assembler" });
+
+    // Verify the binary exists.
+    std.fs.cwd().access(asm_path, .{}) catch {
+        std.debug.print(
+            \\labelle: assembler version {s} not found in cache.
+            \\  expected: {s}
+            \\  run: labelle install assembler {s}
+            \\
+        , .{ pinned_version, asm_path, pinned_version });
+        allocator.free(asm_path);
+        return error.AssemblerNotCached;
+    };
+
+    return asm_path;
 }
 
 /// Spawn `labelle-assembler generate` against the given project and

--- a/src/cli/launcher_manifest.zig
+++ b/src/cli/launcher_manifest.zig
@@ -1,0 +1,37 @@
+/// Minimal parser for project.labelle that reads ONLY launcher-relevant fields.
+///
+/// The launcher must NOT depend on the full ProjectConfig schema so that it
+/// can work across assembler versions — new config fields added later won't
+/// break older CLIs. We achieve this by using `ignore_unknown_fields = true`
+/// in the ZON parser.
+const std = @import("std");
+
+pub const LauncherManifest = struct {
+    assembler_version: ?[]const u8 = null,
+    // Future: zig_version, etc.
+};
+
+/// Read and parse project.labelle into a LauncherManifest.
+/// Unknown fields are silently ignored.
+/// Returns null if the file does not exist (no project.labelle).
+pub fn readLauncherManifest(allocator: std.mem.Allocator, project_dir: []const u8) !?LauncherManifest {
+    @setEvalBranchQuota(10000);
+    const labelle_path = try std.fs.path.join(allocator, &.{ project_dir, "project.labelle" });
+    defer allocator.free(labelle_path);
+
+    const source_raw = std.fs.cwd().readFileAlloc(allocator, labelle_path, 1024 * 1024) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer allocator.free(source_raw);
+
+    const source = try allocator.dupeZ(u8, source_raw);
+    defer allocator.free(source);
+
+    return std.zon.parse.fromSlice(LauncherManifest, allocator, source, null, .{
+        .ignore_unknown_fields = true,
+    }) catch |err| {
+        std.debug.print("labelle: could not parse launcher manifest from project.labelle: {any}\n", .{err});
+        return error.ParseError;
+    };
+}


### PR DESCRIPTION
## Summary

- Add `assembler_version` optional field to `ProjectConfig` so `project.labelle` files can pin a specific assembler binary version
- Add `LauncherManifest` parser (`src/cli/launcher_manifest.zig`) that reads only launcher-relevant fields from `project.labelle` with `ignore_unknown_fields = true` — stays forward-compatible across assembler versions
- Add `resolveAssembler()` in `src/cli/assembler.zig` with three-tier resolution: `LABELLE_ASSEMBLER` env var (dev override) > `assembler_version` in `project.labelle` (resolved from `~/.labelle/assembler/<version>/labelle-assembler`) > in-process fallback
- When a pinned version is not cached, prints an actionable error: `labelle install assembler <version>`

Phase 3 of the assembler split RFC (#122). Follows Phase 1 (#124, standalone binary) and Phase 2 (#125, env var routing).

## Test plan

- [x] `zig build` compiles cleanly
- [x] `zig build test` passes all existing tests
- [ ] Without `assembler_version` in `project.labelle`: behavior identical to Phase 2 (in-process fallback)
- [ ] With `LABELLE_ASSEMBLER` env var set: env var path is used regardless of `assembler_version`
- [ ] With `assembler_version` set and binary cached: cached binary is invoked
- [ ] With `assembler_version` set and binary missing: actionable error message printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)