### PR TITLE
feat(assembler): resolve assembler_version="local:<path>" by building sibling checkout

### DIFF
--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -17,6 +17,7 @@ const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");
 const util = @import("util.zig");
+const runner = @import("runner.zig");
 
 /// GitHub release URL template for assembler binaries.
 const ASSEMBLER_RELEASE_BASE = "https://github.com/labelle-toolkit/labelle-assembler/releases/download";
@@ -48,7 +49,7 @@ fn resolveLocalAssembler(allocator: std.mem.Allocator, rel_path: []const u8, pro
     defer allocator.free(real_source);
 
     std.debug.print("labelle: building local assembler at {s}...\n", .{real_source});
-    const build_result = util.runCmdInDir(allocator, &.{ "zig", "build" }, real_source) catch |err| {
+    const build_result = runner.runZig(allocator, real_source, &.{ "zig", "build" }) catch |err| {
         std.debug.print("labelle: failed to run 'zig build' in {s}: {any}\n", .{ real_source, err });
         return error.AssemblerNotCached;
     };
@@ -59,7 +60,10 @@ fn resolveLocalAssembler(allocator: std.mem.Allocator, rel_path: []const u8, pro
             std.debug.print("labelle: local assembler build failed (exit {d})\n{s}", .{ code, build_result.stderr });
             return error.AssemblerNotCached;
         },
-        else => return error.AssemblerNotCached,
+        else => {
+            std.debug.print("labelle: local assembler build terminated abnormally\n", .{});
+            return error.AssemblerNotCached;
+        },
     }
 
     const bin_path = try std.fs.path.join(allocator, &.{ real_source, "zig-out", "bin", exe_name });

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -31,6 +31,46 @@ pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
     };
 }
 
+/// Resolve `assembler_version = "local:<path>"`: build the sibling
+/// labelle-assembler checkout and return the path to its binary.
+/// `rel_path` is relative to `project_dir` (or absolute).
+fn resolveLocalAssembler(allocator: std.mem.Allocator, rel_path: []const u8, project_dir: []const u8) ![]u8 {
+    const source_dir = if (std.fs.path.isAbsolute(rel_path))
+        try allocator.dupe(u8, rel_path)
+    else
+        try std.fs.path.join(allocator, &.{ project_dir, rel_path });
+    defer allocator.free(source_dir);
+
+    const real_source = std.fs.cwd().realpathAlloc(allocator, source_dir) catch |err| {
+        std.debug.print("labelle: local assembler path '{s}' does not exist: {any}\n", .{ source_dir, err });
+        return error.AssemblerNotCached;
+    };
+    defer allocator.free(real_source);
+
+    std.debug.print("labelle: building local assembler at {s}...\n", .{real_source});
+    const build_result = util.runCmdInDir(allocator, &.{ "zig", "build" }, real_source) catch |err| {
+        std.debug.print("labelle: failed to run 'zig build' in {s}: {any}\n", .{ real_source, err });
+        return error.AssemblerNotCached;
+    };
+    defer allocator.free(build_result.stdout);
+    defer allocator.free(build_result.stderr);
+    switch (build_result.term) {
+        .Exited => |code| if (code != 0) {
+            std.debug.print("labelle: local assembler build failed (exit {d})\n{s}", .{ code, build_result.stderr });
+            return error.AssemblerNotCached;
+        },
+        else => return error.AssemblerNotCached,
+    }
+
+    const bin_path = try std.fs.path.join(allocator, &.{ real_source, "zig-out", "bin", exe_name });
+    std.fs.cwd().access(bin_path, .{}) catch |err| {
+        std.debug.print("labelle: local assembler binary not found at {s}: {any}\n", .{ bin_path, err });
+        allocator.free(bin_path);
+        return error.AssemblerNotCached;
+    };
+    return bin_path;
+}
+
 /// Platform/arch names used in the release URL.
 fn osName() error{UnsupportedPlatform}![]const u8 {
     return switch (builtin.os.tag) {
@@ -174,6 +214,14 @@ pub fn resolveAssembler(allocator: std.mem.Allocator, project_dir: []const u8) !
     defer arena.deinit();
     const manifest = try launcher_manifest.readLauncherManifest(arena.allocator(), project_dir) orelse return null;
     const pinned_version = manifest.assembler_version orelse return null;
+
+    // 2a. `local:<path>` — dev-mode pointer at a sibling labelle-assembler
+    // checkout. Build it on demand (idempotent when up to date) and run
+    // the binary out of its zig-out/bin/. Avoids the URL/hash cache path
+    // entirely so monorepo-style edits round-trip without a release.
+    if (std.mem.startsWith(u8, pinned_version, "local:")) {
+        return try resolveLocalAssembler(allocator, pinned_version["local:".len..], project_dir);
+    }
 
     // Resolve from cache: ~/.labelle/assembler/<version>/labelle-assembler
     const cache_root = try gen.getCacheRoot(allocator);

--- a/src/cli/util.zig
+++ b/src/cli/util.zig
@@ -31,6 +31,17 @@ pub fn runCmd(allocator: std.mem.Allocator, argv: []const []const u8) !std.proce
     });
 }
 
+/// Run a command with `cwd` set to a specific directory. Used when the
+/// command (e.g. `zig build`) must execute inside a sibling source tree
+/// rather than the project directory.
+pub fn runCmdInDir(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) !std.process.Child.RunResult {
+    return std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .cwd = cwd,
+    });
+}
+
 /// Parse semantic version string into a comparable number.
 /// "1.2.3" -> 1*1000000 + 2*1000 + 3 = 1002003
 pub fn parseVersion(version: []const u8) u32 {

--- a/src/cli/util.zig
+++ b/src/cli/util.zig
@@ -31,17 +31,6 @@ pub fn runCmd(allocator: std.mem.Allocator, argv: []const []const u8) !std.proce
     });
 }
 
-/// Run a command with `cwd` set to a specific directory. Used when the
-/// command (e.g. `zig build`) must execute inside a sibling source tree
-/// rather than the project directory.
-pub fn runCmdInDir(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) !std.process.Child.RunResult {
-    return std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = argv,
-        .cwd = cwd,
-    });
-}
-
 /// Parse semantic version string into a comparable number.
 /// "1.2.3" -> 1*1000000 + 2*1000 + 3 = 1002003
 pub fn parseVersion(version: []const u8) u32 {


### PR DESCRIPTION
## Summary

Adds dev-mode resolution for \`assembler_version = "local:<path>"\` in \`project.labelle\`. Until now the CLI only understood release versions — it would try to download \`vlocal:<path>\` from GitHub and fail with an HTTP error. The \`LABELLE_ASSEMBLER\` env var was the only escape hatch, which made monorepo-style sibling layouts awkward to work with.

## Behavior

When the CLI sees a \`local:\` prefix on the assembler version, it:

1. Resolves the path relative to \`project_dir\` (or uses it absolute).
2. Runs \`zig build\` in that directory. Idempotent when the sibling tree is up to date — Zig's incremental cache makes the call near-instant for unchanged sources.
3. Returns the path to \`zig-out/bin/labelle-assembler\` so \`spawnGenerate\` runs the freshly-built binary against the project.

## Why this matters

The \`local:\` form already worked for \`core_version\` / \`engine_version\` / \`gfx_version\` / \`labelle_version\` (handled by the package cache resolver in \`labelle-assembler/src/cache.zig\`). This brings \`assembler_version\` to parity. A project laid out as:

\`\`\`
parent/
  labelle-cli/
  labelle-assembler/
  labelle-core/
  ...
  myproject/
    project.labelle  (assembler_version = "local:../labelle-assembler")
\`\`\`

now builds with just \`labelle run\` — no env vars, no manual rebuilds of the sibling assembler when its sources change.

## Error handling

Failure modes are surfaced inline with actionable messages: missing path, failed \`zig build\`, missing binary after a successful build. The caller still receives \`error.AssemblerNotCached\` so the existing fallback messaging in \`resolveAssembler\` kicks in.

## Test plan

- [x] \`zig build\` in labelle-cli
- [x] Downstream: \`labelle run\` against a project with \`assembler_version = "local:../labelle-assembler"\` builds the sibling assembler and runs the example end-to-end
- [x] Downstream: changing a source file in the sibling \`labelle-assembler\` and re-running \`labelle run\` picks up the change without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)