### PR TITLE
chore: bump DEFAULT_ASSEMBLER_VERSION to 0.5.0

### DIFF
--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -12,7 +12,7 @@ const std = @import("std");
 
 /// Default assembler version pinned in newly scaffolded projects.
 /// Bump this when a new assembler release ships.
-pub const DEFAULT_ASSEMBLER_VERSION = "0.5.0";
+pub const DEFAULT_ASSEMBLER_VERSION = "0.5.1";
 const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -12,7 +12,7 @@ const std = @import("std");
 
 /// Default assembler version pinned in newly scaffolded projects.
 /// Bump this when a new assembler release ships.
-pub const DEFAULT_ASSEMBLER_VERSION = "0.4.0";
+pub const DEFAULT_ASSEMBLER_VERSION = "0.5.0";
 const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");


### PR DESCRIPTION
Picks up the sokol high-DPI rendering fixes and Android APK packaging step from labelle-assembler v0.5.0.