### PR TITLE
docs: reference GitHub Actions workflow for Android releases

### DIFF
--- a/docs/workflows/android-release.yml
+++ b/docs/workflows/android-release.yml
@@ -1,0 +1,126 @@
+# Reference GitHub Actions workflow for a labelle-based Android game.
+#
+# Copy this file into your game repository as
+# `.github/workflows/android-release.yml`. On every `v*` tag push it will:
+#
+#   1. Install Zig + the Android SDK / NDK / build-tools.
+#   2. Check out and build the `labelle` CLI from source.
+#   3. Restore a release keystore from repository secrets.
+#   4. Run `labelle android build --all-abis --release` to produce a
+#      signed fat APK (arm64-v8a + x86_64).
+#   5. Attach the APK to a GitHub Release so Obtainium
+#      (https://github.com/ImranR98/Obtainium) can pick it up.
+#
+# ── Required repository secrets ────────────────────────────────────
+#
+#   ANDROID_KEYSTORE_BASE64   base64-encoded JKS/PKCS12 keystore
+#                             (`base64 -i release.jks | pbcopy`)
+#   ANDROID_KEYSTORE_PASS     password for the keystore
+#   ANDROID_KEY_ALIAS         alias of the signing key inside the keystore
+#   ANDROID_KEY_PASS          password for the key (often same as keystore)
+#
+# Generate a keystore once with:
+#   keytool -genkey -v -keystore release.jks -alias labelle-release \
+#     -keyalg RSA -keysize 2048 -validity 10000
+#
+# ── Things you may want to change ──────────────────────────────────
+#
+#   - `LABELLE_REF` below: pin a specific labelle-cli tag or commit
+#     instead of tracking `main`, so your CI is reproducible.
+#   - The APK path in the "Upload APK to Release" step assumes the
+#     sokol backend (`.labelle/sokol_android/game.apk`). If you use a
+#     different backend, adjust the path.
+#   - `ZIG_VERSION`: bump when labelle-cli's minimum_zig_version moves.
+
+name: Android Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # needed to create the GitHub Release
+
+env:
+  ZIG_VERSION: "0.15.2"
+  LABELLE_REF: "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out game repository
+        uses: actions/checkout@v4
+        with:
+          path: game
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Set up JDK (for keytool + apksigner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android build-tools + NDK
+        run: |
+          sdkmanager --install \
+            "platforms;android-34" \
+            "build-tools;34.0.0" \
+            "ndk;27.0.12077973"
+          # android-actions/setup-android exports ANDROID_SDK_ROOT; the
+          # labelle CLI reads ANDROID_HOME so re-export it here for
+          # compatibility with every android_sdk probe path.
+          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+
+      - name: Check out labelle-cli
+        uses: actions/checkout@v4
+        with:
+          repository: labelle-toolkit/labelle-cli
+          ref: ${{ env.LABELLE_REF }}
+          path: labelle-cli
+
+      - name: Build labelle CLI
+        working-directory: labelle-cli
+        run: |
+          zig build -Doptimize=ReleaseSafe
+          echo "$PWD/zig-out/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Android toolchain
+        working-directory: game
+        run: labelle android doctor
+
+      - name: Restore release keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" \
+            | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed fat APK
+        working-directory: game
+        run: |
+          labelle android build --all-abis --release \
+            --keystore "$RUNNER_TEMP/release.jks" \
+            --keystore-pass "pass:${{ secrets.ANDROID_KEYSTORE_PASS }}" \
+            --key-alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
+            --key-pass "pass:${{ secrets.ANDROID_KEY_PASS }}"
+
+      - name: Rename APK with version
+        working-directory: game
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          # sokol backend landing pad — change this if you use a
+          # different backend.
+          cp .labelle/sokol_android/game.apk "game-${VERSION}.apk"
+
+      - name: Publish GitHub Release with APK
+        uses: softprops/action-gh-release@v2
+        with:
+          files: game/game-*.apk
+          generate_release_notes: true

--- a/docs/workflows/android-release.yml
+++ b/docs/workflows/android-release.yml
@@ -13,8 +13,9 @@
 #
 # ── Required repository secrets ────────────────────────────────────
 #
-#   ANDROID_KEYSTORE_BASE64   base64-encoded JKS/PKCS12 keystore
-#                             (`base64 -i release.jks | pbcopy`)
+#   ANDROID_KEYSTORE_BASE64   single-line base64 of the JKS/PKCS12 keystore.
+#                             macOS:  base64 -i release.jks | tr -d '\n' | pbcopy
+#                             Linux:  base64 -w0 release.jks | xclip -selection clipboard
 #   ANDROID_KEYSTORE_PASS     password for the keystore
 #   ANDROID_KEY_ALIAS         alias of the signing key inside the keystore
 #   ANDROID_KEY_PASS          password for the key (often same as keystore)
@@ -44,6 +45,10 @@ permissions:
 
 env:
   ZIG_VERSION: "0.15.2"
+  # Pin labelle-cli to a specific tag or commit SHA so your CI is
+  # reproducible. `main` is accepted but will drift as upstream
+  # changes land — use it only for local iteration, never for
+  # a shipping release workflow.
   LABELLE_REF: "main"
 
 jobs:
@@ -98,18 +103,26 @@ jobs:
         run: labelle android doctor
 
       - name: Restore release keystore
+        # Secret is read via `env:` + `printf` rather than textual
+        # `${{ secrets.* }}` interpolation so a shell metacharacter in
+        # the base64 blob can't break the script or execute code.
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" \
-            | base64 --decode > "$RUNNER_TEMP/release.jks"
+          printf '%s' "$KEYSTORE_B64" | base64 --decode > "$RUNNER_TEMP/release.jks"
 
       - name: Build signed fat APK
         working-directory: game
+        env:
+          KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASS: ${{ secrets.ANDROID_KEY_PASS }}
         run: |
           labelle android build --all-abis --release \
             --keystore "$RUNNER_TEMP/release.jks" \
-            --keystore-pass "pass:${{ secrets.ANDROID_KEYSTORE_PASS }}" \
-            --key-alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
-            --key-pass "pass:${{ secrets.ANDROID_KEY_PASS }}"
+            --keystore-pass "pass:$KEYSTORE_PASS" \
+            --key-alias "$KEY_ALIAS" \
+            --key-pass "pass:$KEY_PASS"
 
       - name: Rename APK with version
         working-directory: game

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -150,15 +150,21 @@ pub fn handleAndroid(
 
     if (std.mem.eql(u8, cmd, "build")) {
         if (all_abis) {
-            // Arena contains every path string + the StagedAbi slice
-            // returned by buildAllAbis. For `build` we only care that
-            // the .so files landed on disk; the staged paths are
-            // discarded so the arena is all we need.
+            // Arena contains every intermediate path string and the
+            // StagedAbi slice returned by buildAllAbis — they all
+            // live for the duration of the package step and get
+            // released together when the arena drops.
             var arena = std.heap.ArenaAllocator.init(allocator);
             defer arena.deinit();
-            _ = try buildAllAbis(arena.allocator(), target_dir, release_mode);
+            const abis = try buildAllAbis(arena.allocator(), target_dir, release_mode);
+            const apk_path = try packageApkWithAbis(allocator, target_dir, cfg, abis, signing);
+            defer allocator.free(apk_path);
+            std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
         } else {
             try androidBuild(allocator, target_dir, emulator, release_mode);
+            const apk_path = try packageApk(allocator, target_dir, cfg, emulator, signing);
+            defer allocator.free(apk_path);
+            std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
         }
     } else if (std.mem.eql(u8, cmd, "run")) {
         if (all_abis) {
@@ -404,11 +410,7 @@ fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulator: 
 /// entry point — picks the ABI from `emulator` + host arch, then
 /// delegates to `deployToDeviceWithAbis`.
 pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg: gen.ProjectConfig, emulator: bool, signing: SigningConfig) !void {
-    const builtin = @import("builtin");
-    // On Apple Silicon, the Android emulator runs ARM64 images; on
-    // Intel Macs it runs x86_64. Physical device builds always
-    // target arm64-v8a.
-    const abi_dir: []const u8 = if (emulator and builtin.cpu.arch != .aarch64) "x86_64" else "arm64-v8a";
+    const abi_dir = hostAbiDir(emulator);
     const so_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
     defer allocator.free(so_path);
 
@@ -417,9 +419,10 @@ pub fn deployToDevice(allocator: std.mem.Allocator, target_dir: []const u8, cfg:
 }
 
 /// Shared staging / packaging / install / launch pipeline used by
-/// both the single-arch and `--all-abis` paths. `abis` is the list of
-/// `(abi_dir, libgame.so path)` pairs that get fanned out into
-/// `apk-staging/lib/<abi_dir>/libgame.so` before `buildApk` runs.
+/// both the single-arch and `--all-abis` run paths. Stages every
+/// entry in `abis` into `apk-staging/lib/<abi_dir>/libgame.so`,
+/// signs an APK via `packageApkWithAbis`, then pushes it to the
+/// connected device with ADB and launches the NativeActivity.
 pub fn deployToDeviceWithAbis(
     allocator: std.mem.Allocator,
     target_dir: []const u8,
@@ -427,6 +430,52 @@ pub fn deployToDeviceWithAbis(
     abis: []const StagedAbi,
     signing: SigningConfig,
 ) !void {
+    const apk_path = try packageApkWithAbis(allocator, target_dir, cfg, abis, signing);
+    defer allocator.free(apk_path);
+
+    const package_name = try resolvePackageName(allocator, cfg);
+    defer allocator.free(package_name);
+
+    try installAndLaunch(allocator, apk_path, package_name);
+}
+
+/// Single-arch wrapper around `packageApkWithAbis` that mirrors
+/// `deployToDevice`: picks the ABI from `emulator` + host arch,
+/// compiles a one-element `StagedAbi` slice, and returns the path to
+/// the signed APK (caller owns it).
+///
+/// Used by `labelle android build` when `--all-abis` is not set.
+pub fn packageApk(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    emulator: bool,
+    signing: SigningConfig,
+) ![]u8 {
+    const abi_dir = hostAbiDir(emulator);
+    const so_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
+    defer allocator.free(so_path);
+    const abis = [_]StagedAbi{.{ .abi_dir = abi_dir, .so_path = so_path }};
+    return packageApkWithAbis(allocator, target_dir, cfg, abis[0..], signing);
+}
+
+/// Package a signed APK from one or more built `libgame.so` entries.
+/// Does NOT touch ADB — this is the path that `labelle android build`
+/// and CI pipelines use to produce an installable artifact without
+/// requiring a connected device. Returns the owned path to the APK
+/// (typically `<target_dir>/game.apk`).
+///
+/// `abis` is the list of `(abi_dir, libgame.so path)` pairs that get
+/// fanned out into `apk-staging/lib/<abi_dir>/libgame.so` before
+/// `buildApk` runs. A single-element slice produces a single-arch
+/// APK; multi-element slices produce a fat APK.
+pub fn packageApkWithAbis(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    abis: []const StagedAbi,
+    signing: SigningConfig,
+) ![]u8 {
     if (abis.len == 0) return error.NoAbisProvided;
 
     const android_cfg = cfg.android orelse gen.AndroidConfig{};
@@ -444,10 +493,6 @@ pub fn deployToDeviceWithAbis(
             return error.BinaryNotFound;
         };
     }
-
-    // Find ADB
-    const adb = try findAdb(allocator);
-    defer allocator.free(adb);
 
     // Create APK staging directory
     const staging_dir = try std.fs.path.join(allocator, &.{ target_dir, "apk-staging" });
@@ -488,8 +533,18 @@ pub fn deployToDeviceWithAbis(
 
     // Build APK
     const apk_path = try std.fs.path.join(allocator, &.{ target_dir, "game.apk" });
-    defer allocator.free(apk_path);
+    errdefer allocator.free(apk_path);
     try buildApk(allocator, staging_dir, apk_path, android_cfg, signing);
+    return apk_path;
+}
+
+/// Push a previously-built APK to the connected device via `adb
+/// install -r` and launch the NativeActivity. Split out of
+/// `deployToDeviceWithAbis` so the `build` subcommand and CI
+/// pipelines can use the packaging half without touching ADB.
+fn installAndLaunch(allocator: std.mem.Allocator, apk_path: []const u8, package_name: []const u8) !void {
+    const adb = try findAdb(allocator);
+    defer allocator.free(adb);
 
     // Install via ADB
     std.debug.print("labelle: installing on device...\n", .{});
@@ -532,6 +587,23 @@ pub fn deployToDeviceWithAbis(
     }
 
     std.debug.print("labelle: app launched on device\n", .{});
+}
+
+/// Pick the ABI directory for a single-arch build. On Apple Silicon
+/// the Android emulator runs ARM64 images; on Intel Macs it runs
+/// x86_64. Physical device builds always target arm64-v8a.
+fn hostAbiDir(emulator: bool) []const u8 {
+    const builtin = @import("builtin");
+    return if (emulator and builtin.cpu.arch != .aarch64) "x86_64" else "arm64-v8a";
+}
+
+/// Resolve the Android package name from `cfg`, defaulting to
+/// `com.labelle.<project>` when the project doesn't set one. Caller
+/// owns the returned slice.
+fn resolvePackageName(allocator: std.mem.Allocator, cfg: gen.ProjectConfig) ![]const u8 {
+    const android_cfg = cfg.android orelse gen.AndroidConfig{};
+    if (android_cfg.package_name.len > 0) return allocator.dupe(u8, android_cfg.package_name);
+    return defaultPackageName(allocator, cfg.name);
 }
 
 /// Build APK from staging directory using Android SDK tools.


### PR DESCRIPTION
## Summary
Adds `docs/workflows/android-release.yml` — a ready-to-copy GitHub Actions workflow that a labelle game repo can drop into `.github/workflows/` to get tag-triggered signed fat-APK releases.

On every `v*` tag push the workflow:
1. installs Zig + Android SDK/NDK/build-tools,
2. builds the `labelle` CLI from source (pinned via `LABELLE_REF`),
3. restores a signing keystore from repository secrets,
4. runs `labelle android build --all-abis --release` to produce a signed fat APK (arm64-v8a + x86_64),
5. publishes a GitHub Release with the APK attached so [Obtainium](https://github.com/ImranR98/Obtainium) can detect it.

### Design note
This is intentionally a reference file — not a `labelle android init-ci` scaffold command. The labelle.games OTA platform tracked by #139–#143 is the long-term replacement for "copy-a-workflow" distribution; building a CLI scaffold now would become dead weight once that ships. Keeping the immediate deliverable to a single documented YAML file is the smallest change that unblocks users who want GitHub-Release-based updates today.

Closes #138.

## Test plan
- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses cleanly
- [x] `actionlint` reports no warnings
- [ ] Copy into a game repo, set the four secrets, push a `v*` tag, confirm APK shows up on the Release page
- [ ] Install via Obtainium on an Android device