### PR TITLE
feat: flip assembler default — new projects pin assembler_version (Phase 5 of #122)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -356,6 +356,7 @@ pub fn main() !void {
                     std.mem.eql(u8, next_arg, "gfx") or
                     std.mem.eql(u8, next_arg, "cli") or
                     std.mem.eql(u8, next_arg, "labelle") or
+                    std.mem.eql(u8, next_arg, "assembler") or
                     std.mem.eql(u8, next_arg, "all"))
                 {
                     parsed_args.extra_args[parsed_args.extra_count] = next_arg;
@@ -501,6 +502,7 @@ pub fn main() !void {
             parsed.backend,
         );
     } else {
+        std.debug.print("labelle: note: no assembler_version in project.labelle — using bundled generator. Pin a version for reproducible builds.\n", .{});
         try gen.generate(allocator, parsed, output_dir, project_dir);
     }
 

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -9,6 +9,10 @@
 ///      If not cached, auto-downloads from GitHub releases (Phase 4).
 ///   3. Absent — fall back to the bundled in-process generator
 const std = @import("std");
+
+/// Default assembler version pinned in newly scaffolded projects.
+/// Bump this when a new assembler release ships.
+pub const DEFAULT_ASSEMBLER_VERSION = "0.1.0";
 const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -16,7 +16,7 @@ pub fn printHelp() void {
         \\  install [pkg] [ver]  Fetch packages into cache
         \\  install assembler <ver>  Download and cache an assembler binary
         \\  assembler list       List cached assembler versions
-        \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle
+        \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle (pkg: core, engine, gfx, cli, assembler, all)
         \\  update [ver] [--no-path]  Update the labelle CLI itself
         \\  clean [--dry-run] [--project=dir]  Remove unused cached package versions
         \\  help                 Show this help

--- a/src/cli/init.zig
+++ b/src/cli/init.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const gen = @import("generator");
+const assembler = @import("assembler.zig");
 
 /// Scaffold a new project directory with project.labelle and starter files.
 pub fn cmdInit(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
@@ -12,6 +13,7 @@ pub fn cmdInit(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
     var engine_version: []const u8 = gen.ENGINE_VERSION;
     var gfx_version: []const u8 = gen.GFX_VERSION;
     var labelle_version: []const u8 = gen.CLI_VERSION;
+    var assembler_version: []const u8 = assembler.DEFAULT_ASSEMBLER_VERSION;
 
     for (cmd_args) |arg| {
         if (std.mem.startsWith(u8, arg, "--backend=")) {
@@ -28,6 +30,8 @@ pub fn cmdInit(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
             gfx_version = arg["--gfx-version=".len..];
         } else if (std.mem.startsWith(u8, arg, "--labelle-version=")) {
             labelle_version = arg["--labelle-version=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--assembler-version=")) {
+            assembler_version = arg["--assembler-version=".len..];
         } else if (std.mem.startsWith(u8, arg, "--")) {
             std.debug.print("labelle init: unknown flag '{s}'\n", .{arg});
             return error.UnknownFlag;
@@ -93,9 +97,10 @@ pub fn cmdInit(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
             \\    .engine_version = "{s}",
             \\    .gfx_version = "{s}",
             \\    .labelle_version = "{s}",
+            \\    .assembler_version = "{s}",
             \\}}
             \\
-        , .{ core_version, engine_version, gfx_version, labelle_version });
+        , .{ core_version, engine_version, gfx_version, labelle_version, assembler_version });
 
         const path = try std.fs.path.join(allocator, &.{ dir, "project.labelle" });
         defer allocator.free(path);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -23,6 +23,8 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: ge
             gen.ENGINE_VERSION
         else if (std.mem.eql(u8, pkg, "gfx"))
             gen.GFX_VERSION
+        else if (std.mem.eql(u8, pkg, "assembler"))
+            assembler.DEFAULT_ASSEMBLER_VERSION
         else
             gen.CLI_VERSION;
         const version = if (cmd_args.len > 1) cmd_args[1] else default_version;
@@ -36,20 +38,26 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: ge
         } else if (std.mem.eql(u8, pkg, "labelle") or std.mem.eql(u8, pkg, "cli")) {
             content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, version);
         } else if (std.mem.eql(u8, pkg, "assembler")) {
-            const asm_version = if (cmd_args.len > 1) cmd_args[1] else assembler.DEFAULT_ASSEMBLER_VERSION;
             // If assembler_version already exists, replace it; otherwise append it before the closing `}`
             if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
                 const old_asm = cfg.assembler_version orelse "0.0.0";
-                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, asm_version);
+                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, version);
             } else {
                 // Insert assembler_version before the final closing brace
-                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", asm_version);
+                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", version);
             }
         } else if (std.mem.eql(u8, pkg, "all")) {
             content = try replaceAndFree(allocator, content, "core_version", cfg.core_version, gen.CORE_VERSION);
             content = try replaceAndFree(allocator, content, "engine_version", cfg.engine_version, gen.ENGINE_VERSION);
             content = try replaceAndFree(allocator, content, "gfx_version", cfg.gfx_version, gen.GFX_VERSION);
             content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, gen.CLI_VERSION);
+            // Also upgrade assembler if it exists (or add it)
+            if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
+                const old_asm = cfg.assembler_version orelse "0.0.0";
+                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, assembler.DEFAULT_ASSEMBLER_VERSION);
+            } else {
+                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", assembler.DEFAULT_ASSEMBLER_VERSION);
+            }
         } else {
             std.debug.print("labelle upgrade: unknown package '{s}'\n", .{pkg});
             std.debug.print("  packages: core, engine, gfx, cli, assembler, all\n", .{});
@@ -107,8 +115,9 @@ fn insertBeforeClosingBrace(allocator: std.mem.Allocator, old_content: []u8, fie
         try result.appendSlice(allocator, old_content[0..idx]);
         try result.appendSlice(allocator, line);
         try result.appendSlice(allocator, old_content[idx..]);
+        const owned = try result.toOwnedSlice(allocator);
         allocator.free(old_content);
-        return result.toOwnedSlice(allocator);
+        return owned;
     }
 
     // No closing brace found — return content unchanged.

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const gen = @import("generator");
+const assembler = @import("assembler.zig");
 
 /// Bump version fields in project.labelle.
 pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: gen.ProjectConfig, cmd_args: []const []const u8) !void {
@@ -34,6 +35,16 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: ge
             content = try replaceAndFree(allocator, content, "gfx_version", cfg.gfx_version, version);
         } else if (std.mem.eql(u8, pkg, "labelle") or std.mem.eql(u8, pkg, "cli")) {
             content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, version);
+        } else if (std.mem.eql(u8, pkg, "assembler")) {
+            const asm_version = if (cmd_args.len > 1) cmd_args[1] else assembler.DEFAULT_ASSEMBLER_VERSION;
+            // If assembler_version already exists, replace it; otherwise append it before the closing `}`
+            if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
+                const old_asm = cfg.assembler_version orelse "0.0.0";
+                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, asm_version);
+            } else {
+                // Insert assembler_version before the final closing brace
+                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", asm_version);
+            }
         } else if (std.mem.eql(u8, pkg, "all")) {
             content = try replaceAndFree(allocator, content, "core_version", cfg.core_version, gen.CORE_VERSION);
             content = try replaceAndFree(allocator, content, "engine_version", cfg.engine_version, gen.ENGINE_VERSION);
@@ -41,7 +52,7 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: ge
             content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, gen.CLI_VERSION);
         } else {
             std.debug.print("labelle upgrade: unknown package '{s}'\n", .{pkg});
-            std.debug.print("  packages: core, engine, gfx, cli, all\n", .{});
+            std.debug.print("  packages: core, engine, gfx, cli, assembler, all\n", .{});
             allocator.free(content);
             return error.UnknownPackage;
         }
@@ -80,4 +91,26 @@ fn replaceVersionField(allocator: std.mem.Allocator, content: []const u8, field_
     }
 
     return try allocator.dupe(u8, content);
+}
+
+/// Insert a new `.field = "value"` line before the final closing `}` in a ZON file.
+/// Used when adding assembler_version to a project.labelle that doesn't have one yet.
+fn insertBeforeClosingBrace(allocator: std.mem.Allocator, old_content: []u8, field_name: []const u8, value: []const u8) ![]u8 {
+    errdefer allocator.free(old_content);
+
+    const line = try std.fmt.allocPrint(allocator, "    .{s} = \"{s}\",\n", .{ field_name, value });
+    defer allocator.free(line);
+
+    // Find the last `}` in the content.
+    if (std.mem.lastIndexOfScalar(u8, old_content, '}')) |idx| {
+        var result = std.ArrayList(u8){};
+        try result.appendSlice(allocator, old_content[0..idx]);
+        try result.appendSlice(allocator, line);
+        try result.appendSlice(allocator, old_content[idx..]);
+        allocator.free(old_content);
+        return result.toOwnedSlice(allocator);
+    }
+
+    // No closing brace found — return content unchanged.
+    return old_content;
 }


### PR DESCRIPTION
## Summary

- **`labelle init` now scaffolds `assembler_version = "0.1.0"`** in `project.labelle`, so new projects automatically use the standalone assembler binary for reproducible builds.
- **Deprecation notice for in-process fallback**: when no `assembler_version` is set and no `LABELLE_ASSEMBLER` env var exists, prints an informational note nudging users to pin a version.
- **`labelle upgrade assembler [version]`**: new upgrade target that updates (or adds) `assembler_version` in an existing `project.labelle`.

## Details

Phase 5 of the assembler split RFC (#122). Phases 1-4 are merged and the assembler v0.1.0 release is live.

Key design decisions:
- `DEFAULT_ASSEMBLER_VERSION = "0.1.0"` constant lives in `src/cli/assembler.zig` — single source of truth
- Existing projects without `assembler_version` continue to work exactly as before (in-process fallback) — no breaking changes
- The deprecation message is informational only (printed to stderr via `std.debug.print`), not an error
- `labelle upgrade assembler` handles both updating an existing field and inserting a new one into projects that predate Phase 5

## Test plan

- [x] `DEVELOPER_DIR=/Library/Developer/CommandLineTools zig build` compiles cleanly
- [ ] `labelle init test-project` produces a `project.labelle` containing `assembler_version = "0.1.0"`
- [ ] Existing project without `assembler_version` prints the informational note and still builds via in-process generator
- [ ] `labelle upgrade assembler` adds `assembler_version` to a project that lacks it
- [ ] `labelle upgrade assembler 0.2.0` updates an existing `assembler_version` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)