### PR TITLE
fix: bump DEFAULT_ASSEMBLER_VERSION to 0.7.0 and pin full SHA

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.32.0",
+    .version = "1.32.1",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         // Pulls the generator module from labelle-assembler (types,
@@ -16,7 +16,10 @@
             // (game.quit + isKeyPressed timing), RunDesc compile fix,
             // event forwarding to GUI bridge, and the sokol+imgui
             // example. See labelle-assembler v0.7.0 release notes.
-            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/a5486b7.tar.gz",
+            // Use the full 40-char SHA — abbreviated SHAs in archive
+            // URLs can become ambiguous as upstream gains commits and
+            // GitHub will return 404 in that case.
+            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/a5486b767aa51b4de880b8820c395b6e3038fab5.tar.gz",
             .hash = "labelle_assembler-0.1.0-pG4XEKZ1AwCUOL9nZUSr6vKXRr9F0SMgGCnIg2WFEGG0",
         },
         .zspec = .{

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -11,8 +11,10 @@
 const std = @import("std");
 
 /// Default assembler version pinned in newly scaffolded projects.
-/// Bump this when a new assembler release ships.
-pub const DEFAULT_ASSEMBLER_VERSION = "0.6.0";
+/// Bump this in lockstep with the labelle_assembler dep in build.zig.zon —
+/// a stale value here would auto-download a binary whose ABI doesn't match
+/// the bundled generator module the CLI is compiled against.
+pub const DEFAULT_ASSEMBLER_VERSION = "0.7.0";
 const builtin = @import("builtin");
 const gen = @import("generator");
 const launcher_manifest = @import("launcher_manifest.zig");


### PR DESCRIPTION
Two review follow-ups from #168 (just merged). Both flagged by Gemini and one by Cursor Bugbot.

## 1. \`DEFAULT_ASSEMBLER_VERSION\` was stale

\`src/cli/assembler.zig\` line 15 still hardcoded \`"0.6.0"\` even though #168 bumped the bundled \`labelle_assembler\` Zig dep to v0.7.0. The CLI's auto-download fallback (used when a project has no \`assembler_version\` set and no \`LABELLE_ASSEMBLER\` env var) would have downloaded the v0.6.0 standalone binary — ABI-mismatched against the v0.7.0 generator module the CLI is compiled against. Hard to debug because both versions exist and run.

Bump to \`"0.7.0"\` so the two constants stay in lockstep. Updated the comment to make the lockstep requirement explicit so the next person who bumps one remembers to bump the other.

## 2. Abbreviated commit SHA in URL

The \`labelle_assembler\` URL pin used a 7-character abbreviated SHA (\`a5486b7\`). Abbreviated SHAs can become ambiguous as upstream gains commits, and GitHub will return 404 on the archive URL when that happens. Switch to the full 40-char SHA \`a5486b767aa51b4de880b8820c395b6e3038fab5\`, matching the convention the previous v0.6.0 pin used.

## v1.32.1 release

Bumping \`build.zig.zon\` version to \`1.32.1\`. Will tag and release immediately after merge so the broken v1.32.0 isn't sitting at the top of the release list for long.

## Test plan

- [x] \`zig build\` resolves the labelle_assembler dep against the full SHA
- [ ] \`labelle update\` from v1.32.0 → v1.32.1 picks up the fix (verified after release tag is cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)