### PR TITLE
feat(cli): labelle android deploy — build + upload APK to GitHub Releases (#141)

### DIFF
--- a/docs/tester-onboarding.md
+++ b/docs/tester-onboarding.md
@@ -1,0 +1,70 @@
+# Tester onboarding (Android, via Obtainium)
+
+Short guide for sending an internal tester a game build so they can receive updates automatically. Paired with `labelle android deploy` (ticket #141), this is the v1 of labelle's OTA story — zero custom infrastructure, ships through GitHub Releases.
+
+## Developer side (one-time per project)
+
+The game repo needs to be where releases live. If it already has GitHub Releases enabled, you're done. A normal `labelle android deploy --tag v0.3.0` will:
+
+1. Build a signed release APK (uses the keystore configured in `project.labelle` / CLI flags).
+2. Attach it to a new GitHub Release with auto-generated notes (commits since the last tag).
+3. Mark it as a pre-release when `--channel=staging|preview|internal` is set.
+
+Requirements on the dev's machine:
+- [`gh`](https://cli.github.com/) installed and authenticated (`gh auth login`).
+- Android SDK + NDK configured (see `labelle android doctor`).
+- A keystore — for internal testing, the debug keystore produced by `labelle android build` is fine. For production distribution, use a real keystore and pass `--keystore`, `--keystore-pass`, `--key-alias`, `--key-pass`.
+
+Typical deploy commands:
+
+```bash
+# Stable release — public (or private-repo-gated) channel.
+labelle android deploy --tag v0.3.0
+
+# Staging / preview — marked as GitHub pre-release.
+labelle android deploy --tag v0.3.0-rc1 --channel staging
+
+# Multi-arch APK (arm64 + x86_64), custom release notes.
+labelle android deploy --tag v0.3.0 --all-abis --notes-file NOTES.md
+```
+
+## Tester side (one-time per device)
+
+1. **Install Obtainium**. It's an open-source Android app that watches a list of APK sources and installs updates.
+   - Recommended: install from [F-Droid](https://f-droid.org/) for painless updates of Obtainium itself.
+   - Or grab the latest APK directly from <https://github.com/ImranR98/Obtainium/releases>.
+
+2. **Add the game repo as a source**.
+   - Open Obtainium → tap **+** → paste the GitHub repo URL (e.g. `https://github.com/<org>/<game>`).
+   - Obtainium detects the GitHub source, pulls the latest release, and installs the APK.
+   - If the repo is private: Obtainium → Settings → Source settings → GitHub → add a [personal access token](https://github.com/settings/tokens) with `repo` scope. One token covers every private game repo the tester is invited to.
+
+3. **Done**. New deploys show up in Obtainium's Apps tab as available updates; tap to install.
+
+By default Obtainium checks for updates in the background on a schedule (configurable). Testers who want to poll manually can pull-to-refresh the Apps screen.
+
+## Staging / preview channels
+
+GitHub pre-releases (what `--channel staging` produces) are hidden from the "latest" release by default, but Obtainium's GitHub source exposes a per-app **Include pre-releases** toggle. Testers opt into pre-releases per source:
+
+- Obtainium → tap the app → settings icon → toggle **Include pre-releases**.
+
+That's the whole channel story in v1 — testers subscribed with pre-releases on get every build; those without only see the stable tags.
+
+## Limits of the v1 flow
+
+| What you give up vs the planned custom companion (#142) | Workaround |
+|---|---|
+| Silent auto-install | Tester taps "install" in Obtainium's notification. Still zero developer interaction. |
+| Branded experience | Obtainium's UI, not labelle's. |
+| Fine-grained channels beyond stable / prerelease | Separate repos or tag prefixes if needed. |
+| Central revocation of access | Private repo + invite revocation. Obtainium can't fetch without a valid token. |
+
+When any of these become real pain points, revisit #142 (silent-install companion) and #139 (centralized labelle.games service).
+
+## Troubleshooting
+
+- **`gh auth status` fails during deploy.** Run `gh auth login` and retry. The deploy command probes this up front so you don't build a multi-MB APK just to discover the uploader isn't available.
+- **`gh release create` fails with "tag already exists".** Either pick a new tag or delete the existing release first: `gh release delete <tag> --yes`.
+- **Obtainium doesn't detect the new release.** Pull-to-refresh on the Apps screen, or check Settings → Background Updates Interval.
+- **Private repo, Obtainium can't authenticate.** Check the PAT is still valid (`repo` scope, not expired). Issue a new one if in doubt.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -412,6 +412,7 @@ pub fn main() !void {
                 if (std.mem.startsWith(u8, arg, "-") or
                     std.mem.eql(u8, arg, "build") or
                     std.mem.eql(u8, arg, "run") or
+                    std.mem.eql(u8, arg, "deploy") or
                     std.mem.eql(u8, arg, "doctor") or
                     std.mem.eql(u8, arg, "help"))
                 {
@@ -419,7 +420,10 @@ pub fn main() !void {
                     if (std.mem.eql(u8, arg, "--keystore") or
                         std.mem.eql(u8, arg, "--keystore-pass") or
                         std.mem.eql(u8, arg, "--key-alias") or
-                        std.mem.eql(u8, arg, "--key-pass"))
+                        std.mem.eql(u8, arg, "--key-pass") or
+                        std.mem.eql(u8, arg, "--tag") or
+                        std.mem.eql(u8, arg, "--channel") or
+                        std.mem.eql(u8, arg, "--notes-file"))
                     {
                         expect_value = true;
                     }

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -1,9 +1,23 @@
 /// Android build and deployment for labelle-cli.
+///
+/// Submodules live in `android/`. Each one owns a cohesive slice of
+/// the Android pipeline and imports the types it needs from this
+/// file (which doubles as the public namespace — `android.DeployOpts`,
+/// `android.buildAndPackage`, …).
 const std = @import("std");
 const gen = @import("generator");
 const runner = @import("runner.zig");
 const util = @import("util.zig");
 const android_sdk = @import("android_sdk.zig");
+
+// ── Submodules ─────────────────────────────────────────────────────
+const deploy_mod = @import("android/deploy.zig");
+
+// Re-export deploy-side public types so callers see them on the
+// `android` namespace (`android.DeployOpts`) without having to know
+// about the internal module layout.
+pub const DeployOpts = deploy_mod.DeployOpts;
+pub const cmdDeploy = deploy_mod.cmdDeploy;
 
 /// Optimisation mode selected from the CLI flags.
 /// `debug` is the default (stack-safe), `fast` is `ReleaseFast`,
@@ -179,7 +193,7 @@ pub fn handleAndroid(
             try deployToDevice(allocator, target_dir, cfg, emulator, signing);
         }
     } else if (std.mem.eql(u8, cmd, "deploy")) {
-        try cmdDeploy(allocator, target_dir, cfg, .{
+        try deploy_mod.cmdDeploy(allocator, target_dir, cfg, .{
             .tag = deploy_tag,
             .channel = deploy_channel,
             .notes_file = deploy_notes_file,
@@ -967,9 +981,9 @@ fn ensureDebugKeystore(allocator: std.mem.Allocator) ![]u8 {
 
 /// Build the shared library and package the APK in one go. Returns the
 /// caller-owned APK path on disk. Shared by the `android build` entry
-/// point and `deploy android` (#141) — the build half of the deploy
-/// command is identical to a regular build.
-fn buildAndPackage(
+/// point and `android/deploy.cmdDeploy` (#141) — the build half of
+/// the deploy command is identical to a regular build.
+pub fn buildAndPackage(
     allocator: std.mem.Allocator,
     target_dir: []const u8,
     cfg: gen.ProjectConfig,
@@ -990,145 +1004,6 @@ fn buildAndPackage(
     } else {
         try androidBuild(allocator, target_dir, emulator, release_mode);
         return packageApk(allocator, target_dir, cfg, emulator, signing);
-    }
-}
-
-/// Parameters for `labelle android deploy` (#141). Kept as a struct
-/// so the call site in `handleAndroid` stays readable and so adding
-/// future deploy-only flags doesn't ripple into every reader of the
-/// function signature.
-const DeployOpts = struct {
-    tag: ?[]const u8,
-    channel: []const u8, // "stable" | "staging" (others treated as stable for now)
-    notes_file: ?[]const u8,
-    release_mode: ReleaseMode,
-    all_abis: bool,
-    emulator: bool,
-    signing: SigningConfig,
-};
-
-/// Build + package an APK, then upload it as a GitHub Release via the
-/// `gh` CLI. v1 of the labelle.games OTA story (#141): zero server
-/// infrastructure, testers subscribe to the game's GitHub repo URL in
-/// Obtainium, the release flows to their device on next poll.
-fn cmdDeploy(
-    allocator: std.mem.Allocator,
-    target_dir: []const u8,
-    cfg: gen.ProjectConfig,
-    opts: DeployOpts,
-) !void {
-    const tag = opts.tag orelse {
-        std.debug.print(
-            \\labelle android deploy: --tag is required.
-            \\  Example: labelle android deploy --tag v0.3.0
-            \\  (use the release tag you want on GitHub — usually vMAJOR.MINOR.PATCH)
-            \\
-        , .{});
-        return error.InvalidArgs;
-    };
-
-    const channel_is_prerelease = std.mem.eql(u8, opts.channel, "staging") or
-        std.mem.eql(u8, opts.channel, "preview") or
-        std.mem.eql(u8, opts.channel, "internal");
-
-    // `gh` presence + auth is cheap to check up front. Failing here
-    // is a much better UX than building a multi-MB APK and then
-    // discovering the uploader isn't installed.
-    try ensureGhAvailable(allocator);
-
-    std.debug.print(
-        "labelle android deploy: building APK (channel={s}, tag={s})...\n",
-        .{ opts.channel, tag },
-    );
-
-    const apk_path = try buildAndPackage(
-        allocator,
-        target_dir,
-        cfg,
-        opts.release_mode,
-        opts.all_abis,
-        opts.emulator,
-        opts.signing,
-    );
-    defer allocator.free(apk_path);
-
-    std.debug.print("labelle android deploy: uploading {s} to GitHub Releases as {s}...\n", .{ apk_path, tag });
-
-    const release_title = try std.fmt.allocPrint(
-        allocator,
-        "{s} {s}",
-        .{ if (cfg.title.len > 0) cfg.title else cfg.name, tag },
-    );
-    defer allocator.free(release_title);
-
-    var argv: std.ArrayList([]const u8) = .{};
-    defer argv.deinit(allocator);
-    try argv.appendSlice(allocator, &.{
-        "gh",          "release", "create",
-        tag,           apk_path,  "--title",
-        release_title,
-    });
-    if (channel_is_prerelease) try argv.append(allocator, "--prerelease");
-    if (opts.notes_file) |f| {
-        try argv.append(allocator, "--notes-file");
-        try argv.append(allocator, f);
-    } else {
-        try argv.append(allocator, "--generate-notes");
-    }
-
-    const res = try util.runCmd(allocator, argv.items);
-    defer allocator.free(res.stdout);
-    defer allocator.free(res.stderr);
-
-    switch (res.term) {
-        .Exited => |code| {
-            if (code != 0) {
-                std.debug.print(
-                    "labelle android deploy: gh release create failed (exit {d}):\n{s}\n",
-                    .{ code, res.stderr },
-                );
-                return error.DeployFailed;
-            }
-        },
-        else => {
-            std.debug.print("labelle android deploy: gh release create terminated abnormally\n", .{});
-            return error.DeployFailed;
-        },
-    }
-
-    std.debug.print(
-        \\labelle android deploy: release {s} published.
-        \\  Testers with Obtainium subscribed to this repo will see the update on next poll.
-        \\
-    , .{tag});
-}
-
-/// Probe that `gh` is installed and authenticated. Cheaper to fail
-/// here than to build the APK and then discover the uploader is
-/// missing.
-fn ensureGhAvailable(allocator: std.mem.Allocator) !void {
-    const res = util.runCmd(allocator, &.{ "gh", "auth", "status" }) catch |err| {
-        std.debug.print(
-            \\labelle android deploy: failed to run `gh` ({s}).
-            \\  Install it from https://cli.github.com/ and run `gh auth login`.
-            \\
-        , .{@errorName(err)});
-        return error.DeployFailed;
-    };
-    defer allocator.free(res.stdout);
-    defer allocator.free(res.stderr);
-
-    const ok = switch (res.term) {
-        .Exited => |code| code == 0,
-        else => false,
-    };
-    if (!ok) {
-        std.debug.print(
-            \\labelle android deploy: `gh` is installed but not authenticated.
-            \\  Run `gh auth login` to set up GitHub access.
-            \\
-        , .{});
-        return error.DeployFailed;
     }
 }
 

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -97,6 +97,10 @@ pub fn handleAndroid(
     var all_abis = false;
     var release_mode: ReleaseMode = .debug;
     var signing = SigningConfig{};
+    // Deploy-only flags (ignored by other subcommands).
+    var deploy_tag: ?[]const u8 = null;
+    var deploy_channel: []const u8 = "stable";
+    var deploy_notes_file: ?[]const u8 = null;
 
     var i: usize = 0;
     while (i < extra_args.len) : (i += 1) {
@@ -117,6 +121,18 @@ pub fn handleAndroid(
             signing.key_alias = try takeValue(extra_args, &i, arg);
         } else if (std.mem.eql(u8, arg, "--key-pass")) {
             signing.key_pass = try takeValue(extra_args, &i, arg);
+        } else if (std.mem.eql(u8, arg, "--tag")) {
+            deploy_tag = try takeValue(extra_args, &i, arg);
+        } else if (std.mem.startsWith(u8, arg, "--tag=")) {
+            deploy_tag = arg["--tag=".len..];
+        } else if (std.mem.eql(u8, arg, "--channel")) {
+            deploy_channel = try takeValue(extra_args, &i, arg);
+        } else if (std.mem.startsWith(u8, arg, "--channel=")) {
+            deploy_channel = arg["--channel=".len..];
+        } else if (std.mem.eql(u8, arg, "--notes-file")) {
+            deploy_notes_file = try takeValue(extra_args, &i, arg);
+        } else if (std.mem.startsWith(u8, arg, "--notes-file=")) {
+            deploy_notes_file = arg["--notes-file=".len..];
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printHelp();
             return;
@@ -149,23 +165,9 @@ pub fn handleAndroid(
     };
 
     if (std.mem.eql(u8, cmd, "build")) {
-        if (all_abis) {
-            // Arena contains every intermediate path string and the
-            // StagedAbi slice returned by buildAllAbis — they all
-            // live for the duration of the package step and get
-            // released together when the arena drops.
-            var arena = std.heap.ArenaAllocator.init(allocator);
-            defer arena.deinit();
-            const abis = try buildAllAbis(arena.allocator(), target_dir, release_mode);
-            const apk_path = try packageApkWithAbis(allocator, target_dir, cfg, abis, signing);
-            defer allocator.free(apk_path);
-            std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
-        } else {
-            try androidBuild(allocator, target_dir, emulator, release_mode);
-            const apk_path = try packageApk(allocator, target_dir, cfg, emulator, signing);
-            defer allocator.free(apk_path);
-            std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
-        }
+        const apk_path = try buildAndPackage(allocator, target_dir, cfg, release_mode, all_abis, emulator, signing);
+        defer allocator.free(apk_path);
+        std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
     } else if (std.mem.eql(u8, cmd, "run")) {
         if (all_abis) {
             var arena = std.heap.ArenaAllocator.init(allocator);
@@ -176,6 +178,16 @@ pub fn handleAndroid(
             try androidBuild(allocator, target_dir, emulator, release_mode);
             try deployToDevice(allocator, target_dir, cfg, emulator, signing);
         }
+    } else if (std.mem.eql(u8, cmd, "deploy")) {
+        try cmdDeploy(allocator, target_dir, cfg, .{
+            .tag = deploy_tag,
+            .channel = deploy_channel,
+            .notes_file = deploy_notes_file,
+            .release_mode = if (release_mode == .debug) .fast else release_mode,
+            .all_abis = all_abis,
+            .emulator = emulator,
+            .signing = signing,
+        });
     } else if (std.mem.eql(u8, cmd, "doctor")) {
         try runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {
@@ -953,6 +965,173 @@ fn ensureDebugKeystore(allocator: std.mem.Allocator) ![]u8 {
     return keystore;
 }
 
+/// Build the shared library and package the APK in one go. Returns the
+/// caller-owned APK path on disk. Shared by the `android build` entry
+/// point and `deploy android` (#141) — the build half of the deploy
+/// command is identical to a regular build.
+fn buildAndPackage(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    release_mode: ReleaseMode,
+    all_abis: bool,
+    emulator: bool,
+    signing: SigningConfig,
+) ![]const u8 {
+    if (all_abis) {
+        // Arena contains every intermediate path string and the
+        // StagedAbi slice returned by buildAllAbis — they all live
+        // for the duration of the package step and get released
+        // together when the arena drops.
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const abis = try buildAllAbis(arena.allocator(), target_dir, release_mode);
+        return packageApkWithAbis(allocator, target_dir, cfg, abis, signing);
+    } else {
+        try androidBuild(allocator, target_dir, emulator, release_mode);
+        return packageApk(allocator, target_dir, cfg, emulator, signing);
+    }
+}
+
+/// Parameters for `labelle android deploy` (#141). Kept as a struct
+/// so the call site in `handleAndroid` stays readable and so adding
+/// future deploy-only flags doesn't ripple into every reader of the
+/// function signature.
+const DeployOpts = struct {
+    tag: ?[]const u8,
+    channel: []const u8, // "stable" | "staging" (others treated as stable for now)
+    notes_file: ?[]const u8,
+    release_mode: ReleaseMode,
+    all_abis: bool,
+    emulator: bool,
+    signing: SigningConfig,
+};
+
+/// Build + package an APK, then upload it as a GitHub Release via the
+/// `gh` CLI. v1 of the labelle.games OTA story (#141): zero server
+/// infrastructure, testers subscribe to the game's GitHub repo URL in
+/// Obtainium, the release flows to their device on next poll.
+fn cmdDeploy(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    opts: DeployOpts,
+) !void {
+    const tag = opts.tag orelse {
+        std.debug.print(
+            \\labelle android deploy: --tag is required.
+            \\  Example: labelle android deploy --tag v0.3.0
+            \\  (use the release tag you want on GitHub — usually vMAJOR.MINOR.PATCH)
+            \\
+        , .{});
+        return error.InvalidArgs;
+    };
+
+    const channel_is_prerelease = std.mem.eql(u8, opts.channel, "staging") or
+        std.mem.eql(u8, opts.channel, "preview") or
+        std.mem.eql(u8, opts.channel, "internal");
+
+    // `gh` presence + auth is cheap to check up front. Failing here
+    // is a much better UX than building a multi-MB APK and then
+    // discovering the uploader isn't installed.
+    try ensureGhAvailable(allocator);
+
+    std.debug.print(
+        "labelle android deploy: building APK (channel={s}, tag={s})...\n",
+        .{ opts.channel, tag },
+    );
+
+    const apk_path = try buildAndPackage(
+        allocator,
+        target_dir,
+        cfg,
+        opts.release_mode,
+        opts.all_abis,
+        opts.emulator,
+        opts.signing,
+    );
+    defer allocator.free(apk_path);
+
+    std.debug.print("labelle android deploy: uploading {s} to GitHub Releases as {s}...\n", .{ apk_path, tag });
+
+    const release_title = try std.fmt.allocPrint(
+        allocator,
+        "{s} {s}",
+        .{ if (cfg.title.len > 0) cfg.title else cfg.name, tag },
+    );
+    defer allocator.free(release_title);
+
+    var argv: std.ArrayList([]const u8) = .{};
+    defer argv.deinit(allocator);
+    try argv.appendSlice(allocator, &.{
+        "gh",          "release", "create",
+        tag,           apk_path,  "--title",
+        release_title,
+    });
+    if (channel_is_prerelease) try argv.append(allocator, "--prerelease");
+    if (opts.notes_file) |f| {
+        try argv.append(allocator, "--notes-file");
+        try argv.append(allocator, f);
+    } else {
+        try argv.append(allocator, "--generate-notes");
+    }
+
+    const res = try util.runCmd(allocator, argv.items);
+    defer allocator.free(res.stdout);
+    defer allocator.free(res.stderr);
+
+    switch (res.term) {
+        .Exited => |code| {
+            if (code != 0) {
+                std.debug.print(
+                    "labelle android deploy: gh release create failed (exit {d}):\n{s}\n",
+                    .{ code, res.stderr },
+                );
+                return error.DeployFailed;
+            }
+        },
+        else => {
+            std.debug.print("labelle android deploy: gh release create terminated abnormally\n", .{});
+            return error.DeployFailed;
+        },
+    }
+
+    std.debug.print(
+        \\labelle android deploy: release {s} published.
+        \\  Testers with Obtainium subscribed to this repo will see the update on next poll.
+        \\
+    , .{tag});
+}
+
+/// Probe that `gh` is installed and authenticated. Cheaper to fail
+/// here than to build the APK and then discover the uploader is
+/// missing.
+fn ensureGhAvailable(allocator: std.mem.Allocator) !void {
+    const res = util.runCmd(allocator, &.{ "gh", "auth", "status" }) catch |err| {
+        std.debug.print(
+            \\labelle android deploy: failed to run `gh` ({s}).
+            \\  Install it from https://cli.github.com/ and run `gh auth login`.
+            \\
+        , .{@errorName(err)});
+        return error.DeployFailed;
+    };
+    defer allocator.free(res.stdout);
+    defer allocator.free(res.stderr);
+
+    const ok = switch (res.term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+    if (!ok) {
+        std.debug.print(
+            \\labelle android deploy: `gh` is installed but not authenticated.
+            \\  Run `gh auth login` to set up GitHub access.
+            \\
+        , .{});
+        return error.DeployFailed;
+    }
+}
+
 /// Default package name from project name.
 fn defaultPackageName(allocator: std.mem.Allocator, name: []const u8) ![]const u8 {
     return std.fmt.allocPrint(allocator, "com.labelle.{s}", .{name});
@@ -989,6 +1168,7 @@ pub fn printHelp() void {
         \\Commands:
         \\  build      Build for Android device (arm64)
         \\  run        Build and deploy to device/emulator
+        \\  deploy     Build and upload to GitHub Releases (for Obtainium OTA)
         \\  doctor     Probe the Android SDK/NDK environment and report
         \\             the status of every required tool
         \\  help       Show this help
@@ -1006,6 +1186,18 @@ pub fn printHelp() void {
         \\  --keystore-pass <pass>  apksigner --ks-pass (e.g. pass:xxx, env:VAR, file:/p)
         \\  --key-alias <name>      Key alias inside the keystore
         \\  --key-pass <pass>       apksigner --key-pass (defaults to keystore pass)
+        \\
+        \\Deploy (labelle android deploy):
+        \\  --tag <v>               Release tag (required, e.g. v0.3.0)
+        \\  --channel <name>        stable (default) | staging | preview | internal
+        \\                          staging/preview/internal → GitHub pre-release
+        \\  --notes-file <path>     Release notes source (default: --generate-notes
+        \\                          from commits since previous tag)
+        \\
+        \\  Deploy implies a release build (use --release-small to opt into that
+        \\  optimize level) and requires `gh` authenticated locally. Testers
+        \\  install Obtainium once and subscribe to the repo URL; new releases
+        \\  flow automatically.
         \\
     , .{});
 }

--- a/src/cli/android/deploy.zig
+++ b/src/cli/android/deploy.zig
@@ -1,0 +1,157 @@
+/// `labelle android deploy` (#141) — build + package + upload APK to
+/// GitHub Releases. v1 of the labelle.games OTA story: zero server
+/// infrastructure, testers subscribe to the game's GitHub repo URL in
+/// Obtainium, the release flows to their device on next poll.
+///
+/// Dispatcher lives in the parent `android.zig` which parses the flags
+/// and hands them over as `DeployOpts`.
+const std = @import("std");
+const gen = @import("generator");
+
+const util = @import("../util.zig");
+const android = @import("../android.zig");
+
+/// Parameters for `labelle android deploy`. Kept as a struct so the
+/// call site in `handleAndroid` stays readable and so adding future
+/// deploy-only flags doesn't ripple into every reader of the function
+/// signature.
+pub const DeployOpts = struct {
+    tag: ?[]const u8,
+    channel: []const u8, // "stable" | "staging" (others treated as stable for now)
+    notes_file: ?[]const u8,
+    release_mode: android.ReleaseMode,
+    all_abis: bool,
+    emulator: bool,
+    signing: android.SigningConfig,
+};
+
+/// Build + package an APK, then upload it as a GitHub Release via the
+/// `gh` CLI.
+pub fn cmdDeploy(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: gen.ProjectConfig,
+    opts: DeployOpts,
+) !void {
+    const tag = opts.tag orelse {
+        std.debug.print(
+            \\labelle android deploy: --tag is required.
+            \\  Example: labelle android deploy --tag v0.3.0
+            \\  (use the release tag you want on GitHub — usually vMAJOR.MINOR.PATCH)
+            \\
+        , .{});
+        return error.InvalidArgs;
+    };
+
+    const channel_is_prerelease = std.mem.eql(u8, opts.channel, "staging") or
+        std.mem.eql(u8, opts.channel, "preview") or
+        std.mem.eql(u8, opts.channel, "internal");
+
+    // `gh` presence + auth is cheap to check up front. Failing here
+    // is a much better UX than building a multi-MB APK and then
+    // discovering the uploader isn't installed.
+    try ensureGhAvailable(allocator);
+
+    std.debug.print(
+        "labelle android deploy: building APK (channel={s}, tag={s})...\n",
+        .{ opts.channel, tag },
+    );
+
+    const apk_path = try android.buildAndPackage(
+        allocator,
+        target_dir,
+        cfg,
+        opts.release_mode,
+        opts.all_abis,
+        opts.emulator,
+        opts.signing,
+    );
+    defer allocator.free(apk_path);
+
+    std.debug.print("labelle android deploy: uploading {s} to GitHub Releases as {s}...\n", .{ apk_path, tag });
+
+    // Match the label the APK itself ships with so the release name
+    // in GitHub reads the same as what testers see on their device.
+    // `packageApkWithAbis` uses `android.app_name ?? cfg.title`; we
+    // mirror that precedence, then fall back to `cfg.name` instead of
+    // printing an empty label if both are blank.
+    const android_cfg = cfg.android orelse gen.AndroidConfig{};
+    const app_label = if (android_cfg.app_name.len > 0)
+        android_cfg.app_name
+    else if (cfg.title.len > 0)
+        cfg.title
+    else
+        cfg.name;
+    const release_title = try std.fmt.allocPrint(allocator, "{s} {s}", .{ app_label, tag });
+    defer allocator.free(release_title);
+
+    var argv: std.ArrayList([]const u8) = .{};
+    defer argv.deinit(allocator);
+    try argv.appendSlice(allocator, &.{
+        "gh",          "release", "create",
+        tag,           apk_path,  "--title",
+        release_title,
+    });
+    if (channel_is_prerelease) try argv.append(allocator, "--prerelease");
+    if (opts.notes_file) |f| {
+        try argv.append(allocator, "--notes-file");
+        try argv.append(allocator, f);
+    } else {
+        try argv.append(allocator, "--generate-notes");
+    }
+
+    const res = try util.runCmd(allocator, argv.items);
+    defer allocator.free(res.stdout);
+    defer allocator.free(res.stderr);
+
+    switch (res.term) {
+        .Exited => |code| {
+            if (code != 0) {
+                std.debug.print(
+                    "labelle android deploy: gh release create failed (exit {d}):\n{s}\n",
+                    .{ code, res.stderr },
+                );
+                return error.DeployFailed;
+            }
+        },
+        else => {
+            std.debug.print("labelle android deploy: gh release create terminated abnormally\n", .{});
+            return error.DeployFailed;
+        },
+    }
+
+    std.debug.print(
+        \\labelle android deploy: release {s} published.
+        \\  Testers with Obtainium subscribed to this repo will see the update on next poll.
+        \\
+    , .{tag});
+}
+
+/// Probe that `gh` is installed and authenticated. Cheaper to fail
+/// here than to build the APK and then discover the uploader is
+/// missing.
+fn ensureGhAvailable(allocator: std.mem.Allocator) !void {
+    const res = util.runCmd(allocator, &.{ "gh", "auth", "status" }) catch |err| {
+        std.debug.print(
+            \\labelle android deploy: failed to run `gh` ({s}).
+            \\  Install it from https://cli.github.com/ and run `gh auth login`.
+            \\
+        , .{@errorName(err)});
+        return error.DeployFailed;
+    };
+    defer allocator.free(res.stdout);
+    defer allocator.free(res.stderr);
+
+    const ok = switch (res.term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+    if (!ok) {
+        std.debug.print(
+            \\labelle android deploy: `gh` is installed but not authenticated.
+            \\  Run `gh auth login` to set up GitHub access.
+            \\
+        , .{});
+        return error.DeployFailed;
+    }
+}


### PR DESCRIPTION
Closes #141. Ships v1 of the labelle.games OTA story per the [Obtainium pivot proposed in #139](https://github.com/labelle-toolkit/labelle-cli/issues/139#issuecomment-4270139174) — no custom companion app, no centralized cloud, no dashboard. Testers install Obtainium once, subscribe to the repo URL, updates flow in.

## What's in the box

New subcommand: \`labelle android deploy\`.

\`\`\`bash
labelle android deploy --tag v0.3.0
labelle android deploy --tag v0.3.0-rc1 --channel staging
labelle android deploy --tag v0.3.0 --all-abis --notes-file NOTES.md
\`\`\`

The command:
1. Probes \`gh auth status\` up front (fail-fast before building a multi-MB APK if the uploader isn't set up).
2. Builds + packages via the existing \`android build\` path.
3. Shells out to \`gh release create <tag> <apk> --title \"<name> <tag>\" --generate-notes [--prerelease]\`.

Staging / preview / internal channels → \`--prerelease\` on the GitHub side; testers opt into pre-releases per-source in Obtainium.

## Refactor

Extracted \`buildAndPackage\` — both \`android build\` and \`android deploy\` now share the all_abis vs single-arch branching. The \`build\` subcommand is now a three-line wrapper around the helper.

## Naming choice: \`labelle android deploy\` vs the ticket's \`labelle deploy android\`

Chose the former to stay consistent with the existing \`android build / run / doctor\` layout. Adding a top-level \`deploy\` dispatcher is trivial when a second platform lands (\`deploy ios\`, \`deploy web\`). Happy to flip if reviewers disagree.

## Docs

\`docs/tester-onboarding.md\` walks testers through Obtainium install, the GitHub source add (including PAT for private repos), and the pre-release toggle for staging channels. Intended to serve as the labelle.games onboarding page if/when the v2 web surface lands.

## What's not covered here

- End-to-end test on a real CI/dev machine with Android SDK and signing key configured. This branch compiles cleanly and the shell-out assembly is verified, but the build step hits SDK setup errors on my local Mac — the last acceptance checkbox in #141 is left open for someone with a working environment.
- Unit tests for the deploy path — most of the logic is argument plumbing and a shell-out, and the existing android.zig has no unit tests to mirror. Happy to add a harness if reviewers want one.

## Test plan
- [x] \`zig build\` clean.
- [x] \`zig build test\` — 21/21 existing tests still pass.
- [x] \`labelle android help\` documents the deploy subcommand + flags.
- [x] Missing \`--tag\` surfaces an actionable error before building.
- [x] Missing \`gh auth\` surfaces an actionable error before building.
- [x] \`--channel staging\` maps to \`--prerelease\` on the \`gh\` argv.
- [ ] Full deploy round-trip on a machine with the Android SDK + a valid keystore + \`gh\` authed. Reviewer with a set-up environment to sanity-check.