### PR TITLE
feat(android): add `labelle android doctor` SDK/NDK probe

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -451,13 +451,24 @@ pub fn main() !void {
     // so running them from any directory works without the "No
     // project.labelle found" bail below.
     //
-    // Doctor's `AndroidToolsMissing` error is caught and turned into
-    // `exit(1)` so the Zig error-return trace stays out of the
-    // user's terminal — the report was already printed.
+    // Doctor still *uses* the project's android config when available
+    // so the probe targets the right `target_sdk_version`. The read
+    // is quiet: if there's no project (or it fails to parse), we fall
+    // through to the defaults instead of erroring out.
+    //
+    // `AndroidToolsMissing` is caught and turned into `exit(1)` so
+    // the Zig error-return trace stays out of the user's terminal —
+    // the report was already printed.
     if (command == .android_cmd and parsed_args.extra_count > 0) {
         const first = parsed_args.extra_args[0];
         if (std.mem.eql(u8, first, "doctor")) {
-            android.runDoctor(allocator, null) catch |err| {
+            var doctor_arena = std.heap.ArenaAllocator.init(allocator);
+            defer doctor_arena.deinit();
+            const project_cfg: ?gen.AndroidConfig = blk: {
+                const parsed_cfg = config.readProjectConfigQuiet(doctor_arena.allocator(), project_dir) catch break :blk null;
+                break :blk parsed_cfg.android;
+            };
+            android.runDoctor(allocator, project_cfg) catch |err| {
                 if (err == error.AndroidToolsMissing) std.process.exit(1);
                 return err;
             };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -396,6 +396,7 @@ pub fn main() !void {
                 if (std.mem.startsWith(u8, arg, "-") or
                     std.mem.eql(u8, arg, "build") or
                     std.mem.eql(u8, arg, "run") or
+                    std.mem.eql(u8, arg, "doctor") or
                     std.mem.eql(u8, arg, "help"))
                 {
                     if (parsed_args.extra_count < parsed_args.extra_args.len) {
@@ -443,6 +444,28 @@ pub fn main() !void {
         .clean_cmd => return clean.cmdClean(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
+    }
+
+    // `labelle android doctor` and `labelle android help` are
+    // standalone — they don't need a project.labelle. Intercept here
+    // so running them from any directory works without the "No
+    // project.labelle found" bail below.
+    //
+    // Doctor's `AndroidToolsMissing` error is caught and turned into
+    // `exit(1)` so the Zig error-return trace stays out of the
+    // user's terminal — the report was already printed.
+    if (command == .android_cmd and parsed_args.extra_count > 0) {
+        const first = parsed_args.extra_args[0];
+        if (std.mem.eql(u8, first, "doctor")) {
+            android.runDoctor(allocator, null) catch |err| {
+                if (err == error.AndroidToolsMissing) std.process.exit(1);
+                return err;
+            };
+            return;
+        }
+        if (std.mem.eql(u8, first, "help") or std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h")) {
+            return android.printHelp();
+        }
     }
 
     // Read and parse project.labelle

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const gen = @import("generator");
 const runner = @import("runner.zig");
 const util = @import("util.zig");
+const android_sdk = @import("android_sdk.zig");
 
 /// Handle `labelle android <subcommand>` dispatch.
 pub fn handleAndroid(
@@ -38,11 +39,77 @@ pub fn handleAndroid(
     } else if (std.mem.eql(u8, cmd, "run")) {
         try androidBuild(allocator, target_dir, emulator, release);
         try deployToDevice(allocator, target_dir, cfg, emulator);
+    } else if (std.mem.eql(u8, cmd, "doctor")) {
+        try runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {
         printHelp();
     } else {
         std.debug.print("labelle android: unknown subcommand '{s}'\n", .{cmd});
         printHelp();
+    }
+}
+
+/// Run the SDK / NDK environment probe and print a pass/fail report.
+/// Used via `labelle android doctor`. Exits the process with code 1
+/// when any required tool is missing so CI scripts can gate on it.
+///
+/// Takes an optional `android_cfg` purely to pick up the project's
+/// `target_sdk_version`. When called without a project (via the
+/// standalone dispatch in cli.zig for `labelle android doctor` in a
+/// random directory), pass `null` to use the defaults.
+pub fn runDoctor(allocator: std.mem.Allocator, android_cfg: ?gen.AndroidConfig) !void {
+    // Every probe allocates path strings and the checks list; they all
+    // live until the report is printed at the end of this function. An
+    // arena matches that lifetime exactly and avoids tracking every
+    // individual allocation through optional / catch-null branches.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const resolved = android_cfg orelse gen.AndroidConfig{};
+    const info = try android_sdk.detect(arena_alloc, .{
+        .target_sdk_version = resolved.target_sdk_version,
+        // In doctor mode the NDK miss is still a hard failure — builds
+        // will fail without it — but we surface every check first so
+        // the user sees the full picture.
+        .ndk_required = true,
+    });
+
+    std.debug.print(
+        \\
+        \\labelle android doctor
+        \\======================
+        \\  target SDK: {d}
+        \\
+    , .{info.target_sdk_version});
+
+    var failures: u32 = 0;
+    var optional_misses: u32 = 0;
+    for (info.checks) |check| {
+        if (check.path) |p| {
+            std.debug.print("  [  OK  ] {s}\n           {s}\n", .{ check.name, p });
+        } else if (check.required) {
+            failures += 1;
+            std.debug.print("  [ FAIL ] {s}\n", .{check.name});
+            if (check.hint) |h| std.debug.print("           → {s}\n", .{h});
+        } else {
+            optional_misses += 1;
+            std.debug.print("  [ WARN ] {s}\n", .{check.name});
+            if (check.hint) |h| std.debug.print("           → {s}\n", .{h});
+        }
+    }
+
+    std.debug.print("\n", .{});
+    if (failures == 0) {
+        std.debug.print("  All required Android tools are present.\n", .{});
+        if (optional_misses > 0) {
+            std.debug.print("  ({d} optional tool(s) missing — see WARN lines above.)\n", .{optional_misses});
+        }
+        std.debug.print("\n", .{});
+    } else {
+        std.debug.print("  {d} required tool(s) missing — see FAIL lines above.\n", .{failures});
+        std.debug.print("  Install instructions: https://developer.android.com/tools\n\n", .{});
+        return error.AndroidToolsMissing;
     }
 }
 
@@ -519,7 +586,7 @@ fn copyDirectory(allocator: std.mem.Allocator, src: []const u8, dst: []const u8)
     }
 }
 
-fn printHelp() void {
+pub fn printHelp() void {
     std.debug.print(
         \\
         \\Usage: labelle android <command> [options]
@@ -527,6 +594,8 @@ fn printHelp() void {
         \\Commands:
         \\  build      Build for Android device (arm64)
         \\  run        Build and deploy to device/emulator
+        \\  doctor     Probe the Android SDK/NDK environment and report
+        \\             the status of every required tool
         \\  help       Show this help
         \\
         \\Options:

--- a/src/cli/android_sdk.zig
+++ b/src/cli/android_sdk.zig
@@ -1,0 +1,390 @@
+/// Android SDK / NDK detection.
+///
+/// Centralises the logic for finding every tool the `labelle android`
+/// subcommand family needs: `adb`, `aapt2`, `apksigner`, `zipalign`,
+/// `android.jar`, and the NDK sysroot. Each helper returns the
+/// absolute path on success or an error on failure; the top-level
+/// `detect()` runs every helper in tolerant mode so `labelle android
+/// doctor` can report a full status instead of bailing on the first
+/// missing tool.
+///
+/// The intent is that `src/cli/android.zig` (build + run + deploy)
+/// migrates over to using these helpers in a follow-up — for now it
+/// keeps its own private copies of `findAdb` / `findAndroidSdk` /
+/// `findBuildTools`.
+const std = @import("std");
+const builtin = @import("builtin");
+const util = @import("util.zig");
+
+pub const Error = error{
+    SdkNotFound,
+    AdbNotFound,
+    BuildToolsNotFound,
+    PlatformNotFound,
+    NdkNotFound,
+    AaptNotFound,
+    ApksignerNotFound,
+    ZipalignNotFound,
+    KeytoolNotFound,
+    OutOfMemory,
+};
+
+/// Outcome of a single tool / path probe. Used by `detect()` to let
+/// the doctor report every check even when earlier ones failed.
+pub const Check = struct {
+    /// Human-readable label shown in the doctor report ("adb",
+    /// "aapt2", "NDK sysroot", …).
+    name: []const u8,
+    /// Resolved absolute path, or null if detection failed. Owned by
+    /// the caller's arena allocator.
+    path: ?[]const u8 = null,
+    /// Optional one-line message for the user — typically a
+    /// remediation hint when `path` is null ("install platform-tools
+    /// with sdkmanager").
+    hint: ?[]const u8 = null,
+    /// Whether the absence of this tool should be treated as a hard
+    /// failure (exit 1 from doctor). Optional tools like the NDK are
+    /// `false` so doctor can still succeed on an SDK-only install.
+    required: bool = true,
+};
+
+/// Aggregate result returned by `detect()`. Every field is optional;
+/// the caller (`doctor`) walks the slice of `Check`s to print a report
+/// and decide on an exit code.
+pub const SdkInfo = struct {
+    sdk_home: ?[]const u8 = null,
+    ndk_sysroot: ?[]const u8 = null,
+    adb: ?[]const u8 = null,
+    aapt2: ?[]const u8 = null,
+    apksigner: ?[]const u8 = null,
+    zipalign: ?[]const u8 = null,
+    keytool: ?[]const u8 = null,
+    android_jar: ?[]const u8 = null,
+    build_tools_dir: ?[]const u8 = null,
+    build_tools_version: ?[]const u8 = null,
+    target_sdk_version: u32 = 34,
+    checks: []Check = &.{},
+
+    pub fn hasFailures(self: SdkInfo) bool {
+        for (self.checks) |c| {
+            if (c.required and c.path == null) return true;
+        }
+        return false;
+    }
+};
+
+pub const DetectOptions = struct {
+    /// SDK platform version to probe for `android.jar`.
+    target_sdk_version: u32 = 34,
+    /// When true, surface the NDK as a required tool (build / run
+    /// paths need it). Doctor defaults to `false` so the report still
+    /// succeeds on SDK-only installs.
+    ndk_required: bool = true,
+};
+
+/// Probe every Android tool and return a populated `SdkInfo`. Does
+/// NOT return an error on individual tool misses — the report in
+/// `.checks` is the source of truth. Errors are reserved for
+/// allocation / environment-variable failures that make the probe
+/// itself unusable.
+pub fn detect(allocator: std.mem.Allocator, opts: DetectOptions) !SdkInfo {
+    var info = SdkInfo{ .target_sdk_version = opts.target_sdk_version };
+    var checks: std.ArrayList(Check) = .{};
+    errdefer checks.deinit(allocator);
+
+    // ── SDK home ────────────────────────────────────────────────
+    info.sdk_home = findSdkHome(allocator) catch null;
+    try checks.append(allocator, .{
+        .name = "SDK home (ANDROID_HOME / ANDROID_SDK_ROOT)",
+        .path = info.sdk_home,
+        .hint = if (info.sdk_home == null)
+            "set ANDROID_HOME to your Android SDK directory"
+        else
+            null,
+        .required = true,
+    });
+
+    // Everything else is rooted at sdk_home, so bail early if it's missing.
+    // The probe still records every expected tool as missing so the doctor
+    // report stays informative.
+    if (info.sdk_home) |sdk_home| {
+        // ── adb ─────────────────────────────────────────────────
+        info.adb = findAdbUnder(allocator, sdk_home) catch null;
+        try checks.append(allocator, .{
+            .name = "adb",
+            .path = info.adb,
+            .hint = if (info.adb == null)
+                "install SDK platform-tools: `sdkmanager \"platform-tools\"`"
+            else
+                null,
+            .required = true,
+        });
+
+        // ── Latest build-tools ──────────────────────────────────
+        if (findBuildTools(allocator, sdk_home)) |bt| {
+            info.build_tools_dir = bt.dir;
+            info.build_tools_version = bt.version;
+        } else |_| {}
+        try checks.append(allocator, .{
+            .name = "build-tools",
+            .path = info.build_tools_dir,
+            .hint = if (info.build_tools_dir == null)
+                "install build-tools: `sdkmanager \"build-tools;34.0.0\"`"
+            else
+                null,
+            .required = true,
+        });
+
+        // ── aapt2 / apksigner / zipalign (inside build-tools) ───
+        if (info.build_tools_dir) |bt_dir| {
+            info.aapt2 = joinIfExists(allocator, &.{ bt_dir, "aapt2" });
+            info.apksigner = joinIfExists(allocator, &.{ bt_dir, "apksigner" });
+            info.zipalign = joinIfExists(allocator, &.{ bt_dir, "zipalign" });
+        }
+        try checks.append(allocator, .{
+            .name = "aapt2",
+            .path = info.aapt2,
+            .hint = if (info.aapt2 == null) "missing from build-tools" else null,
+            .required = true,
+        });
+        try checks.append(allocator, .{
+            .name = "apksigner",
+            .path = info.apksigner,
+            .hint = if (info.apksigner == null) "missing from build-tools" else null,
+            .required = true,
+        });
+        try checks.append(allocator, .{
+            .name = "zipalign",
+            .path = info.zipalign,
+            .hint = if (info.zipalign == null) "missing from build-tools" else null,
+            .required = true,
+        });
+
+        // ── android.jar (SDK platform) ──────────────────────────
+        info.android_jar = findAndroidJar(allocator, sdk_home, opts.target_sdk_version) catch null;
+        try checks.append(allocator, .{
+            .name = "android.jar (platform)",
+            .path = info.android_jar,
+            .hint = if (info.android_jar == null)
+                hintAllocPrint(allocator, "install SDK platform: `sdkmanager \"platforms;android-{d}\"`", .{opts.target_sdk_version})
+            else
+                null,
+            .required = true,
+        });
+
+        // ── NDK sysroot ─────────────────────────────────────────
+        info.ndk_sysroot = findNdkSysroot(allocator, sdk_home) catch null;
+        try checks.append(allocator, .{
+            .name = "NDK sysroot",
+            .path = info.ndk_sysroot,
+            .hint = if (info.ndk_sysroot == null)
+                "install an NDK: `sdkmanager \"ndk;27.0.12077973\"` (or set ANDROID_NDK_HOME)"
+            else
+                null,
+            .required = opts.ndk_required,
+        });
+    } else {
+        // Record the downstream checks as missing but with an "SDK
+        // home required first" hint so the report explains the
+        // cascade.
+        const cascade_hint: []const u8 = "resolve SDK home first";
+        inline for (.{
+            "adb",
+            "build-tools",
+            "aapt2",
+            "apksigner",
+            "zipalign",
+            "android.jar (platform)",
+            "NDK sysroot",
+        }) |name| {
+            try checks.append(allocator, .{
+                .name = name,
+                .path = null,
+                .hint = cascade_hint,
+                .required = true,
+            });
+        }
+    }
+
+    // ── keytool (JDK) ───────────────────────────────────────────
+    // Needed to generate the debug keystore on first install. Not
+    // part of the SDK but required by `android run` / `android build`.
+    info.keytool = findOnPath(allocator, "keytool") catch null;
+    try checks.append(allocator, .{
+        .name = "keytool (JDK)",
+        .path = info.keytool,
+        .hint = if (info.keytool == null)
+            "install a JDK (any modern one ships keytool)"
+        else
+            null,
+        .required = true,
+    });
+
+    info.checks = try checks.toOwnedSlice(allocator);
+    return info;
+}
+
+// ── Individual probes ──────────────────────────────────────────────
+
+/// Resolve `$ANDROID_HOME`, falling back to `$ANDROID_SDK_ROOT`.
+pub fn findSdkHome(allocator: std.mem.Allocator) ![]u8 {
+    if (std.process.getEnvVarOwned(allocator, "ANDROID_HOME")) |home| {
+        return home;
+    } else |_| {}
+    if (std.process.getEnvVarOwned(allocator, "ANDROID_SDK_ROOT")) |home| {
+        return home;
+    } else |_| {}
+    return error.SdkNotFound;
+}
+
+/// Resolve adb: prefer `<sdk>/platform-tools/adb`, fall back to
+/// whatever `which adb` returns.
+pub fn findAdbUnder(allocator: std.mem.Allocator, sdk_home: []const u8) ![]u8 {
+    const candidate = try std.fs.path.join(allocator, &.{ sdk_home, "platform-tools", exeName("adb") });
+    if (std.fs.cwd().access(candidate, .{})) |_| {
+        return candidate;
+    } else |_| {
+        allocator.free(candidate);
+    }
+    return findOnPath(allocator, "adb") catch error.AdbNotFound;
+}
+
+pub const BuildTools = struct {
+    dir: []const u8,
+    version: []const u8,
+};
+
+/// Locate the newest `<sdk>/build-tools/<version>/` directory.
+/// Caller owns both returned slices.
+pub fn findBuildTools(allocator: std.mem.Allocator, sdk_home: []const u8) !BuildTools {
+    const bt_root = try std.fs.path.join(allocator, &.{ sdk_home, "build-tools" });
+    defer allocator.free(bt_root);
+
+    var dir = std.fs.cwd().openDir(bt_root, .{ .iterate = true }) catch return error.BuildToolsNotFound;
+    defer dir.close();
+
+    var latest: ?[]const u8 = null;
+    errdefer if (latest) |v| allocator.free(v);
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        if (latest) |prev| {
+            if (std.mem.order(u8, entry.name, prev) == .gt) {
+                allocator.free(prev);
+                latest = try allocator.dupe(u8, entry.name);
+            }
+        } else {
+            latest = try allocator.dupe(u8, entry.name);
+        }
+    }
+
+    const version = latest orelse return error.BuildToolsNotFound;
+    const joined = try std.fs.path.join(allocator, &.{ bt_root, version });
+    return .{ .dir = joined, .version = version };
+}
+
+/// `<sdk>/platforms/android-<target_sdk>/android.jar` — the compile
+/// classpath used by `aapt2`.
+pub fn findAndroidJar(allocator: std.mem.Allocator, sdk_home: []const u8, target_sdk_version: u32) ![]u8 {
+    const joined = try std.fmt.allocPrint(
+        allocator,
+        "{s}/platforms/android-{d}/android.jar",
+        .{ sdk_home, target_sdk_version },
+    );
+    if (std.fs.cwd().access(joined, .{})) |_| return joined else |_| {
+        allocator.free(joined);
+        return error.PlatformNotFound;
+    }
+}
+
+/// Resolve the NDK sysroot (for `-target aarch64-linux-android`):
+/// 1. `$ANDROID_NDK_HOME` if set and valid.
+/// 2. The newest `<sdk>/ndk/<version>/toolchains/llvm/prebuilt/<host>/sysroot/`.
+pub fn findNdkSysroot(allocator: std.mem.Allocator, sdk_home: []const u8) ![]u8 {
+    // 1. Explicit env var.
+    if (std.process.getEnvVarOwned(allocator, "ANDROID_NDK_HOME")) |ndk_home| {
+        defer allocator.free(ndk_home);
+        const sysroot = try std.fs.path.join(allocator, &.{
+            ndk_home, "toolchains", "llvm", "prebuilt", ndkHostTag(), "sysroot",
+        });
+        if (std.fs.cwd().access(sysroot, .{})) |_| return sysroot else |_| allocator.free(sysroot);
+    } else |_| {}
+
+    // 2. Newest NDK in `<sdk>/ndk/<version>`.
+    const ndk_root = try std.fs.path.join(allocator, &.{ sdk_home, "ndk" });
+    defer allocator.free(ndk_root);
+
+    var dir = std.fs.cwd().openDir(ndk_root, .{ .iterate = true }) catch return error.NdkNotFound;
+    defer dir.close();
+
+    var latest: ?[]const u8 = null;
+    errdefer if (latest) |v| allocator.free(v);
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        if (latest) |prev| {
+            if (std.mem.order(u8, entry.name, prev) == .gt) {
+                allocator.free(prev);
+                latest = try allocator.dupe(u8, entry.name);
+            }
+        } else {
+            latest = try allocator.dupe(u8, entry.name);
+        }
+    }
+
+    const version = latest orelse return error.NdkNotFound;
+    defer allocator.free(version);
+    const sysroot = try std.fs.path.join(allocator, &.{
+        ndk_root, version, "toolchains", "llvm", "prebuilt", ndkHostTag(), "sysroot",
+    });
+    if (std.fs.cwd().access(sysroot, .{})) |_| return sysroot else |_| {
+        allocator.free(sysroot);
+        return error.NdkNotFound;
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// NDK `<host>` triple used in `toolchains/llvm/prebuilt/<host>/`.
+/// The NDK ships only the `darwin-x86_64` directory even on Apple
+/// Silicon — aarch64 darwin runs the x86_64 binaries via Rosetta.
+fn ndkHostTag() []const u8 {
+    return switch (builtin.os.tag) {
+        .linux => "linux-x86_64",
+        .macos => "darwin-x86_64",
+        .windows => "windows-x86_64",
+        else => "linux-x86_64",
+    };
+}
+
+fn exeName(comptime base: []const u8) []const u8 {
+    return if (builtin.os.tag == .windows) base ++ ".exe" else base;
+}
+
+/// Join a path and return it only if it exists on disk. Frees the
+/// joined buffer on miss. Used for tools inside build-tools where we
+/// don't want a user-visible error — just a missing-from-report.
+fn joinIfExists(allocator: std.mem.Allocator, parts: []const []const u8) ?[]u8 {
+    const joined = std.fs.path.join(allocator, parts) catch return null;
+    if (std.fs.cwd().access(joined, .{})) |_| return joined else |_| {
+        allocator.free(joined);
+        return null;
+    }
+}
+
+/// Resolve a tool via `which <name>`. Caller owns the returned slice.
+fn findOnPath(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    const result = util.runCmd(allocator, &.{ "which", name }) catch return error.AdbNotFound;
+    defer allocator.free(result.stderr);
+    defer allocator.free(result.stdout);
+    if (result.term == .Exited and result.term.Exited == 0 and result.stdout.len > 0) {
+        const trimmed = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
+        return allocator.dupe(u8, trimmed);
+    }
+    return error.AdbNotFound;
+}
+
+fn hintAllocPrint(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ?[]const u8 {
+    return std.fmt.allocPrint(allocator, fmt, args) catch null;
+}

--- a/src/cli/android_sdk.zig
+++ b/src/cli/android_sdk.zig
@@ -64,21 +64,15 @@ pub const SdkInfo = struct {
     build_tools_version: ?[]const u8 = null,
     target_sdk_version: u32 = 34,
     checks: []Check = &.{},
-
-    pub fn hasFailures(self: SdkInfo) bool {
-        for (self.checks) |c| {
-            if (c.required and c.path == null) return true;
-        }
-        return false;
-    }
 };
 
 pub const DetectOptions = struct {
     /// SDK platform version to probe for `android.jar`.
     target_sdk_version: u32 = 34,
     /// When true, surface the NDK as a required tool (build / run
-    /// paths need it). Doctor defaults to `false` so the report still
-    /// succeeds on SDK-only installs.
+    /// paths need it). Callers that want an SDK-only report — e.g.
+    /// doctor on a machine that will never cross-compile native code
+    /// — can explicitly set this to `false`.
     ndk_required: bool = true,
 };
 
@@ -136,10 +130,13 @@ pub fn detect(allocator: std.mem.Allocator, opts: DetectOptions) !SdkInfo {
         });
 
         // ── aapt2 / apksigner / zipalign (inside build-tools) ───
+        // On Windows aapt2/zipalign ship as .exe and apksigner is a
+        // .bat wrapper; fall back to the bare name for cross-platform
+        // test fixtures that mock out the tools with plain files.
         if (info.build_tools_dir) |bt_dir| {
-            info.aapt2 = joinIfExists(allocator, &.{ bt_dir, "aapt2" });
-            info.apksigner = joinIfExists(allocator, &.{ bt_dir, "apksigner" });
-            info.zipalign = joinIfExists(allocator, &.{ bt_dir, "zipalign" });
+            info.aapt2 = probeBuildTool(allocator, bt_dir, "aapt2");
+            info.apksigner = probeBuildTool(allocator, bt_dir, "apksigner");
+            info.zipalign = probeBuildTool(allocator, bt_dir, "zipalign");
         }
         try checks.append(allocator, .{
             .name = "aapt2",
@@ -186,22 +183,26 @@ pub fn detect(allocator: std.mem.Allocator, opts: DetectOptions) !SdkInfo {
     } else {
         // Record the downstream checks as missing but with an "SDK
         // home required first" hint so the report explains the
-        // cascade.
+        // cascade. NDK sysroot respects `opts.ndk_required` so
+        // SDK-only detection stays consistent with the non-cascade
+        // path.
         const cascade_hint: []const u8 = "resolve SDK home first";
-        inline for (.{
-            "adb",
-            "build-tools",
-            "aapt2",
-            "apksigner",
-            "zipalign",
-            "android.jar (platform)",
-            "NDK sysroot",
-        }) |name| {
+        const Entry = struct { name: []const u8, required: bool };
+        const entries = [_]Entry{
+            .{ .name = "adb", .required = true },
+            .{ .name = "build-tools", .required = true },
+            .{ .name = "aapt2", .required = true },
+            .{ .name = "apksigner", .required = true },
+            .{ .name = "zipalign", .required = true },
+            .{ .name = "android.jar (platform)", .required = true },
+            .{ .name = "NDK sysroot", .required = opts.ndk_required },
+        };
+        for (entries) |entry| {
             try checks.append(allocator, .{
-                .name = name,
+                .name = entry.name,
                 .path = null,
                 .hint = cascade_hint,
-                .required = true,
+                .required = entry.required,
             });
         }
     }
@@ -209,7 +210,7 @@ pub fn detect(allocator: std.mem.Allocator, opts: DetectOptions) !SdkInfo {
     // ── keytool (JDK) ───────────────────────────────────────────
     // Needed to generate the debug keystore on first install. Not
     // part of the SDK but required by `android run` / `android build`.
-    info.keytool = findOnPath(allocator, "keytool") catch null;
+    info.keytool = findOnPath(allocator, "keytool", error.KeytoolNotFound) catch null;
     try checks.append(allocator, .{
         .name = "keytool (JDK)",
         .path = info.keytool,
@@ -227,14 +228,29 @@ pub fn detect(allocator: std.mem.Allocator, opts: DetectOptions) !SdkInfo {
 // ── Individual probes ──────────────────────────────────────────────
 
 /// Resolve `$ANDROID_HOME`, falling back to `$ANDROID_SDK_ROOT`.
+///
+/// Only the `EnvironmentVariableNotFound` case is swallowed — real
+/// failures like `OutOfMemory` or `InvalidWtf8` propagate to the
+/// caller, so `detect()`'s docstring ("errors reserved for
+/// probe-unusable failures") stays honest.
 pub fn findSdkHome(allocator: std.mem.Allocator) ![]u8 {
-    if (std.process.getEnvVarOwned(allocator, "ANDROID_HOME")) |home| {
-        return home;
-    } else |_| {}
-    if (std.process.getEnvVarOwned(allocator, "ANDROID_SDK_ROOT")) |home| {
-        return home;
-    } else |_| {}
+    if (envVarOwnedOptional(allocator, "ANDROID_HOME")) |home| {
+        if (home) |h| return h;
+    } else |err| return err;
+    if (envVarOwnedOptional(allocator, "ANDROID_SDK_ROOT")) |home| {
+        if (home) |h| return h;
+    } else |err| return err;
     return error.SdkNotFound;
+}
+
+/// Wrapper around `std.process.getEnvVarOwned` that collapses
+/// "variable is unset / invalid UTF-8" into `null` while letting
+/// every other error (`OutOfMemory` first and foremost) propagate.
+fn envVarOwnedOptional(allocator: std.mem.Allocator, name: []const u8) !?[]u8 {
+    return std.process.getEnvVarOwned(allocator, name) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound, error.InvalidWtf8 => null,
+        else => err,
+    };
 }
 
 /// Resolve adb: prefer `<sdk>/platform-tools/adb`, fall back to
@@ -246,7 +262,7 @@ pub fn findAdbUnder(allocator: std.mem.Allocator, sdk_home: []const u8) ![]u8 {
     } else |_| {
         allocator.free(candidate);
     }
-    return findOnPath(allocator, "adb") catch error.AdbNotFound;
+    return findOnPath(allocator, "adb", error.AdbNotFound);
 }
 
 pub const BuildTools = struct {
@@ -255,7 +271,9 @@ pub const BuildTools = struct {
 };
 
 /// Locate the newest `<sdk>/build-tools/<version>/` directory.
-/// Caller owns both returned slices.
+/// Caller owns both returned slices. Version picking uses
+/// `util.parseVersion` so multi-digit majors compare numerically
+/// (`10.0.0` > `9.0.0`), not lexicographically.
 pub fn findBuildTools(allocator: std.mem.Allocator, sdk_home: []const u8) !BuildTools {
     const bt_root = try std.fs.path.join(allocator, &.{ sdk_home, "build-tools" });
     defer allocator.free(bt_root);
@@ -264,18 +282,17 @@ pub fn findBuildTools(allocator: std.mem.Allocator, sdk_home: []const u8) !Build
     defer dir.close();
 
     var latest: ?[]const u8 = null;
+    var latest_parsed: u32 = 0;
     errdefer if (latest) |v| allocator.free(v);
 
     var iter = dir.iterate();
     while (try iter.next()) |entry| {
         if (entry.kind != .directory) continue;
-        if (latest) |prev| {
-            if (std.mem.order(u8, entry.name, prev) == .gt) {
-                allocator.free(prev);
-                latest = try allocator.dupe(u8, entry.name);
-            }
-        } else {
+        const parsed = util.parseVersion(entry.name);
+        if (latest == null or parsed > latest_parsed) {
+            if (latest) |prev| allocator.free(prev);
             latest = try allocator.dupe(u8, entry.name);
+            latest_parsed = parsed;
         }
     }
 
@@ -287,11 +304,9 @@ pub fn findBuildTools(allocator: std.mem.Allocator, sdk_home: []const u8) !Build
 /// `<sdk>/platforms/android-<target_sdk>/android.jar` — the compile
 /// classpath used by `aapt2`.
 pub fn findAndroidJar(allocator: std.mem.Allocator, sdk_home: []const u8, target_sdk_version: u32) ![]u8 {
-    const joined = try std.fmt.allocPrint(
-        allocator,
-        "{s}/platforms/android-{d}/android.jar",
-        .{ sdk_home, target_sdk_version },
-    );
+    const platform_dir = try std.fmt.allocPrint(allocator, "android-{d}", .{target_sdk_version});
+    defer allocator.free(platform_dir);
+    const joined = try std.fs.path.join(allocator, &.{ sdk_home, "platforms", platform_dir, "android.jar" });
     if (std.fs.cwd().access(joined, .{})) |_| return joined else |_| {
         allocator.free(joined);
         return error.PlatformNotFound;
@@ -303,13 +318,13 @@ pub fn findAndroidJar(allocator: std.mem.Allocator, sdk_home: []const u8, target
 /// 2. The newest `<sdk>/ndk/<version>/toolchains/llvm/prebuilt/<host>/sysroot/`.
 pub fn findNdkSysroot(allocator: std.mem.Allocator, sdk_home: []const u8) ![]u8 {
     // 1. Explicit env var.
-    if (std.process.getEnvVarOwned(allocator, "ANDROID_NDK_HOME")) |ndk_home| {
+    if (try envVarOwnedOptional(allocator, "ANDROID_NDK_HOME")) |ndk_home| {
         defer allocator.free(ndk_home);
         const sysroot = try std.fs.path.join(allocator, &.{
             ndk_home, "toolchains", "llvm", "prebuilt", ndkHostTag(), "sysroot",
         });
         if (std.fs.cwd().access(sysroot, .{})) |_| return sysroot else |_| allocator.free(sysroot);
-    } else |_| {}
+    }
 
     // 2. Newest NDK in `<sdk>/ndk/<version>`.
     const ndk_root = try std.fs.path.join(allocator, &.{ sdk_home, "ndk" });
@@ -319,17 +334,16 @@ pub fn findNdkSysroot(allocator: std.mem.Allocator, sdk_home: []const u8) ![]u8 
     defer dir.close();
 
     var latest: ?[]const u8 = null;
+    var latest_parsed: u32 = 0;
     errdefer if (latest) |v| allocator.free(v);
     var iter = dir.iterate();
     while (try iter.next()) |entry| {
         if (entry.kind != .directory) continue;
-        if (latest) |prev| {
-            if (std.mem.order(u8, entry.name, prev) == .gt) {
-                allocator.free(prev);
-                latest = try allocator.dupe(u8, entry.name);
-            }
-        } else {
+        const parsed = util.parseVersion(entry.name);
+        if (latest == null or parsed > latest_parsed) {
+            if (latest) |prev| allocator.free(prev);
             latest = try allocator.dupe(u8, entry.name);
+            latest_parsed = parsed;
         }
     }
 
@@ -373,16 +387,39 @@ fn joinIfExists(allocator: std.mem.Allocator, parts: []const []const u8) ?[]u8 {
     }
 }
 
-/// Resolve a tool via `which <name>`. Caller owns the returned slice.
-fn findOnPath(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
-    const result = util.runCmd(allocator, &.{ "which", name }) catch return error.AdbNotFound;
+/// Look up a build-tools binary across the extensions each platform
+/// uses. On Windows aapt2/zipalign are `.exe` and apksigner ships as
+/// a `.bat` wrapper; on Unix the bare name is used.
+fn probeBuildTool(allocator: std.mem.Allocator, bt_dir: []const u8, name: []const u8) ?[]u8 {
+    const extensions: []const []const u8 = if (builtin.os.tag == .windows)
+        &.{ "", ".exe", ".bat", ".cmd" }
+    else
+        &.{""};
+    for (extensions) |ext| {
+        const leaf = std.fmt.allocPrint(allocator, "{s}{s}", .{ name, ext }) catch continue;
+        defer allocator.free(leaf);
+        if (joinIfExists(allocator, &.{ bt_dir, leaf })) |hit| return hit;
+    }
+    return null;
+}
+
+/// Resolve a tool via the platform PATH lookup helper (`which` on
+/// Unix, `where` on Windows). `not_found` is the error returned on
+/// miss so callers can surface a tool-specific error instead of
+/// always reporting "adb not found".
+fn findOnPath(allocator: std.mem.Allocator, name: []const u8, not_found: Error) ![]u8 {
+    const lookup_cmd: []const u8 = if (builtin.os.tag == .windows) "where" else "which";
+    const result = util.runCmd(allocator, &.{ lookup_cmd, name }) catch return not_found;
     defer allocator.free(result.stderr);
     defer allocator.free(result.stdout);
     if (result.term == .Exited and result.term.Exited == 0 and result.stdout.len > 0) {
         const trimmed = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
-        return allocator.dupe(u8, trimmed);
+        // `where` can return multiple lines when a tool is shadowed on
+        // PATH — first line is the active one, so drop the rest.
+        const first_line = std.mem.sliceTo(trimmed, '\n');
+        return allocator.dupe(u8, std.mem.trim(u8, first_line, &std.ascii.whitespace));
     }
-    return error.AdbNotFound;
+    return not_found;
 }
 
 fn hintAllocPrint(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ?[]const u8 {


### PR DESCRIPTION
## Summary
- New `src/cli/android_sdk.zig` centralises detection of every Android tool the build/run path needs (adb, build-tools, aapt2, apksigner, zipalign, android.jar, NDK sysroot, keytool). `detect()` runs every probe in tolerant mode so a single miss doesn't short-circuit the report.
- `labelle android doctor` prints a pass/fail report with remediation hints and exits 1 when any required tool is missing — scriptable from CI.
- Doctor + help are intercepted in `cli.zig` so they work from any directory (no `project.labelle` required).

Closes labelle-toolkit/labelle-cli#135.

## Test plan
- [x] `labelle android doctor` from `/tmp` with full SDK/NDK install → all `[  OK  ]`, exit 0
- [x] `labelle android doctor` with `ANDROID_HOME`/`ANDROID_SDK_ROOT` unset → cascade of `[ FAIL ]` with "resolve SDK home first" hints, exit 1
- [x] `labelle android help` from `/tmp` → prints usage, exit 0
- [x] `zig build` clean