### PR TITLE
feat: remove bundled generator fallback, always use external assembler

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -486,25 +486,21 @@ pub fn main() !void {
     const effective_optimize = parsed_args.optimize_override orelse
         if (parsed.platform == .wasm) @as(?[]const u8, "ReleaseSafe") else null;
 
-    // Phase 2-3 of RFC #122: optionally route through the standalone
-    // labelle-assembler binary instead of the in-process generator.
+    // Route through the standalone labelle-assembler binary.
     // Resolution order: LABELLE_ASSEMBLER env var > assembler_version
-    // in project.labelle > in-process fallback.
-    if (try assembler.resolveAssembler(allocator, project_dir)) |asm_path| {
-        defer allocator.free(asm_path);
-        std.debug.print("  using assembler: {s}\n", .{asm_path});
-        try assembler.spawnGenerate(
-            allocator,
-            asm_path,
-            project_dir,
-            parsed_args.scene_override,
-            parsed.platform,
-            parsed.backend,
-        );
-    } else {
-        std.debug.print("labelle: note: no assembler_version in project.labelle — using bundled generator. Pin a version for reproducible builds.\n", .{});
-        try gen.generate(allocator, parsed, output_dir, project_dir);
-    }
+    // in project.labelle. If neither is set, auto-downloads the default version.
+    const asm_path = try assembler.resolveAssembler(allocator, project_dir) orelse
+        try assembler.resolveDefault(allocator);
+    defer allocator.free(asm_path);
+    std.debug.print("  using assembler: {s}\n", .{asm_path});
+    try assembler.spawnGenerate(
+        allocator,
+        asm_path,
+        project_dir,
+        parsed_args.scene_override,
+        parsed.platform,
+        parsed.backend,
+    );
 
     // Target subdir: .labelle/raylib_desktop/, etc.
     const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(parsed.backend), @tagName(parsed.platform) });

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -125,11 +125,44 @@ pub fn downloadAssembler(allocator: std.mem.Allocator, version: []const u8, dest
     std.debug.print("  cached at {s}\n", .{dest_path});
 }
 
-/// Resolve the assembler binary path using three-tier priority:
+/// Resolve the default assembler version. Downloads it if not cached.
+/// Used when no assembler_version is configured in project.labelle.
+/// Caller owns the returned slice and must free it.
+pub fn resolveDefault(allocator: std.mem.Allocator) ![]u8 {
+    const cache_root = try gen.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+
+    const asm_path = try std.fs.path.join(allocator, &.{ cache_root, "assembler", DEFAULT_ASSEMBLER_VERSION, exe_name });
+
+    std.fs.cwd().access(asm_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.debug.print("labelle: no assembler_version in project.labelle — downloading default v{s}...\n", .{DEFAULT_ASSEMBLER_VERSION});
+            downloadAssembler(allocator, DEFAULT_ASSEMBLER_VERSION, asm_path) catch {
+                std.debug.print(
+                    \\
+                    \\labelle: could not download assembler v{s}.
+                    \\  Add assembler_version to project.labelle or set LABELLE_ASSEMBLER env var.
+                    \\  run: labelle install assembler {s}
+                    \\
+                , .{ DEFAULT_ASSEMBLER_VERSION, DEFAULT_ASSEMBLER_VERSION });
+                allocator.free(asm_path);
+                return error.AssemblerNotCached;
+            };
+        },
+        else => {
+            allocator.free(asm_path);
+            return err;
+        },
+    };
+
+    return asm_path;
+}
+
+/// Resolve the assembler binary path using priority:
 ///   1. LABELLE_ASSEMBLER env var (local dev override)
 ///   2. assembler_version from project.labelle (pinned, resolved from cache)
 ///      If not cached, auto-downloads from GitHub releases.
-///   3. null (use in-process generator)
+///   3. null — caller should use resolveDefault() as fallback
 ///
 /// Caller owns the returned slice and must free it.
 pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !?[]u8 {

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -137,7 +137,7 @@ pub fn resolveDefault(allocator: std.mem.Allocator) ![]u8 {
     std.fs.cwd().access(asm_path, .{}) catch |err| switch (err) {
         error.FileNotFound => {
             std.debug.print("labelle: no assembler_version in project.labelle — downloading default v{s}...\n", .{DEFAULT_ASSEMBLER_VERSION});
-            downloadAssembler(allocator, DEFAULT_ASSEMBLER_VERSION, asm_path) catch {
+            downloadAssembler(allocator, DEFAULT_ASSEMBLER_VERSION, asm_path) catch |dl_err| {
                 std.debug.print(
                     \\
                     \\labelle: could not download assembler v{s}.
@@ -146,7 +146,7 @@ pub fn resolveDefault(allocator: std.mem.Allocator) ![]u8 {
                     \\
                 , .{ DEFAULT_ASSEMBLER_VERSION, DEFAULT_ASSEMBLER_VERSION });
                 allocator.free(asm_path);
-                return error.AssemblerNotCached;
+                return dl_err;
             };
         },
         else => {


### PR DESCRIPTION
## Summary

- Remove the in-process `gen.generate()` fallback path — the CLI now always routes through the standalone `labelle-assembler` binary
- When no `assembler_version` is set in `project.labelle` and no `LABELLE_ASSEMBLER` env var, auto-downloads the default version (v0.1.0)
- The `generator/` directory is kept as a dependency for shared types (`Platform`, `Backend`) and GUI resolution used in CLI status output

This makes `labelle-assembler` the single source of truth for code generation, which means #129 only needs to be fixed there (labelle-toolkit/labelle-assembler#1).

## Test plan

- [x] `zig build` + `zig build test` pass
- [ ] Verify auto-download works on a project without `assembler_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)