### PR TITLE
feat(android): --all-abis fat APK with arm64 + x86_64

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,17 +10,16 @@
         // below to pick up new assembler types; the old mirror
         // approach made every assembler change a double-edit (#151).
         .labelle_assembler = .{
-            // Pinned to the v0.7.0 release commit (2026-04-14).
-            // Brings the sokol fixes from this morning's session: rect
-            // outline draw, raylib-matching clear color, input lifecycle
-            // (game.quit + isKeyPressed timing), RunDesc compile fix,
-            // event forwarding to GUI bridge, and the sokol+imgui
-            // example. See labelle-assembler v0.7.0 release notes.
+            // Pinned to the post-v0.7.0 tip that carries the
+            // `-Dandroid_arch=arm64|x86_64` option in the Android
+            // build.zig template (labelle-assembler#43). `labelle
+            // android --all-abis` relies on that option to produce a
+            // fat APK from a single host.
             // Use the full 40-char SHA — abbreviated SHAs in archive
             // URLs can become ambiguous as upstream gains commits and
             // GitHub will return 404 in that case.
-            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/a5486b767aa51b4de880b8820c395b6e3038fab5.tar.gz",
-            .hash = "labelle_assembler-0.1.0-pG4XEKZ1AwCUOL9nZUSr6vKXRr9F0SMgGCnIg2WFEGG0",
+            .url = "https://github.com/labelle-toolkit/labelle-assembler/archive/4e60304d6dee5cef81a363a4770964b3c0839562.tar.gz",
+            .hash = "labelle_assembler-0.1.0-pG4XEBN5AwD7bXG3IZlRpVJoK5HwM05C9jMer7ngzejJ",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.7.0.tar.gz",

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -48,6 +48,43 @@ const ResolvedSigning = struct {
     is_debug: bool,
 };
 
+/// One built .so ready to be staged into `lib/<abi_dir>/libgame.so`.
+/// `deployToDevice` takes a slice of these so the single-arch and
+/// multi-arch (`--all-abis` fat APK) paths share the same staging /
+/// packaging / signing / install pipeline.
+pub const StagedAbi = struct {
+    /// APK `lib/` subdirectory (e.g. `arm64-v8a`, `x86_64`).
+    abi_dir: []const u8,
+    /// Absolute or target-dir-relative path to the built `libgame.so`.
+    so_path: []const u8,
+};
+
+/// The two arches `--all-abis` produces, in the order they're built.
+/// arm64 first so the faster device build runs before the slower
+/// x86_64 cross-build.
+const all_abi_archs = [_]AbiArch{ .arm64, .x86_64 };
+
+/// Android target arch selector. Mirrors the `-Dandroid_arch` option
+/// in the generated build.zig template.
+pub const AbiArch = enum {
+    arm64,
+    x86_64,
+
+    pub fn optionValue(self: AbiArch) []const u8 {
+        return switch (self) {
+            .arm64 => "arm64",
+            .x86_64 => "x86_64",
+        };
+    }
+
+    pub fn libDir(self: AbiArch) []const u8 {
+        return switch (self) {
+            .arm64 => "arm64-v8a",
+            .x86_64 => "x86_64",
+        };
+    }
+};
+
 /// Handle `labelle android <subcommand>` dispatch.
 pub fn handleAndroid(
     allocator: std.mem.Allocator,
@@ -57,6 +94,7 @@ pub fn handleAndroid(
 ) !void {
     var subcmd: ?[]const u8 = null;
     var emulator = false;
+    var all_abis = false;
     var release_mode: ReleaseMode = .debug;
     var signing = SigningConfig{};
 
@@ -65,6 +103,8 @@ pub fn handleAndroid(
         const arg = extra_args[i];
         if (std.mem.eql(u8, arg, "--emulator")) {
             emulator = true;
+        } else if (std.mem.eql(u8, arg, "--all-abis")) {
+            all_abis = true;
         } else if (std.mem.eql(u8, arg, "--release")) {
             release_mode = .fast;
         } else if (std.mem.eql(u8, arg, "--release-small")) {
@@ -98,6 +138,10 @@ pub fn handleAndroid(
         );
         return error.InvalidArgs;
     }
+    if (all_abis and emulator) {
+        std.debug.print("labelle android: --all-abis and --emulator are mutually exclusive\n", .{});
+        return error.InvalidArgs;
+    }
 
     const cmd = subcmd orelse {
         printHelp();
@@ -105,10 +149,21 @@ pub fn handleAndroid(
     };
 
     if (std.mem.eql(u8, cmd, "build")) {
-        try androidBuild(allocator, target_dir, emulator, release_mode);
+        if (all_abis) {
+            _ = try buildAllAbis(allocator, target_dir, release_mode);
+        } else {
+            try androidBuild(allocator, target_dir, emulator, release_mode);
+        }
     } else if (std.mem.eql(u8, cmd, "run")) {
-        try androidBuild(allocator, target_dir, emulator, release_mode);
-        try deployToDevice(allocator, target_dir, cfg, emulator, signing);
+        if (all_abis) {
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            const abis = try buildAllAbis(arena.allocator(), target_dir, release_mode);
+            try deployToDeviceWithAbis(allocator, target_dir, cfg, abis, signing);
+        } else {
+            try androidBuild(allocator, target_dir, emulator, release_mode);
+            try deployToDevice(allocator, target_dir, cfg, emulator, signing);
+        }
     } else if (std.mem.eql(u8, cmd, "doctor")) {
         try runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {
@@ -201,6 +256,86 @@ pub fn runDoctor(allocator: std.mem.Allocator, android_cfg: ?gen.AndroidConfig) 
     }
 }
 
+/// Build every ABI the fat APK needs, stashing each `libgame.so` at
+/// a per-arch path so back-to-back `zig build` invocations don't
+/// clobber each other. Returns a slice of `StagedAbi` entries (owned
+/// by `allocator`, typically an arena) that `deployToDeviceWithAbis`
+/// can stage into `apk-staging/lib/<abi>/`.
+///
+/// Relies on the generated build.zig accepting
+/// `-Dandroid_arch=arm64|x86_64`, which landed in labelle-assembler's
+/// Android template. Projects generated before that template change
+/// will fail with "unknown option 'android_arch'" — users need to
+/// regenerate build.zig.
+fn buildAllAbis(allocator: std.mem.Allocator, target_dir: []const u8, release_mode: ReleaseMode) ![]const StagedAbi {
+    const stash_root = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "android-multi" });
+    std.fs.cwd().makePath(stash_root) catch {};
+
+    var staged: std.ArrayList(StagedAbi) = .{};
+    errdefer staged.deinit(allocator);
+
+    for (all_abi_archs) |abi| {
+        try androidBuildArch(allocator, target_dir, abi, release_mode);
+
+        const src = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
+        defer allocator.free(src);
+        std.fs.cwd().access(src, .{}) catch {
+            std.debug.print("labelle: build for {s} did not produce {s}\n", .{ abi.optionValue(), src });
+            return error.BinaryNotFound;
+        };
+
+        const dst_dir = try std.fs.path.join(allocator, &.{ stash_root, abi.libDir() });
+        try std.fs.cwd().makePath(dst_dir);
+        const dst = try std.fs.path.join(allocator, &.{ dst_dir, "libgame.so" });
+        try std.fs.cwd().copyFile(src, std.fs.cwd(), dst, .{});
+
+        try staged.append(allocator, .{ .abi_dir = abi.libDir(), .so_path = dst });
+    }
+
+    return staged.toOwnedSlice(allocator);
+}
+
+/// Run `zig build -Dandroid_arch=<abi>` for a single target arch.
+/// Unlike `androidBuild`, this never passes `-Demulator` — the arch
+/// is selected explicitly so back-to-back builds are reproducible
+/// regardless of host CPU.
+fn androidBuildArch(allocator: std.mem.Allocator, target_dir: []const u8, abi: AbiArch, release_mode: ReleaseMode) !void {
+    const mode_label = switch (release_mode) {
+        .debug => "",
+        .fast => " [ReleaseFast]",
+        .small => " [ReleaseSmall]",
+    };
+    std.debug.print("labelle: building for Android ({s}){s}...\n", .{ abi.libDir(), mode_label });
+
+    var zig_args: std.ArrayList([]const u8) = .{};
+    defer zig_args.deinit(allocator);
+    try zig_args.appendSlice(allocator, &.{ "zig", "build" });
+
+    const arch_flag = try std.fmt.allocPrint(allocator, "-Dandroid_arch={s}", .{abi.optionValue()});
+    defer allocator.free(arch_flag);
+    try zig_args.append(allocator, arch_flag);
+
+    if (release_mode.optimizeFlag()) |flag| {
+        try zig_args.append(allocator, flag);
+    }
+
+    const build_result = try runner.runZig(allocator, target_dir, zig_args.items);
+    defer allocator.free(build_result.stdout);
+    defer allocator.free(build_result.stderr);
+
+    switch (build_result.term) {
+        .Exited => |code| if (code != 0) {
+            std.debug.print("labelle: Android build failed ({s}):\n{s}\n", .{ abi.libDir(), build_result.stderr });
+            return error.BuildFailed;
+        },
+        else => {
+            std.debug.print("labelle: Android build ({s}) terminated abnormally\n{s}\n", .{ abi.libDir(), build_result.stderr });
+            return error.BuildFailed;
+        },
+    }
+    std.debug.print("  {s} build ok\n", .{abi.libDir()});
+}
+
 /// Build the Android shared library via `zig build`.
 fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: bool, release_mode: ReleaseMode) !void {
     const mode_label = switch (release_mode) {
@@ -241,8 +376,35 @@ fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: 
     std.debug.print("  build ok\n", .{});
 }
 
-/// Package APK and deploy to device/emulator via ADB.
+/// Package APK and deploy to device/emulator via ADB. Single-arch
+/// entry point — picks the ABI from `emulator` + host arch, then
+/// delegates to `deployToDeviceWithAbis`.
 pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg: gen.ProjectConfig, emulator: bool, signing: SigningConfig) !void {
+    const builtin = @import("builtin");
+    // On Apple Silicon, the Android emulator runs ARM64 images; on
+    // Intel Macs it runs x86_64. Physical device builds always
+    // target arm64-v8a.
+    const abi_dir: []const u8 = if (emulator and builtin.cpu.arch != .aarch64) "x86_64" else "arm64-v8a";
+    const so_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
+    defer allocator.free(so_path);
+
+    const abis = [_]StagedAbi{.{ .abi_dir = abi_dir, .so_path = so_path }};
+    try deployToDeviceWithAbis(allocator, target_dir, cfg, abis[0..], signing);
+}
+
+/// Shared staging / packaging / install / launch pipeline used by
+/// both the single-arch and `--all-abis` paths. `abis` is the list of
+/// `(abi_dir, libgame.so path)` pairs that get fanned out into
+/// `apk-staging/lib/<abi_dir>/libgame.so` before `buildApk` runs.
+pub fn deployToDeviceWithAbis(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    abis: []const StagedAbi,
+    signing: SigningConfig,
+) !void {
+    if (abis.len == 0) return error.NoAbisProvided;
+
     const android_cfg = cfg.android orelse gen.AndroidConfig{};
     // package_name may be heap-allocated (defaultPackageName) or a slice into
     // android_cfg (no allocation).  Track whether we own it so we can free it.
@@ -251,16 +413,13 @@ pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg:
     defer if (package_name_owned) allocator.free(package_name);
     const app_name = if (android_cfg.app_name.len > 0) android_cfg.app_name else cfg.title;
 
-    // Locate the built .so
-    const lib_name = if (emulator) "x86_64-linux-android" else "aarch64-linux-android";
-    _ = lib_name;
-    const so_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
-    defer allocator.free(so_path);
-
-    std.fs.cwd().access(so_path, .{}) catch {
-        std.debug.print("labelle: Android .so not found at {s}\n", .{so_path});
-        return error.BinaryNotFound;
-    };
+    // Validate every .so exists before we touch the staging dir.
+    for (abis) |abi| {
+        std.fs.cwd().access(abi.so_path, .{}) catch {
+            std.debug.print("labelle: Android .so not found at {s}\n", .{abi.so_path});
+            return error.BinaryNotFound;
+        };
+    }
 
     // Find ADB
     const adb = try findAdb(allocator);
@@ -272,18 +431,18 @@ pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg:
     // Intentionally ignoring errors: the staging directory may not exist on first run.
     std.fs.cwd().deleteTree(staging_dir) catch {};
 
-    // Stage .so into lib/<abi>/.
-    // On Apple Silicon, the Android emulator runs ARM64 images; on Intel Macs
-    // it runs x86_64.  Physical device builds always target arm64-v8a.
-    const builtin = @import("builtin");
-    const abi_dir = if (emulator and builtin.cpu.arch != .aarch64) "x86_64" else "arm64-v8a";
-    const lib_dir = try std.fs.path.join(allocator, &.{ staging_dir, "lib", abi_dir });
-    defer allocator.free(lib_dir);
-    try std.fs.cwd().makePath(lib_dir);
+    // Fan out every staged .so into `lib/<abi>/libgame.so`. The fat
+    // APK case produces multiple directories under `lib/`; apksigner
+    // and Android's package installer pick the right one per device.
+    for (abis) |abi| {
+        const lib_dir = try std.fs.path.join(allocator, &.{ staging_dir, "lib", abi.abi_dir });
+        defer allocator.free(lib_dir);
+        try std.fs.cwd().makePath(lib_dir);
 
-    const staged_so = try std.fs.path.join(allocator, &.{ lib_dir, "libgame.so" });
-    defer allocator.free(staged_so);
-    try std.fs.cwd().copyFile(so_path, std.fs.cwd(), staged_so, .{});
+        const staged_so = try std.fs.path.join(allocator, &.{ lib_dir, "libgame.so" });
+        defer allocator.free(staged_so);
+        try std.fs.cwd().copyFile(abi.so_path, std.fs.cwd(), staged_so, .{});
+    }
 
     // Generate AndroidManifest.xml
     const manifest_path = try std.fs.path.join(allocator, &.{ staging_dir, "AndroidManifest.xml" });
@@ -740,6 +899,9 @@ pub fn printHelp() void {
         \\
         \\Options:
         \\  --emulator         Target x86_64 emulator instead of arm64 device
+        \\  --all-abis         Build both arm64-v8a and x86_64 into a fat APK
+        \\                     (mutually exclusive with --emulator; requires
+        \\                      an assembler release with -Dandroid_arch)
         \\  --release          Build with ReleaseFast optimization
         \\  --release-small    Build with ReleaseSmall optimization
         \\

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -150,7 +150,13 @@ pub fn handleAndroid(
 
     if (std.mem.eql(u8, cmd, "build")) {
         if (all_abis) {
-            _ = try buildAllAbis(allocator, target_dir, release_mode);
+            // Arena contains every path string + the StagedAbi slice
+            // returned by buildAllAbis. For `build` we only care that
+            // the .so files landed on disk; the staged paths are
+            // discarded so the arena is all we need.
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            _ = try buildAllAbis(arena.allocator(), target_dir, release_mode);
         } else {
             try androidBuild(allocator, target_dir, emulator, release_mode);
         }
@@ -258,9 +264,15 @@ pub fn runDoctor(allocator: std.mem.Allocator, android_cfg: ?gen.AndroidConfig) 
 
 /// Build every ABI the fat APK needs, stashing each `libgame.so` at
 /// a per-arch path so back-to-back `zig build` invocations don't
-/// clobber each other. Returns a slice of `StagedAbi` entries (owned
-/// by `allocator`, typically an arena) that `deployToDeviceWithAbis`
-/// can stage into `apk-staging/lib/<abi>/`.
+/// clobber each other. Returns a slice of `StagedAbi` entries —
+/// every `so_path` field and the slice itself are owned by
+/// `allocator`.
+///
+/// Callers pass an ArenaAllocator so transient intermediate strings
+/// (stash_root, per-iter dst_dir) plus the returned slice are
+/// released together; manual defers are still used for correctness
+/// under a non-arena allocator (the `errdefer` that walks the list
+/// on failure, and the per-iter `dst_dir` free).
 ///
 /// Relies on the generated build.zig accepting
 /// `-Dandroid_arch=arm64|x86_64`, which landed in labelle-assembler's
@@ -269,10 +281,19 @@ pub fn runDoctor(allocator: std.mem.Allocator, android_cfg: ?gen.AndroidConfig) 
 /// regenerate build.zig.
 fn buildAllAbis(allocator: std.mem.Allocator, target_dir: []const u8, release_mode: ReleaseMode) ![]const StagedAbi {
     const stash_root = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "android-multi" });
-    std.fs.cwd().makePath(stash_root) catch {};
+    defer allocator.free(stash_root);
+    // Wipe any stale per-arch binaries from a previous `--all-abis`
+    // run — we want each invocation to start from a clean slate so
+    // aborted builds don't leave half-a-fat-APK lying around. Missing
+    // is fine; permission errors will surface on makePath below.
+    std.fs.cwd().deleteTree(stash_root) catch {};
+    try std.fs.cwd().makePath(stash_root);
 
     var staged: std.ArrayList(StagedAbi) = .{};
-    errdefer staged.deinit(allocator);
+    errdefer {
+        for (staged.items) |item| allocator.free(item.so_path);
+        staged.deinit(allocator);
+    }
 
     for (all_abi_archs) |abi| {
         try androidBuildArch(allocator, target_dir, abi, release_mode);
@@ -285,8 +306,11 @@ fn buildAllAbis(allocator: std.mem.Allocator, target_dir: []const u8, release_mo
         };
 
         const dst_dir = try std.fs.path.join(allocator, &.{ stash_root, abi.libDir() });
+        defer allocator.free(dst_dir);
         try std.fs.cwd().makePath(dst_dir);
+
         const dst = try std.fs.path.join(allocator, &.{ dst_dir, "libgame.so" });
+        errdefer allocator.free(dst);
         try std.fs.cwd().copyFile(src, std.fs.cwd(), dst, .{});
 
         try staged.append(allocator, .{ .abi_dir = abi.libDir(), .so_path = dst });


### PR DESCRIPTION
## Summary
Add \`labelle android build|run --all-abis\` which runs \`zig build -Dandroid_arch=arm64\` followed by \`-Dandroid_arch=x86_64\`, stashes each \`libgame.so\` at a per-arch path under \`zig-out/android-multi/\`, and stages both into the APK as \`lib/arm64-v8a/\` and \`lib/x86_64/\`.

The staging → packaging → install → launch pipeline is now shared between the single-arch and multi-arch paths: \`deployToDevice\` becomes a thin wrapper that builds a one-element \`StagedAbi\` slice and delegates to \`deployToDeviceWithAbis\`, which fans every entry into \`apk-staging/lib/<abi>/libgame.so\` before signing.

Closes labelle-toolkit/labelle-cli#136.

## Dependencies
- **Blocked on labelle-toolkit/labelle-assembler#43** — adds \`-Dandroid_arch\` to the Android build.zig template. This PR is draft until #43 merges, a new assembler tag ships, and the \`labelle_assembler\` pin in \`build.zig.zon\` is bumped.
- Based on #171 (keystore + \`--release-small\`). Retarget to main after #171 lands.

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` green
- [x] \`labelle android help\` shows \`--all-abis\`
- [ ] End-to-end: \`labelle android run --all-abis\` on Apple Silicon
  - [ ] both \`zig-out/android-multi/arm64-v8a/libgame.so\` and \`.../x86_64/libgame.so\` produced
  - [ ] APK contains \`lib/arm64-v8a/libgame.so\` + \`lib/x86_64/libgame.so\`
  - [ ] Installs on arm64 device
  - [ ] Installs on x86_64 emulator
- [ ] \`labelle android --all-abis --emulator\` rejects with clear error