### PR TITLE
chore: bump assembler to v0.6.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,14 @@
         // below to pick up new assembler types; the old mirror
         // approach made every assembler change a double-edit (#151).
         .labelle_assembler = .{
-            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/a610afd51a9c967edec3919a138aac9a67ca58c2.tar.gz",
+            // Pinned to the v0.6.0 release commit (2026-04-14).
+            // Zig's package hash is content-hashed over
+            // \`paths = {build.zig, build.zig.zon, src}\`, so this
+            // hash happens to match the earlier a610afd pin — the
+            // plugins/examples absorbs didn't touch src/. The URL
+            // is still bumped to point at the release tag's commit
+            // for clarity.
+            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/295021cd5d12fc28d2ea5014b44cd45b48e71d48.tar.gz",
             .hash = "labelle_assembler-0.1.0-pG4XEN5xAwAnum-kDc9yodAT3RzwkiOQPUg3W7N-IX9L",
         },
         .zspec = .{

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -12,7 +12,7 @@ const std = @import("std");
 
 /// Default assembler version pinned in newly scaffolded projects.
 /// Bump this when a new assembler release ships.
-pub const DEFAULT_ASSEMBLER_VERSION = "0.5.1";
+pub const DEFAULT_ASSEMBLER_VERSION = "0.6.0";
 const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");


### PR DESCRIPTION
## Summary

Point the CLI at the freshly-tagged labelle-assembler v0.6.0, which ships the full #8–#13 cluster of backend/ECS bug fixes plus the absorbed plugins and examples.

## Changes

- **`DEFAULT_ASSEMBLER_VERSION`**: \`0.5.1\` → \`0.6.0\`. New projects scaffolded via \`labelle init\` now pin to v0.6.0 and auto-download that release binary on first generate.
- **\`build.zig.zon\` \`labelle_assembler\` dep**: \`a610afd\` → \`295021cd\` (the v0.6.0 tag's commit SHA). The Zig package hash happens to match the previous pin because Zig content-hashes the assembler's \`paths = {build.zig, build.zig.zon, src}\`, and the plugins/examples absorbs didn't touch \`src/\`.

## What v0.6.0 ships to users

**Bug fixes previously unreleased:**
- #8 SDL portable paths — Linux/Windows/Intel Mac builds fixed
- #9 bgfx native window handle per-platform dispatch
- #10 sokol audio sample buffer leak on unload
- #11 raylib audio slot recycling (slot exhaustion after 256 load/unload cycles)
- #12 wgpu WAV parser integer overflow + truncation tolerance (security-adjacent)
- #13 zig-ecs view zero-allocation (borrows storage slice instead of materializing)

**Structural absorb + CI:**
- plugins/debug, plugins/imgui, plugins/nuklear absorbed from labelle-cli
- examples/{raylib,sokol,bgfx,wgpu} absorbed with new end-to-end \`Examples integration test\` CI job
- sokol-zig / zbgfx / zglfw / nuklear / rlImGui / raylib-zig dep pinning (closes #146 fragility class)

**Also included:**
- sokol HiDPI camera offset fix
- sokol Android detection via ABI check (Zig 0.15 compat)
- iOS build.zig compat fixes

## Test plan

- [x] \`zig build test\` green after the bump
- [ ] CI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>