### PR TITLE
feat: assembler binary distribution and auto-download (Phase 4 of #122)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -303,6 +303,7 @@ fn handleAssemblerCmd(allocator: std.mem.Allocator, cmd_args: []const []const u8
     }
     std.debug.print("labelle assembler: unknown subcommand '{s}'\n", .{cmd_args[0]});
     std.debug.print("  usage: labelle assembler list\n", .{});
+    return error.UnknownSubcommand;
 }
 
 pub fn main() !void {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -7,6 +7,8 @@
 ///   labelle [dir]                       — alias for `run`
 ///   labelle init <name> [dir]           — scaffold a new project
 ///   labelle install [pkg] [ver]         — fetch packages into cache
+///   labelle install assembler <ver>    — download and cache an assembler binary
+///   labelle assembler list             — list cached assembler versions
 ///   labelle upgrade [dir] [pkg] [ver]   — bump versions in project.labelle
 ///   labelle update [ver]                — self-update the CLI
 ///   labelle clean [--dry-run]           — prune unused package versions
@@ -31,7 +33,7 @@ const serve = @import("cli/serve.zig");
 const ios = @import("cli/ios.zig");
 const util = @import("cli/util.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, help_cmd, version, targets };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, help_cmd, version, targets, assembler_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -294,6 +296,15 @@ fn collectExtraArgs(args: *std.process.ArgIterator, extra_args: *[8][]const u8, 
     }
 }
 
+/// Handle `labelle assembler <subcommand>`.
+fn handleAssemblerCmd(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    if (cmd_args.len == 0 or std.mem.eql(u8, cmd_args[0], "list")) {
+        return assembler.cmdListAssemblers(allocator);
+    }
+    std.debug.print("labelle assembler: unknown subcommand '{s}'\n", .{cmd_args[0]});
+    std.debug.print("  usage: labelle assembler list\n", .{});
+}
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
@@ -376,6 +387,9 @@ pub fn main() !void {
                     parsed_args.project_dir = arg;
                 }
             }
+        } else if (std.mem.eql(u8, first, "assembler")) {
+            parsed_args.command = .assembler_cmd;
+            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
         } else if (std.mem.eql(u8, first, "help") or std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h")) {
             parsed_args.command = .help_cmd;
         } else if (std.mem.eql(u8, first, "version") or std.mem.eql(u8, first, "--version") or std.mem.eql(u8, first, "-v")) {
@@ -408,6 +422,7 @@ pub fn main() !void {
         .install_cmd => return install.cmdInstall(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .update_cmd => return update.cmdUpdate(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .clean_cmd => return clean.cmdClean(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
     }
 

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -28,20 +28,26 @@ pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
 }
 
 /// Platform/arch names used in the release URL.
-fn osName() []const u8 {
+fn osName() error{UnsupportedPlatform}![]const u8 {
     return switch (builtin.os.tag) {
         .macos => "macos",
         .linux => "linux",
         .windows => "windows",
-        else => "unknown",
+        else => {
+            std.debug.print("labelle: unsupported OS for assembler download: {s}\n", .{@tagName(builtin.os.tag)});
+            return error.UnsupportedPlatform;
+        },
     };
 }
 
-fn archName() []const u8 {
+fn archName() error{UnsupportedPlatform}![]const u8 {
     return switch (builtin.cpu.arch) {
         .aarch64 => "aarch64",
         .x86_64 => "x86_64",
-        else => "unknown",
+        else => {
+            std.debug.print("labelle: unsupported architecture for assembler download: {s}\n", .{@tagName(builtin.cpu.arch)});
+            return error.UnsupportedPlatform;
+        },
     };
 }
 
@@ -58,8 +64,8 @@ pub fn downloadAssembler(allocator: std.mem.Allocator, version: []const u8, dest
     const url = try std.fmt.allocPrint(allocator, "{s}/v{s}/labelle-assembler-{s}-{s}", .{
         ASSEMBLER_RELEASE_BASE,
         version,
-        osName(),
-        archName(),
+        try osName(),
+        try archName(),
     });
     defer allocator.free(url);
 
@@ -67,7 +73,7 @@ pub fn downloadAssembler(allocator: std.mem.Allocator, version: []const u8, dest
     std.debug.print("  url: {s}\n", .{url});
 
     // Ensure the parent directory exists.
-    if (std.fs.path.dirnamePosix(dest_path) orelse std.fs.path.dirnameWindows(dest_path)) |dir| {
+    if (std.fs.path.dirname(dest_path)) |dir| {
         std.fs.cwd().makePath(dir) catch |err| {
             std.debug.print("labelle: could not create directory {s}: {any}\n", .{ dir, err });
             return error.AssemblerDownloadFailed;
@@ -102,7 +108,14 @@ pub fn downloadAssembler(allocator: std.mem.Allocator, version: []const u8, dest
 
     // Make executable on Unix.
     if (builtin.os.tag != .windows) {
-        _ = util.runCmd(allocator, &.{ "chmod", "+x", dest_path }) catch {};
+        const file = std.fs.cwd().openFile(dest_path, .{}) catch |err| {
+            std.debug.print("labelle: could not open {s} for chmod: {any}\n", .{ dest_path, err });
+            return;
+        };
+        defer file.close();
+        file.chmod(0o755) catch |err| {
+            std.debug.print("labelle: chmod failed for {s}: {any}\n", .{ dest_path, err });
+        };
     }
 
     std.debug.print("  cached at {s}\n", .{dest_path});
@@ -132,21 +145,27 @@ pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !
     const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", pinned_version, exe_name });
 
     // Verify the binary exists; if not, auto-download it.
-    std.fs.cwd().access(asm_path, .{}) catch {
-        // Phase 4: auto-download instead of just erroring.
-        std.debug.print("labelle: assembler v{s} not cached, downloading...\n", .{pinned_version});
-        downloadAssembler(allocator, pinned_version, asm_path) catch {
-            // Download failed — fall back to the manual install message.
-            std.debug.print(
-                \\
-                \\labelle: assembler version {s} not found in cache.
-                \\  expected: {s}
-                \\  run: labelle install assembler {s}
-                \\
-            , .{ pinned_version, asm_path, pinned_version });
+    std.fs.cwd().access(asm_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            // Phase 4: auto-download instead of just erroring.
+            std.debug.print("labelle: assembler v{s} not cached, downloading...\n", .{pinned_version});
+            downloadAssembler(allocator, pinned_version, asm_path) catch {
+                // Download failed — fall back to the manual install message.
+                std.debug.print(
+                    \\
+                    \\labelle: assembler version {s} not found in cache.
+                    \\  expected: {s}
+                    \\  run: labelle install assembler {s}
+                    \\
+                , .{ pinned_version, asm_path, pinned_version });
+                allocator.free(asm_path);
+                return error.AssemblerNotCached;
+            };
+        },
+        else => {
             allocator.free(asm_path);
-            return error.AssemblerNotCached;
-        };
+            return err;
+        },
     };
 
     return asm_path;

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -1,18 +1,21 @@
 /// Subprocess wrapper for the standalone labelle-assembler binary.
 ///
-/// Phase 2-3 of the assembler split (RFC #122). Resolves the external
+/// Phase 2-4 of the assembler split (RFC #122). Resolves the external
 /// assembler binary via three-tier priority:
 ///
 ///   1. `LABELLE_ASSEMBLER` env var — local dev override (always wins)
 ///   2. `assembler_version` in project.labelle — pinned version resolved
 ///      from the cache at `~/.labelle/assembler/<version>/labelle-assembler`
+///      If not cached, auto-downloads from GitHub releases (Phase 4).
 ///   3. Absent — fall back to the bundled in-process generator
-///
-/// When an `assembler_version` is pinned but the cached binary is missing,
-/// the CLI prints an actionable error and returns `error.AssemblerNotCached`.
 const std = @import("std");
+const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");
+const util = @import("util.zig");
+
+/// GitHub release URL template for assembler binaries.
+const ASSEMBLER_RELEASE_BASE = "https://github.com/labelle-toolkit/labelle-assembler/releases/download";
 
 /// Look up the override path. Returns null if `LABELLE_ASSEMBLER` is
 /// unset, in which case the CLI should use the in-process generator.
@@ -24,9 +27,91 @@ pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
     };
 }
 
+/// Platform/arch names used in the release URL.
+fn osName() []const u8 {
+    return switch (builtin.os.tag) {
+        .macos => "macos",
+        .linux => "linux",
+        .windows => "windows",
+        else => "unknown",
+    };
+}
+
+fn archName() []const u8 {
+    return switch (builtin.cpu.arch) {
+        .aarch64 => "aarch64",
+        .x86_64 => "x86_64",
+        else => "unknown",
+    };
+}
+
+const exe_suffix = if (builtin.os.tag == .windows) ".exe" else "";
+const exe_name = "labelle-assembler" ++ exe_suffix;
+
+/// Download an assembler binary from GitHub releases and cache it.
+///
+/// URL pattern: https://github.com/labelle-toolkit/labelle-assembler/releases/download/v<version>/labelle-assembler-<os>-<arch>
+///
+/// The binary is saved to `~/.labelle/assembler/<version>/labelle-assembler`
+/// and made executable on Unix.
+pub fn downloadAssembler(allocator: std.mem.Allocator, version: []const u8, dest_path: []const u8) !void {
+    const url = try std.fmt.allocPrint(allocator, "{s}/v{s}/labelle-assembler-{s}-{s}", .{
+        ASSEMBLER_RELEASE_BASE,
+        version,
+        osName(),
+        archName(),
+    });
+    defer allocator.free(url);
+
+    std.debug.print("labelle: downloading assembler v{s}...\n", .{version});
+    std.debug.print("  url: {s}\n", .{url});
+
+    // Ensure the parent directory exists.
+    if (std.fs.path.dirnamePosix(dest_path) orelse std.fs.path.dirnameWindows(dest_path)) |dir| {
+        std.fs.cwd().makePath(dir) catch |err| {
+            std.debug.print("labelle: could not create directory {s}: {any}\n", .{ dir, err });
+            return error.AssemblerDownloadFailed;
+        };
+    }
+
+    // Use curl with -L to follow redirects (GitHub releases redirect to S3).
+    const result = util.runCmd(allocator, &.{ "curl", "-fSL", "-o", dest_path, url }) catch {
+        std.debug.print("labelle: download failed (is curl installed?)\n", .{});
+        std.debug.print("  url: {s}\n", .{url});
+        std.debug.print("  you can download manually and place it at: {s}\n", .{dest_path});
+        return error.AssemblerDownloadFailed;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            std.debug.print("labelle: download failed (HTTP error, exit code {d})\n", .{code});
+            std.debug.print("  url: {s}\n", .{url});
+            std.debug.print("  you can download manually and place it at: {s}\n", .{dest_path});
+            // Clean up partial download
+            std.fs.cwd().deleteFile(dest_path) catch {};
+            return error.AssemblerDownloadFailed;
+        },
+        else => {
+            std.debug.print("labelle: download process terminated abnormally\n", .{});
+            std.fs.cwd().deleteFile(dest_path) catch {};
+            return error.AssemblerDownloadFailed;
+        },
+    }
+
+    // Make executable on Unix.
+    if (builtin.os.tag != .windows) {
+        _ = util.runCmd(allocator, &.{ "chmod", "+x", dest_path }) catch {};
+    }
+
+    std.debug.print("  cached at {s}\n", .{dest_path});
+}
+
 /// Resolve the assembler binary path using three-tier priority:
 ///   1. LABELLE_ASSEMBLER env var (local dev override)
 ///   2. assembler_version from project.labelle (pinned, resolved from cache)
+///      If not cached, auto-downloads from GitHub releases.
 ///   3. null (use in-process generator)
 ///
 /// Caller owns the returned slice and must free it.
@@ -44,22 +129,91 @@ pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !
     const cache_root = try gen.getCacheRoot(allocator);
     defer allocator.free(cache_root);
 
-    const exe_name = "labelle-assembler" ++ if (comptime @import("builtin").os.tag == .windows) ".exe" else "";
     const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", pinned_version, exe_name });
 
-    // Verify the binary exists.
+    // Verify the binary exists; if not, auto-download it.
     std.fs.cwd().access(asm_path, .{}) catch {
-        std.debug.print(
-            \\labelle: assembler version {s} not found in cache.
-            \\  expected: {s}
-            \\  run: labelle install assembler {s}
-            \\
-        , .{ pinned_version, asm_path, pinned_version });
-        allocator.free(asm_path);
-        return error.AssemblerNotCached;
+        // Phase 4: auto-download instead of just erroring.
+        std.debug.print("labelle: assembler v{s} not cached, downloading...\n", .{pinned_version});
+        downloadAssembler(allocator, pinned_version, asm_path) catch {
+            // Download failed — fall back to the manual install message.
+            std.debug.print(
+                \\
+                \\labelle: assembler version {s} not found in cache.
+                \\  expected: {s}
+                \\  run: labelle install assembler {s}
+                \\
+            , .{ pinned_version, asm_path, pinned_version });
+            allocator.free(asm_path);
+            return error.AssemblerNotCached;
+        };
     };
 
     return asm_path;
+}
+
+/// Explicitly install (download + cache) an assembler version.
+/// Called by `labelle install assembler <version>`.
+pub fn cmdInstallAssembler(allocator: std.mem.Allocator, version: []const u8) !void {
+    const cache_root = try gen.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+
+    const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", version, exe_name });
+    defer allocator.free(asm_path);
+
+    // Check if already cached.
+    std.fs.cwd().access(asm_path, .{}) catch {
+        // Not cached — download it.
+        try downloadAssembler(allocator, version, asm_path);
+        std.debug.print("labelle: assembler v{s} installed\n", .{version});
+        return;
+    };
+
+    std.debug.print("labelle: assembler v{s} already cached at {s}\n", .{ version, asm_path });
+}
+
+/// List cached assembler versions by scanning ~/.labelle/assembler/.
+pub fn cmdListAssemblers(allocator: std.mem.Allocator) !void {
+    const cache_root = try gen.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+
+    const asm_dir = try std.fs.path.join(allocator, &.{ cache_root, "assembler" });
+    defer allocator.free(asm_dir);
+
+    var dir = std.fs.cwd().openDir(asm_dir, .{ .iterate = true }) catch {
+        std.debug.print("labelle: no cached assembler versions found\n", .{});
+        std.debug.print("  cache directory: {s}\n", .{asm_dir});
+        return;
+    };
+    defer dir.close();
+
+    var count: usize = 0;
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind == .directory) {
+            if (count == 0) {
+                std.debug.print("Cached assembler versions:\n", .{});
+            }
+            // Verify the binary actually exists inside the version directory.
+            const bin_path = try std.fs.path.join(allocator, &.{ asm_dir, entry.name, exe_name });
+            defer allocator.free(bin_path);
+            const exists = blk: {
+                std.fs.cwd().access(bin_path, .{}) catch break :blk false;
+                break :blk true;
+            };
+            if (exists) {
+                std.debug.print("  {s}\n", .{entry.name});
+            } else {
+                std.debug.print("  {s} (incomplete — binary missing)\n", .{entry.name});
+            }
+            count += 1;
+        }
+    }
+
+    if (count == 0) {
+        std.debug.print("labelle: no cached assembler versions found\n", .{});
+        std.debug.print("  cache directory: {s}\n", .{asm_dir});
+    }
 }
 
 /// Spawn `labelle-assembler generate` against the given project and

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -14,6 +14,8 @@ pub fn printHelp() void {
         \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build + run (default)
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
+        \\  install assembler <ver>  Download and cache an assembler binary
+        \\  assembler list       List cached assembler versions
         \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle
         \\  update [ver] [--no-path]  Update the labelle CLI itself
         \\  clean [--dry-run] [--project=dir]  Remove unused cached package versions

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2,9 +2,21 @@ const std = @import("std");
 const gen = @import("generator");
 const config = @import("config.zig");
 const cache = @import("cache.zig");
+const assembler = @import("assembler.zig");
 
 /// Fetch and cache packages without modifying any project.
 pub fn cmdInstall(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    // Handle `labelle install assembler <version>` and `labelle install assembler`
+    if (cmd_args.len >= 1 and std.mem.eql(u8, cmd_args[0], "assembler")) {
+        if (cmd_args.len < 2) {
+            std.debug.print("labelle install assembler: missing version argument\n", .{});
+            std.debug.print("  usage: labelle install assembler <version>\n", .{});
+            std.debug.print("  example: labelle install assembler 1.0.0\n", .{});
+            return error.MissingArgument;
+        }
+        return assembler.cmdInstallAssembler(allocator, cmd_args[1]);
+    }
+
     if (cmd_args.len == 0) {
         var arena = std.heap.ArenaAllocator.init(allocator);
         defer arena.deinit();


### PR DESCRIPTION
## Summary

- **Auto-download**: When `assembler_version` is pinned in `project.labelle` but the binary isn't cached, the CLI now automatically downloads it from `https://github.com/labelle-toolkit/labelle-assembler/releases/download/v<version>/labelle-assembler-<os>-<arch>` using curl with redirect support. On download failure, falls back to the existing actionable error message.
- **`labelle install assembler <version>`**: New subcommand for explicitly downloading and caching an assembler binary (useful for CI, offline prep, or when auto-download fails).
- **`labelle assembler list`**: New subcommand that lists cached assembler versions by scanning `~/.labelle/assembler/`, showing which have complete binaries.

Implements Phase 4 of the assembler split RFC (#122). Builds on Phase 3's cache layout (`~/.labelle/assembler/<version>/labelle-assembler`).

## Test plan

- [x] `DEVELOPER_DIR=/Library/Developer/CommandLineTools zig build` compiles cleanly
- [x] `labelle help` shows new commands
- [x] `labelle assembler list` works (shows "no cached versions" when empty)
- [ ] `labelle install assembler <version>` downloads correctly (requires assembler releases to be published)
- [ ] Auto-download triggers when `assembler_version` is pinned but not cached (requires assembler releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)