### PR TITLE
feat(android): --release-small and custom keystore signing flags

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -98,7 +98,12 @@ const Platform = gen.Platform;
 const ParsedArgs = struct {
     command: Command,
     project_dir: []const u8 = ".",
-    extra_args: [8][]const u8 = undefined,
+    // Sized for the longest realistic android invocation:
+    //   android run --all-abis --release --keystore k --keystore-pass p
+    //               --key-alias a --key-pass kp
+    // That's 11 tokens — 16 gives headroom for future flags without
+    // risking silent truncation (flagged by the PR #171 review).
+    extra_args: [16][]const u8 = undefined,
     extra_count: usize = 0,
     timeout_ns: ?u64 = null,
     scene_override: ?[]const u8 = null,
@@ -286,15 +291,22 @@ fn parseRunArgs(args: *std.process.ArgIterator, cmd_name: []const u8, allow_dir:
 }
 
 /// Collect all remaining args into extra_args buffer.
-fn collectExtraArgs(args: *std.process.ArgIterator, extra_args: *[8][]const u8, extra_count: *usize) ParseError!void {
+fn collectExtraArgs(args: *std.process.ArgIterator, parsed_args: *ParsedArgs) ParseError!void {
     while (args.next()) |arg| {
-        if (extra_count.* >= extra_args.len) {
-            std.debug.print("labelle: too many arguments\n", .{});
-            return error.TooManyArguments;
-        }
-        extra_args[extra_count.*] = arg;
-        extra_count.* += 1;
+        try appendExtraArg(parsed_args, arg);
     }
+}
+
+/// Append one token to `ParsedArgs.extra_args`, surfacing overflow as
+/// an error instead of silently dropping it (which would let the
+/// subcommand fall through to `project_dir`).
+fn appendExtraArg(parsed_args: *ParsedArgs, arg: []const u8) ParseError!void {
+    if (parsed_args.extra_count >= parsed_args.extra_args.len) {
+        std.debug.print("labelle: too many arguments\n", .{});
+        return error.TooManyArguments;
+    }
+    parsed_args.extra_args[parsed_args.extra_count] = arg;
+    parsed_args.extra_count += 1;
 }
 
 /// Handle `labelle assembler <subcommand>`.
@@ -345,10 +357,10 @@ pub fn main() !void {
             parsed_args.docker_target = result.docker_target;
         } else if (std.mem.eql(u8, first, "init")) {
             parsed_args.command = .init_cmd;
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "install")) {
             parsed_args.command = .install_cmd;
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "upgrade")) {
             parsed_args.command = .upgrade_cmd;
             if (args.next()) |next_arg| {
@@ -360,19 +372,18 @@ pub fn main() !void {
                     std.mem.eql(u8, next_arg, "assembler") or
                     std.mem.eql(u8, next_arg, "all"))
                 {
-                    parsed_args.extra_args[parsed_args.extra_count] = next_arg;
-                    parsed_args.extra_count += 1;
+                    try appendExtraArg(&parsed_args, next_arg);
                 } else {
                     parsed_args.project_dir = next_arg;
                 }
             }
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "update")) {
             parsed_args.command = .update_cmd;
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "clean")) {
             parsed_args.command = .clean_cmd;
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "ios")) {
             parsed_args.command = .ios_cmd;
             // First non-flag arg that isn't a subcommand is the project dir
@@ -382,10 +393,7 @@ pub fn main() !void {
                     std.mem.eql(u8, arg, "xcode") or
                     std.mem.eql(u8, arg, "run"))
                 {
-                    if (parsed_args.extra_count < parsed_args.extra_args.len) {
-                        parsed_args.extra_args[parsed_args.extra_count] = arg;
-                        parsed_args.extra_count += 1;
-                    }
+                    try appendExtraArg(&parsed_args, arg);
                 } else {
                     parsed_args.project_dir = arg;
                 }
@@ -397,10 +405,7 @@ pub fn main() !void {
             var expect_value = false;
             while (args.next()) |arg| {
                 if (expect_value) {
-                    if (parsed_args.extra_count < parsed_args.extra_args.len) {
-                        parsed_args.extra_args[parsed_args.extra_count] = arg;
-                        parsed_args.extra_count += 1;
-                    }
+                    try appendExtraArg(&parsed_args, arg);
                     expect_value = false;
                     continue;
                 }
@@ -410,10 +415,7 @@ pub fn main() !void {
                     std.mem.eql(u8, arg, "doctor") or
                     std.mem.eql(u8, arg, "help"))
                 {
-                    if (parsed_args.extra_count < parsed_args.extra_args.len) {
-                        parsed_args.extra_args[parsed_args.extra_count] = arg;
-                        parsed_args.extra_count += 1;
-                    }
+                    try appendExtraArg(&parsed_args, arg);
                     if (std.mem.eql(u8, arg, "--keystore") or
                         std.mem.eql(u8, arg, "--keystore-pass") or
                         std.mem.eql(u8, arg, "--key-alias") or
@@ -427,7 +429,7 @@ pub fn main() !void {
             }
         } else if (std.mem.eql(u8, first, "assembler")) {
             parsed_args.command = .assembler_cmd;
-            try collectExtraArgs(&args, &parsed_args.extra_args, &parsed_args.extra_count);
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "help") or std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h")) {
             parsed_args.command = .help_cmd;
         } else if (std.mem.eql(u8, first, "version") or std.mem.eql(u8, first, "--version") or std.mem.eql(u8, first, "-v")) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -392,7 +392,18 @@ pub fn main() !void {
             }
         } else if (std.mem.eql(u8, first, "android")) {
             parsed_args.command = .android_cmd;
+            // Android value-bearing flags: the NEXT token after one of
+            // these is the flag's value, not the project directory.
+            var expect_value = false;
             while (args.next()) |arg| {
+                if (expect_value) {
+                    if (parsed_args.extra_count < parsed_args.extra_args.len) {
+                        parsed_args.extra_args[parsed_args.extra_count] = arg;
+                        parsed_args.extra_count += 1;
+                    }
+                    expect_value = false;
+                    continue;
+                }
                 if (std.mem.startsWith(u8, arg, "-") or
                     std.mem.eql(u8, arg, "build") or
                     std.mem.eql(u8, arg, "run") or
@@ -402,6 +413,13 @@ pub fn main() !void {
                     if (parsed_args.extra_count < parsed_args.extra_args.len) {
                         parsed_args.extra_args[parsed_args.extra_count] = arg;
                         parsed_args.extra_count += 1;
+                    }
+                    if (std.mem.eql(u8, arg, "--keystore") or
+                        std.mem.eql(u8, arg, "--keystore-pass") or
+                        std.mem.eql(u8, arg, "--key-alias") or
+                        std.mem.eql(u8, arg, "--key-pass"))
+                    {
+                        expect_value = true;
                     }
                 } else {
                     parsed_args.project_dir = arg;
@@ -641,7 +659,7 @@ pub fn main() !void {
     } else if (parsed.platform == .android) {
         // Android: deploy to device/emulator
         std.debug.print("labelle: deploying to Android...\n", .{});
-        try android.deployToDevice(allocator, target_dir, parsed, false);
+        try android.deployToDevice(allocator, target_dir, parsed, false, .{});
     } else {
         if (timeout_ns) |t| {
             const secs = t / std.time.ns_per_s;

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -5,6 +5,49 @@ const runner = @import("runner.zig");
 const util = @import("util.zig");
 const android_sdk = @import("android_sdk.zig");
 
+/// Optimisation mode selected from the CLI flags.
+/// `debug` is the default (stack-safe), `fast` is `ReleaseFast`,
+/// `small` is `ReleaseSmall`. Maps directly to the `-Doptimize=` arg
+/// we pass to `zig build`.
+pub const ReleaseMode = enum {
+    debug,
+    fast,
+    small,
+
+    pub fn optimizeFlag(self: ReleaseMode) ?[]const u8 {
+        return switch (self) {
+            .debug => null,
+            .fast => "-Doptimize=ReleaseFast",
+            .small => "-Doptimize=ReleaseSmall",
+        };
+    }
+};
+
+/// APK signing configuration. Every field is optional — unset means
+/// "use the debug keystore with the well-known `android` passwords".
+/// When `keystore` is set, `keystore_pass` is required too; the rest
+/// fall back to sensible defaults (`--key-pass` defaults to the
+/// keystore pass, `--key-alias` defaults to the only alias in the
+/// keystore when apksigner can find one).
+pub const SigningConfig = struct {
+    keystore: ?[]const u8 = null,
+    keystore_pass: ?[]const u8 = null,
+    key_alias: ?[]const u8 = null,
+    key_pass: ?[]const u8 = null,
+};
+
+/// Post-validation signing values passed into apksigner. Unlike
+/// `SigningConfig`, every required field is non-optional — the
+/// resolver picks debug defaults when the user didn't supply a
+/// keystore.
+const ResolvedSigning = struct {
+    keystore: []const u8,
+    keystore_pass: []const u8,
+    key_alias: ?[]const u8,
+    key_pass: ?[]const u8,
+    is_debug: bool,
+};
+
 /// Handle `labelle android <subcommand>` dispatch.
 pub fn handleAndroid(
     allocator: std.mem.Allocator,
@@ -14,13 +57,34 @@ pub fn handleAndroid(
 ) !void {
     var subcmd: ?[]const u8 = null;
     var emulator = false;
-    var release = false;
+    var release_mode: ReleaseMode = .debug;
+    var signing = SigningConfig{};
 
-    for (extra_args) |arg| {
+    var i: usize = 0;
+    while (i < extra_args.len) : (i += 1) {
+        const arg = extra_args[i];
         if (std.mem.eql(u8, arg, "--emulator")) {
             emulator = true;
         } else if (std.mem.eql(u8, arg, "--release")) {
-            release = true;
+            release_mode = .fast;
+        } else if (std.mem.eql(u8, arg, "--release-small")) {
+            release_mode = .small;
+        } else if (std.mem.eql(u8, arg, "--keystore")) {
+            i += 1;
+            if (i >= extra_args.len) return missingValue(arg);
+            signing.keystore = extra_args[i];
+        } else if (std.mem.eql(u8, arg, "--keystore-pass")) {
+            i += 1;
+            if (i >= extra_args.len) return missingValue(arg);
+            signing.keystore_pass = extra_args[i];
+        } else if (std.mem.eql(u8, arg, "--key-alias")) {
+            i += 1;
+            if (i >= extra_args.len) return missingValue(arg);
+            signing.key_alias = extra_args[i];
+        } else if (std.mem.eql(u8, arg, "--key-pass")) {
+            i += 1;
+            if (i >= extra_args.len) return missingValue(arg);
+            signing.key_pass = extra_args[i];
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
@@ -29,16 +93,21 @@ pub fn handleAndroid(
         }
     }
 
+    if (signing.keystore != null and signing.keystore_pass == null) {
+        std.debug.print("labelle android: --keystore requires --keystore-pass\n", .{});
+        return error.InvalidArgs;
+    }
+
     const cmd = subcmd orelse {
         printHelp();
         return;
     };
 
     if (std.mem.eql(u8, cmd, "build")) {
-        try androidBuild(allocator, target_dir, emulator, release);
+        try androidBuild(allocator, target_dir, emulator, release_mode);
     } else if (std.mem.eql(u8, cmd, "run")) {
-        try androidBuild(allocator, target_dir, emulator, release);
-        try deployToDevice(allocator, target_dir, cfg, emulator);
+        try androidBuild(allocator, target_dir, emulator, release_mode);
+        try deployToDevice(allocator, target_dir, cfg, emulator, signing);
     } else if (std.mem.eql(u8, cmd, "doctor")) {
         try runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {
@@ -47,6 +116,11 @@ pub fn handleAndroid(
         std.debug.print("labelle android: unknown subcommand '{s}'\n", .{cmd});
         printHelp();
     }
+}
+
+fn missingValue(flag: []const u8) error{InvalidArgs} {
+    std.debug.print("labelle android: {s} requires a value\n", .{flag});
+    return error.InvalidArgs;
 }
 
 /// Run the SDK / NDK environment probe and print a pass/fail report.
@@ -114,8 +188,16 @@ pub fn runDoctor(allocator: std.mem.Allocator, android_cfg: ?gen.AndroidConfig) 
 }
 
 /// Build the Android shared library via `zig build`.
-fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: bool, release: bool) !void {
-    std.debug.print("labelle: building for Android{s}...\n", .{if (emulator) " (emulator)" else ""});
+fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: bool, release_mode: ReleaseMode) !void {
+    const mode_label = switch (release_mode) {
+        .debug => "",
+        .fast => " [ReleaseFast]",
+        .small => " [ReleaseSmall]",
+    };
+    std.debug.print("labelle: building for Android{s}{s}...\n", .{
+        if (emulator) " (emulator)" else "",
+        mode_label,
+    });
 
     var zig_args: std.ArrayList([]const u8) = .{};
     defer zig_args.deinit(allocator);
@@ -124,8 +206,8 @@ fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: 
     if (emulator) {
         try zig_args.append(allocator, "-Demulator=true");
     }
-    if (release) {
-        try zig_args.append(allocator, "-Doptimize=ReleaseFast");
+    if (release_mode.optimizeFlag()) |flag| {
+        try zig_args.append(allocator, flag);
     }
 
     const build_result = try runner.runZig(allocator, target_dir, zig_args.items);
@@ -146,7 +228,7 @@ fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: 
 }
 
 /// Package APK and deploy to device/emulator via ADB.
-pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg: gen.ProjectConfig, emulator: bool) !void {
+pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg: gen.ProjectConfig, emulator: bool, signing: SigningConfig) !void {
     const android_cfg = cfg.android orelse gen.AndroidConfig{};
     // package_name may be heap-allocated (defaultPackageName) or a slice into
     // android_cfg (no allocation).  Track whether we own it so we can free it.
@@ -210,7 +292,7 @@ pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg:
     // Build APK
     const apk_path = try std.fs.path.join(allocator, &.{ target_dir, "game.apk" });
     defer allocator.free(apk_path);
-    try buildApk(allocator, staging_dir, apk_path, android_cfg);
+    try buildApk(allocator, staging_dir, apk_path, android_cfg, signing);
 
     // Install via ADB
     std.debug.print("labelle: installing on device...\n", .{});
@@ -256,7 +338,7 @@ pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg:
 }
 
 /// Build APK from staging directory using Android SDK tools.
-fn buildApk(allocator: std.mem.Allocator, staging_dir: []const u8, apk_path: []const u8, android_cfg: gen.AndroidConfig) !void {
+fn buildApk(allocator: std.mem.Allocator, staging_dir: []const u8, apk_path: []const u8, android_cfg: gen.AndroidConfig, signing: SigningConfig) !void {
     const sdk_home = try findAndroidSdk(allocator);
     defer allocator.free(sdk_home);
 
@@ -369,18 +451,51 @@ fn buildApk(allocator: std.mem.Allocator, staging_dir: []const u8, apk_path: []c
         }
     }
 
-    // Sign with debug keystore
-    const keystore = try ensureDebugKeystore(allocator);
-    defer allocator.free(keystore);
+    // ── Sign ────────────────────────────────────────────────────────
+    // `signing` wins when the user passed `--keystore` — otherwise we
+    // generate / reuse the debug keystore at ~/.labelle/. Both paths
+    // end up invoking apksigner with an argv built from the same
+    // builder so the two code paths stay in sync.
+    var debug_keystore_buf: ?[]u8 = null;
+    defer if (debug_keystore_buf) |b| allocator.free(b);
+
+    const resolved: ResolvedSigning = if (signing.keystore) |ks| .{
+        .keystore = ks,
+        .keystore_pass = signing.keystore_pass.?, // validated in handleAndroid
+        .key_alias = signing.key_alias,
+        .key_pass = signing.key_pass,
+        .is_debug = false,
+    } else blk: {
+        const kp = try ensureDebugKeystore(allocator);
+        debug_keystore_buf = kp;
+        break :blk .{
+            .keystore = kp,
+            .keystore_pass = "pass:android",
+            .key_alias = "androiddebugkey",
+            .key_pass = "pass:android",
+            .is_debug = true,
+        };
+    };
+
+    if (resolved.is_debug) {
+        std.debug.print("labelle: signing APK with debug keystore\n", .{});
+    } else {
+        std.debug.print("labelle: signing APK with {s}\n", .{resolved.keystore});
+    }
 
     {
-        const result = util.runCmd(allocator, &.{
+        var args: std.ArrayList([]const u8) = .{};
+        defer args.deinit(allocator);
+        try args.appendSlice(allocator, &.{
             apksigner, "sign",
-            "--ks",     keystore,
-            "--ks-pass", "pass:android",
-            "--out",    apk_path,
-            aligned_apk,
-        }) catch |err| {
+            "--ks",     resolved.keystore,
+            "--ks-pass", resolved.keystore_pass,
+        });
+        if (resolved.key_alias) |a| try args.appendSlice(allocator, &.{ "--ks-key-alias", a });
+        if (resolved.key_pass) |p| try args.appendSlice(allocator, &.{ "--key-pass", p });
+        try args.appendSlice(allocator, &.{ "--out", apk_path, aligned_apk });
+
+        const result = util.runCmd(allocator, args.items) catch |err| {
             std.debug.print("labelle: apksigner failed: {}\n", .{err});
             return err;
         };
@@ -599,8 +714,15 @@ pub fn printHelp() void {
         \\  help       Show this help
         \\
         \\Options:
-        \\  --emulator   Target x86_64 emulator instead of arm64 device
-        \\  --release    Build with ReleaseFast optimization
+        \\  --emulator         Target x86_64 emulator instead of arm64 device
+        \\  --release          Build with ReleaseFast optimization
+        \\  --release-small    Build with ReleaseSmall optimization
+        \\
+        \\Signing (release):
+        \\  --keystore <path>       Path to JKS keystore (default: debug keystore)
+        \\  --keystore-pass <pass>  apksigner --ks-pass (e.g. pass:xxx, env:VAR, file:/p)
+        \\  --key-alias <name>      Key alias inside the keystore
+        \\  --key-pass <pass>       apksigner --key-pass (defaults to keystore pass)
         \\
     , .{});
 }

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -70,21 +70,13 @@ pub fn handleAndroid(
         } else if (std.mem.eql(u8, arg, "--release-small")) {
             release_mode = .small;
         } else if (std.mem.eql(u8, arg, "--keystore")) {
-            i += 1;
-            if (i >= extra_args.len) return missingValue(arg);
-            signing.keystore = extra_args[i];
+            signing.keystore = try takeValue(extra_args, &i, arg);
         } else if (std.mem.eql(u8, arg, "--keystore-pass")) {
-            i += 1;
-            if (i >= extra_args.len) return missingValue(arg);
-            signing.keystore_pass = extra_args[i];
+            signing.keystore_pass = try takeValue(extra_args, &i, arg);
         } else if (std.mem.eql(u8, arg, "--key-alias")) {
-            i += 1;
-            if (i >= extra_args.len) return missingValue(arg);
-            signing.key_alias = extra_args[i];
+            signing.key_alias = try takeValue(extra_args, &i, arg);
         } else if (std.mem.eql(u8, arg, "--key-pass")) {
-            i += 1;
-            if (i >= extra_args.len) return missingValue(arg);
-            signing.key_pass = extra_args[i];
+            signing.key_pass = try takeValue(extra_args, &i, arg);
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
@@ -95,6 +87,15 @@ pub fn handleAndroid(
 
     if (signing.keystore != null and signing.keystore_pass == null) {
         std.debug.print("labelle android: --keystore requires --keystore-pass\n", .{});
+        return error.InvalidArgs;
+    }
+    if (signing.keystore == null and
+        (signing.keystore_pass != null or signing.key_alias != null or signing.key_pass != null))
+    {
+        std.debug.print(
+            "labelle android: --keystore-pass, --key-alias and --key-pass require --keystore\n",
+            .{},
+        );
         return error.InvalidArgs;
     }
 
@@ -121,6 +122,19 @@ pub fn handleAndroid(
 fn missingValue(flag: []const u8) error{InvalidArgs} {
     std.debug.print("labelle android: {s} requires a value\n", .{flag});
     return error.InvalidArgs;
+}
+
+/// Pull the next token as the value of a value-bearing flag. Rejects
+/// both the end-of-args case and tokens that look like another flag
+/// (start with `-`), so `--keystore --keystore-pass p` surfaces a
+/// clear "--keystore requires a value" instead of silently eating
+/// `--keystore-pass`.
+fn takeValue(extra_args: []const []const u8, i: *usize, flag: []const u8) error{InvalidArgs}![]const u8 {
+    i.* += 1;
+    if (i.* >= extra_args.len) return missingValue(flag);
+    const v = extra_args[i.*];
+    if (std.mem.startsWith(u8, v, "-")) return missingValue(flag);
+    return v;
 }
 
 /// Run the SDK / NDK environment probe and print a pass/fail report.
@@ -459,12 +473,23 @@ fn buildApk(allocator: std.mem.Allocator, staging_dir: []const u8, apk_path: []c
     var debug_keystore_buf: ?[]u8 = null;
     defer if (debug_keystore_buf) |b| allocator.free(b);
 
-    const resolved: ResolvedSigning = if (signing.keystore) |ks| .{
-        .keystore = ks,
-        .keystore_pass = signing.keystore_pass.?, // validated in handleAndroid
-        .key_alias = signing.key_alias,
-        .key_pass = signing.key_pass,
-        .is_debug = false,
+    // Re-validate here rather than trust `handleAndroid`'s check — the
+    // public `deployToDevice` is callable from other code paths (e.g.
+    // `labelle run` dispatching to Android without the android.zig
+    // arg parser), and we don't want a `SigningConfig` with a
+    // keystore but no pass to hit a panicking `.?` unwrap.
+    const resolved: ResolvedSigning = if (signing.keystore) |ks| blk: {
+        const kp = signing.keystore_pass orelse {
+            std.debug.print("labelle: signing keystore requires keystore_pass\n", .{});
+            return error.InvalidArgs;
+        };
+        break :blk .{
+            .keystore = ks,
+            .keystore_pass = kp,
+            .key_alias = signing.key_alias,
+            .key_pass = signing.key_pass,
+            .is_debug = false,
+        };
     } else blk: {
         const kp = try ensureDebugKeystore(allocator);
         debug_keystore_buf = kp;


### PR DESCRIPTION
## Summary
Phase 3 bits that are purely CLI-side (multi-arch APK lands in a follow-up that needs a new assembler template):

- `--release-small` builds with `ReleaseSmall` for minimum-size release artifacts. `--release` keeps meaning `ReleaseFast`.
- `--keystore <path>` + `--keystore-pass <pass>` + optional `--key-alias <name>` / `--key-pass <pass>` drive apksigner for real release signing. When omitted, the existing debug-keystore path is unchanged.

A new `ReleaseMode` enum replaces the `release: bool` plumbing so future variants (e.g. `--release-safe`) don't add more flag parameters to every function. `SigningConfig` → `ResolvedSigning` keeps debug defaults in one place and builds the apksigner argv from a single builder.

The top-level CLI parser got a small tweak: value-bearing flags (`--keystore`, `--keystore-pass`, `--key-alias`, `--key-pass`) now consume the following token instead of letting it fall through to `project_dir`.

Part of #136. Based on #170 (doctor) — retarget to main after that merges.

## Test plan
- [x] `zig build` clean
- [x] `zig build test` green
- [x] `labelle android help` shows the new flags
- [ ] End-to-end: build a signed release APK with a real keystore and install on a device