### PR TITLE
fix: sokol_main must return sapp_desc on Android/iOS; request GLES 3.0

### DIFF
--- a/backends/sokol/src/window.zig
+++ b/backends/sokol/src/window.zig
@@ -1,4 +1,5 @@
 /// Sokol window backend — windowing lifecycle via sokol_app.
+const builtin = @import("builtin");
 const sokol = @import("sokol");
 const sapp = sokol.app;
 const sg = sokol.gfx;
@@ -59,6 +60,39 @@ pub fn endFrame() void {
     sg.commit();
 }
 
+/// The sokol app descriptor type — re-exported so callers don't need to
+/// import sokol directly (used by mobile sokol_main return type).
+pub const Desc = sapp.Desc;
+
+/// Build a sokol app descriptor without starting the event loop.
+/// Used on mobile targets where sokol calls sokol_main() and reads its
+/// return value as sapp_desc — the host must NOT call sapp_run() itself.
+pub fn makeDesc(desc: struct {
+    init_cb: *const fn () callconv(.c) void,
+    frame_cb: *const fn () callconv(.c) void,
+    cleanup_cb: *const fn () callconv(.c) void,
+    event_cb: ?*const fn ([*c]const sapp.Event) callconv(.c) void = null,
+    w: i32 = 800,
+    h: i32 = 600,
+    title: [:0]const u8 = "LaBelle v2",
+}) sapp.Desc {
+    // Android emulators typically support GLES 3.0 but not 3.1.
+    // Sokol defaults to 3.1 on Android, which causes EGL_BAD_CONFIG on emulators.
+    // Request 3.0 explicitly so the app works on both real devices and emulators.
+    const is_android = comptime builtin.target.os.tag == .linux and builtin.target.abi.isAndroid();
+    return .{
+        .init_cb = desc.init_cb,
+        .frame_cb = desc.frame_cb,
+        .cleanup_cb = desc.cleanup_cb,
+        .event_cb = desc.event_cb orelse null,
+        .width = desc.w,
+        .height = desc.h,
+        .window_title = desc.title,
+        .gl = if (is_android) .{ .major_version = 3, .minor_version = 0 } else .{},
+        .logger = .{ .func = slog.func },
+    };
+}
+
 /// Run the sokol application loop with callbacks.
 pub fn run(desc: struct {
     init_cb: *const fn () callconv(.c) void,
@@ -69,14 +103,5 @@ pub fn run(desc: struct {
     h: i32 = 600,
     title: [:0]const u8 = "LaBelle v2",
 }) void {
-    sapp.run(.{
-        .init_cb = desc.init_cb,
-        .frame_cb = desc.frame_cb,
-        .cleanup_cb = desc.cleanup_cb,
-        .event_cb = desc.event_cb orelse null,
-        .width = desc.w,
-        .height = desc.h,
-        .window_title = desc.title,
-        .logger = .{ .func = slog.func },
-    });
+    sapp.run(makeDesc(desc));
 }

--- a/backends/sokol/templates/mobile.txt
+++ b/backends/sokol/templates/mobile.txt
@@ -48,8 +48,14 @@ export fn cleanup() callconv(.c) void {
 }
 
 // {{entry_comment}}
-pub fn main() void {
-    window.run(.{
+// sokol's C runtime provides the OS entry point (ANativeActivity_onCreate on
+// Android, main() on iOS) and calls sokol_main() to configure the app.
+// sokol_main must RETURN sapp_desc — it must NOT call sapp_run() itself.
+// Zig's own pub fn main() is not used for shared-library / UIKit targets.
+export fn sokol_main(argc: c_int, argv: [*][*:0]u8) window.Desc {
+    _ = argc;
+    _ = argv;
+    return window.makeDesc(.{
         .init_cb = &init,
         .frame_cb = &frame,
         .cleanup_cb = &cleanup,


### PR DESCRIPTION
## Summary

- **`window.zig`**: Add `Desc` type alias and `makeDesc()` function that returns `sapp.Desc` instead of calling `sapp.run()`. Mobile targets need to return the descriptor from `sokol_main` — sokol's NativeActivity runtime calls `sokol_main()` and reads its return value as `sapp_desc`. Calling `sapp.run()` inside `sokol_main` would attempt to double-start the event loop.
- **`window.zig`**: Explicitly request GLES 3.0 (`minor_version = 0`) on Android. Sokol defaults to GLES 3.1 on Android which fails on Android emulators with `EGL_BAD_CONFIG: no ES 3.1 support`. GLES 3.0 works on both real devices and emulators.
- **`mobile.txt`**: Update `sokol_main` entry point to `export fn sokol_main(...) window.Desc` returning `window.makeDesc(...)` instead of being `void` and calling `window.run()`.

## Root cause

`sokol_main` in sokol's C API is declared as:
```c
extern sapp_desc sokol_main(int argc, char* argv[]);
```
The previous implementation was `void` and called `window.run()` internally. This caused sokol to read garbage from the return registers as `sapp_desc`, failing `assert(desc->width >= 0)` in `_sapp_init_state`. After fixing that, the emulator crashed with `EGL_BAD_CONFIG: no ES 3.1 support` since sokol defaults to requesting GLES 3.1 on Android which emulators don't support.

## Test plan

- [x] `labelle android run --emulator` builds and launches on Android ARM64 emulator (Apple Silicon Mac)
- [x] App starts without `assertion "desc->width >= 0"` crash
- [x] App starts without `EGL_BAD_CONFIG: no ES 3.1 support` crash
- [x] `Displayed com.labelle.flying_platform/android.app.NativeActivity` appears in logcat (activity rendered)