### PR TITLE
chore: bump labelle_assembler to v0.7.0, release v1.32.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.28.0",
+    .version = "1.32.0",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         // Pulls the generator module from labelle-assembler (types,
@@ -10,15 +10,14 @@
         // below to pick up new assembler types; the old mirror
         // approach made every assembler change a double-edit (#151).
         .labelle_assembler = .{
-            // Pinned to the v0.6.0 release commit (2026-04-14).
-            // Zig's package hash is content-hashed over
-            // \`paths = {build.zig, build.zig.zon, src}\`, so this
-            // hash happens to match the earlier a610afd pin — the
-            // plugins/examples absorbs didn't touch src/. The URL
-            // is still bumped to point at the release tag's commit
-            // for clarity.
-            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/295021cd5d12fc28d2ea5014b44cd45b48e71d48.tar.gz",
-            .hash = "labelle_assembler-0.1.0-pG4XEN5xAwAnum-kDc9yodAT3RzwkiOQPUg3W7N-IX9L",
+            // Pinned to the v0.7.0 release commit (2026-04-14).
+            // Brings the sokol fixes from this morning's session: rect
+            // outline draw, raylib-matching clear color, input lifecycle
+            // (game.quit + isKeyPressed timing), RunDesc compile fix,
+            // event forwarding to GUI bridge, and the sokol+imgui
+            // example. See labelle-assembler v0.7.0 release notes.
+            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/a5486b7.tar.gz",
+            .hash = "labelle_assembler-0.1.0-pG4XEKZ1AwCUOL9nZUSr6vKXRr9F0SMgGCnIg2WFEGG0",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.7.0.tar.gz",


### PR DESCRIPTION
## Summary

Bumps the \`labelle_assembler\` Zig dep pin to v0.7.0 (\`a5486b7\`) and rolls forward the CLI version to 1.32.0.

## What v0.7.0 brings

All sokol fixes from today's batch in labelle-assembler — see the full release notes at https://github.com/labelle-toolkit/labelle-assembler/releases/tag/v0.7.0:

- **#37** sokol RunDesc compile fix (unblocks every sokol-backend project)
- **#34** sokol \`drawRectangleLinesEx\` (declarative outline gizmos render correctly)
- **#35** sokol clear color matches raylib's \`(30, 30, 35)\`
- **#36** sokol input lifecycle — \`game.quit()\` honored, \`isKeyPressed\` timing fix
- **#38** sokol forwards sapp events to the GUI bridge so ImGui IO works
- **#39** new \`examples/sokol_imgui/\` end-to-end smoke test
- **#32** Android-ready sokol example with WASD camera and animation

## What 1.32.0 brings on top of v1.31.0

- **#167** — \`assembler_version = "local:<path>"\` now resolves by building the sibling labelle-assembler checkout on demand. No more needing \`LABELLE_ASSEMBLER\` env var for monorepo-style sibling layouts. The \`local:\` form already worked for \`core_version\` / \`engine_version\` / \`gfx_version\` / \`labelle_version\`; this brings \`assembler_version\` to parity.

## Test plan

- [x] \`zig build\` against the new assembler v0.7.0 hash
- [x] Downstream: build labelle-assembler/examples/sokol_imgui via the new CLI binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)