### PR TITLE
feat(cli): add `labelle test` subcommand for in-file test discovery

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -12,6 +12,7 @@
 ///   labelle upgrade [dir] [pkg] [ver]   — bump versions in project.labelle
 ///   labelle update [ver]                — self-update the CLI
 ///   labelle clean [--dry-run]           — prune unused package versions
+///   labelle test [dir] [--verbose]      — run inline `test` blocks across the project source tree
 const std = @import("std");
 const gen = @import("generator");
 
@@ -22,6 +23,7 @@ const install = @import("cli/install.zig");
 const upgrade = @import("cli/upgrade.zig");
 const update = @import("cli/update.zig");
 const clean = @import("cli/clean.zig");
+const test_cmd_mod = @import("cli/test.zig");
 const config = @import("cli/config.zig");
 const compatibility = @import("cli/compatibility.zig");
 const lockfile = @import("cli/lockfile.zig");
@@ -35,7 +37,7 @@ const ios = @import("cli/ios.zig");
 const android = @import("cli/android.zig");
 const util = @import("cli/util.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, help_cmd, version, targets, assembler_cmd };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, help_cmd, version, targets, assembler_cmd, test_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -398,6 +400,9 @@ pub fn main() !void {
         } else if (std.mem.eql(u8, first, "clean")) {
             parsed_args.command = .clean_cmd;
             try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "test")) {
+            parsed_args.command = .test_cmd;
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "ios")) {
             parsed_args.command = .ios_cmd;
             // First non-flag arg that isn't a subcommand is the project dir
@@ -481,6 +486,7 @@ pub fn main() !void {
         .install_cmd => return install.cmdInstall(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .update_cmd => return update.cmdUpdate(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .clean_cmd => return clean.cmdClean(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .test_cmd => return test_cmd_mod.cmdTest(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
     }
@@ -824,6 +830,13 @@ pub const ParseOptimizeFlagSpec = struct {
         }
     };
 };
+
+// Surface inline-test specs from the `test` subcommand module so
+// `zspec.runAll(@This())` walks into them. Without these re-exports
+// zspec only sees the `pub const` namespaces declared directly in
+// cli.zig and would skip the test_cmd_mod's nested spec structs.
+pub const TestCmdShouldSkipPathSpec = test_cmd_mod.ShouldSkipPathSpec;
+pub const TestCmdFileHasTestBlockSpec = test_cmd_mod.FileHasTestBlockSpec;
 
 pub const ParsePlatformValueSpec = struct {
     pub const valid_platforms = struct {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -835,7 +835,7 @@ pub const ParseOptimizeFlagSpec = struct {
 // `zspec.runAll(@This())` walks into them. Without these re-exports
 // zspec only sees the `pub const` namespaces declared directly in
 // cli.zig and would skip the test_cmd_mod's nested spec structs.
-pub const TestCmdShouldSkipPathSpec = test_cmd_mod.ShouldSkipPathSpec;
+pub const TestCmdIsSkipDirSpec = test_cmd_mod.IsSkipDirSpec;
 pub const TestCmdFileHasTestBlockSpec = test_cmd_mod.FileHasTestBlockSpec;
 
 pub const ParsePlatformValueSpec = struct {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -19,6 +19,7 @@ pub fn printHelp() void {
         \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle (pkg: core, engine, gfx, cli, assembler, all)
         \\  update [ver] [--no-path]  Update the labelle CLI itself
         \\  clean [--dry-run] [--project=dir]  Remove unused cached package versions
+        \\  test [dir] [--verbose]  Run inline `test` blocks across the project source tree
         \\  help                 Show this help
         \\  version              Show CLI version
         \\
@@ -37,6 +38,8 @@ pub fn printHelp() void {
         \\  labelle run --docker
         \\  labelle install 0.2.0
         \\  labelle upgrade core 0.2.0
+        \\  labelle test
+        \\  labelle test ../my-game --verbose
         \\
     , .{gen.CLI_VERSION});
 }

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -1,0 +1,272 @@
+const std = @import("std");
+const config = @import("config.zig");
+
+/// Directories that hold generated, cached, or vendored output rather
+/// than user-authored source. We skip them when discovering test files
+/// so that `labelle test` doesn't try to run `zig test` against the
+/// assembler's emitted build tree (which has its own `zig build test`)
+/// or against pulled-in dependency caches.
+const skip_dirs = [_][]const u8{
+    ".labelle",
+    "zig-out",
+    "zig-cache",
+    ".zig-cache",
+    ".git",
+    "node_modules",
+};
+
+const TestStats = struct {
+    files_run: usize = 0,
+    files_with_tests: usize = 0,
+    files_failed: usize = 0,
+};
+
+/// Run in-file Zig tests across the project's source tree.
+///
+/// Walks the project directory for `.zig` files, skipping generated
+/// and cache directories, then invokes `zig test <file>` on each file
+/// that contains a `test` block. Aggregates results and exits non-zero
+/// if any file fails so this is usable from CI.
+pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    var project_dir: []const u8 = ".";
+    var verbose = false;
+    var dir_set = false;
+
+    for (cmd_args) |arg| {
+        if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
+            verbose = true;
+        } else if (std.mem.startsWith(u8, arg, "--")) {
+            std.debug.print("labelle test: unknown flag '{s}'\n", .{arg});
+            std.debug.print("  usage: labelle test [dir] [--verbose]\n", .{});
+            return error.UnknownFlag;
+        } else if (!dir_set) {
+            project_dir = arg;
+            dir_set = true;
+        } else {
+            std.debug.print("labelle test: unexpected argument '{s}'\n", .{arg});
+            return error.TooManyArguments;
+        }
+    }
+
+    // Confirm we're in a labelle project so users running `labelle test`
+    // outside of one get a familiar error rather than an empty pass.
+    var probe_arena = std.heap.ArenaAllocator.init(allocator);
+    defer probe_arena.deinit();
+    _ = config.readProjectConfig(probe_arena.allocator(), project_dir) catch |err| {
+        if (err == error.FileNotFound) {
+            std.debug.print("\n  No project.labelle found in '{s}'.\n\n", .{project_dir});
+            std.debug.print("  Run `labelle test` from the root of a labelle project.\n\n", .{});
+            return;
+        }
+        return err;
+    };
+
+    var stats = TestStats{};
+    try discoverAndRun(allocator, project_dir, &stats, verbose);
+
+    std.debug.print("\nlabelle test: {d} file(s) scanned, {d} ran tests, {d} failed\n", .{
+        stats.files_run,
+        stats.files_with_tests,
+        stats.files_failed,
+    });
+
+    if (stats.files_failed > 0) {
+        std.process.exit(1);
+    }
+}
+
+/// Walk `root` recursively, invoking `zig test` on each `.zig` file
+/// that declares at least one `test` block. Skips entries from `skip_dirs`.
+fn discoverAndRun(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    stats: *TestStats,
+    verbose: bool,
+) !void {
+    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch |err| {
+        std.debug.print("labelle test: could not open '{s}': {any}\n", .{ root, err });
+        return error.OpenFailed;
+    };
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+        if (shouldSkipPath(entry.path)) continue;
+
+        const rel_path = try std.fs.path.join(allocator, &.{ root, entry.path });
+        defer allocator.free(rel_path);
+
+        stats.files_run += 1;
+
+        const has_tests = fileHasTestBlock(allocator, rel_path) catch |err| {
+            std.debug.print("labelle test: could not read '{s}': {any}\n", .{ rel_path, err });
+            stats.files_failed += 1;
+            continue;
+        };
+        if (!has_tests) {
+            if (verbose) std.debug.print("  skip {s} (no test blocks)\n", .{rel_path});
+            continue;
+        }
+
+        stats.files_with_tests += 1;
+        std.debug.print("  test {s}\n", .{rel_path});
+        const ok = try runZigTest(allocator, rel_path);
+        if (!ok) {
+            stats.files_failed += 1;
+            std.debug.print("    FAILED: {s}\n", .{rel_path});
+        }
+    }
+}
+
+/// Return true if `rel_path` (a forward-slash or os-sep separated
+/// relative path produced by `Dir.Walker`) starts with a directory we
+/// want to skip — generated output, cache, vendored deps, etc.
+fn shouldSkipPath(rel_path: []const u8) bool {
+    var iter = std.mem.splitAny(u8, rel_path, "/\\");
+    while (iter.next()) |segment| {
+        if (segment.len == 0) continue;
+        for (skip_dirs) |skip| {
+            if (std.mem.eql(u8, segment, skip)) return true;
+        }
+    }
+    return false;
+}
+
+/// Cheap heuristic: scan the source for a `test` keyword followed by
+/// either a string literal or a brace, which catches both
+/// `test "name" { ... }` and `test { ... }` forms. Avoids spawning a
+/// `zig test` process for every .zig file in the tree, most of which
+/// (components, scripts, hooks) won't have inline tests.
+fn fileHasTestBlock(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const bytes = try std.fs.cwd().readFileAlloc(allocator, path, 4 * 1024 * 1024);
+    defer allocator.free(bytes);
+
+    var i: usize = 0;
+    while (i < bytes.len) {
+        const idx = std.mem.indexOfPos(u8, bytes, i, "test") orelse return false;
+        // Must be at start-of-line or preceded by whitespace so we don't
+        // match identifiers like `latest` or `mytest`.
+        const at_word_boundary = idx == 0 or isIdentifierBoundary(bytes[idx - 1]);
+        const after = idx + "test".len;
+        if (at_word_boundary and after < bytes.len) {
+            // Skip whitespace after the keyword.
+            var j = after;
+            while (j < bytes.len and (bytes[j] == ' ' or bytes[j] == '\t')) : (j += 1) {}
+            if (j < bytes.len and (bytes[j] == '{' or bytes[j] == '"')) return true;
+        }
+        i = idx + 1;
+    }
+    return false;
+}
+
+fn isIdentifierBoundary(c: u8) bool {
+    return !(std.ascii.isAlphanumeric(c) or c == '_');
+}
+
+/// Run `zig test <path>` with inherited stdio. Returns true on a clean
+/// (exit 0) run, false otherwise.
+fn runZigTest(allocator: std.mem.Allocator, path: []const u8) !bool {
+    var child: std.process.Child = .init(&.{ "zig", "test", path }, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    try child.spawn();
+    const term = try child.wait();
+    return switch (term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+}
+
+// --- Tests ---
+
+const expect = @import("zspec").expect;
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+pub const ShouldSkipPathSpec = struct {
+    pub const skips = struct {
+        test "skips .labelle subtree" {
+            try expect.equal(shouldSkipPath(".labelle/sokol_desktop/build.zig"), true);
+        }
+        test "skips zig-out subtree" {
+            try expect.equal(shouldSkipPath("zig-out/bin/foo.zig"), true);
+        }
+        test "skips nested .zig-cache" {
+            try expect.equal(shouldSkipPath("subdir/.zig-cache/o/x.zig"), true);
+        }
+        test "skips .git tree" {
+            try expect.equal(shouldSkipPath(".git/objects/x.zig"), true);
+        }
+    };
+
+    pub const keeps = struct {
+        test "keeps components" {
+            try expect.equal(shouldSkipPath("components/player.zig"), false);
+        }
+        test "keeps scripts/playing" {
+            try expect.equal(shouldSkipPath("scripts/playing/move.zig"), false);
+        }
+        test "keeps top-level zig file" {
+            try expect.equal(shouldSkipPath("util.zig"), false);
+        }
+    };
+};
+
+pub const FileHasTestBlockSpec = struct {
+    fn writeAndCheck(contents: []const u8) !bool {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const file = try tmp.dir.createFile("x.zig", .{});
+        try file.writeAll(contents);
+        file.close();
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const dir_path = try tmp.dir.realpath(".", &buf);
+        const path = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "x.zig" });
+        defer std.testing.allocator.free(path);
+        return try fileHasTestBlock(std.testing.allocator, path);
+    }
+
+    pub const detects = struct {
+        test "named test block" {
+            try expect.equal(try writeAndCheck("test \"trivial\" { }\n"), true);
+        }
+        test "anonymous test block" {
+            try expect.equal(try writeAndCheck("test {\n    return;\n}\n"), true);
+        }
+        test "test block after other code" {
+            try expect.equal(try writeAndCheck(
+                \\const std = @import("std");
+                \\pub fn foo() void {}
+                \\test "foo works" { }
+                \\
+            ), true);
+        }
+    };
+
+    pub const ignores = struct {
+        test "no test blocks" {
+            try expect.equal(try writeAndCheck(
+                \\const std = @import("std");
+                \\pub fn foo() void {}
+                \\
+            ), false);
+        }
+        test "test substring inside identifier" {
+            try expect.equal(try writeAndCheck(
+                \\const latest = 1;
+                \\const mytest = 2;
+                \\
+            ), false);
+        }
+        test "the word test in a comment without a block" {
+            try expect.equal(try writeAndCheck("// no test here\n"), false);
+        }
+    };
+};

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const config = @import("config.zig");
+const runner = @import("runner.zig");
 
 /// Directory names that hold generated, cached, or vendored output
 /// rather than user-authored source. We prune them at the iterator
@@ -201,19 +202,12 @@ fn isIdentifierBoundary(c: u8) bool {
 
 /// Run `zig test <rel_path>` from `cwd` with inherited stdio. Running
 /// in `cwd` (the project root) means tests that touch relative paths
-/// see the same filesystem layout as `zig build run` would.
+/// see the same filesystem layout as `zig build run` would. Delegates
+/// the spawn/wait dance to `runner.runZigInherit` so all CLI-driven
+/// zig invocations share one process-management code path.
 fn runZigTest(allocator: std.mem.Allocator, cwd: []const u8, rel_path: []const u8) !bool {
-    var child: std.process.Child = .init(&.{ "zig", "test", rel_path }, allocator);
-    child.cwd = cwd;
-    child.stdin_behavior = .Inherit;
-    child.stdout_behavior = .Inherit;
-    child.stderr_behavior = .Inherit;
-    try child.spawn();
-    const term = try child.wait();
-    return switch (term) {
-        .Exited => |code| code == 0,
-        else => false,
-    };
+    const code = try runner.runZigInherit(allocator, cwd, &.{ "zig", "test", rel_path }, null);
+    return code == 0;
 }
 
 // --- Tests ---

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const config = @import("config.zig");
 
-/// Directories that hold generated, cached, or vendored output rather
-/// than user-authored source. We skip them when discovering test files
-/// so that `labelle test` doesn't try to run `zig test` against the
-/// assembler's emitted build tree (which has its own `zig build test`)
-/// or against pulled-in dependency caches.
+/// Directory names that hold generated, cached, or vendored output
+/// rather than user-authored source. We prune them at the iterator
+/// level so `labelle test` doesn't recurse into the assembler's
+/// emitted build tree (which has its own `zig build test`) or into
+/// large dependency caches.
 const skip_dirs = [_][]const u8{
     ".labelle",
     "zig-out",
@@ -21,12 +21,14 @@ const TestStats = struct {
     files_failed: usize = 0,
 };
 
+const usage = "  usage: labelle test [dir] [--verbose]\n";
+
 /// Run in-file Zig tests across the project's source tree.
 ///
 /// Walks the project directory for `.zig` files, skipping generated
 /// and cache directories, then invokes `zig test <file>` on each file
-/// that contains a `test` block. Aggregates results and exits non-zero
-/// if any file fails so this is usable from CI.
+/// that contains a `test` block. Aggregates results and returns a
+/// non-zero error on any failure so this is usable from CI.
 pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
     var project_dir: []const u8 = ".";
     var verbose = false;
@@ -37,27 +39,29 @@ pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
             verbose = true;
         } else if (std.mem.startsWith(u8, arg, "--")) {
             std.debug.print("labelle test: unknown flag '{s}'\n", .{arg});
-            std.debug.print("  usage: labelle test [dir] [--verbose]\n", .{});
+            std.debug.print(usage, .{});
             return error.UnknownFlag;
         } else if (!dir_set) {
             project_dir = arg;
             dir_set = true;
         } else {
             std.debug.print("labelle test: unexpected argument '{s}'\n", .{arg});
+            std.debug.print(usage, .{});
             return error.TooManyArguments;
         }
     }
 
-    // Confirm we're in a labelle project so users running `labelle test`
-    // outside of one get a familiar error rather than an empty pass.
+    // Confirm we're in a labelle project. Use the quiet variant so we
+    // don't double-print: the inner reader already logs "could not
+    // read ..." which would duplicate the friendly hint below.
     var probe_arena = std.heap.ArenaAllocator.init(allocator);
     defer probe_arena.deinit();
-    _ = config.readProjectConfig(probe_arena.allocator(), project_dir) catch |err| {
+    _ = config.readProjectConfigQuiet(probe_arena.allocator(), project_dir) catch |err| {
         if (err == error.FileNotFound) {
             std.debug.print("\n  No project.labelle found in '{s}'.\n\n", .{project_dir});
             std.debug.print("  Run `labelle test` from the root of a labelle project.\n\n", .{});
-            return;
         }
+        // Propagate so CI exits non-zero on a misconfigured invocation.
         return err;
     };
 
@@ -70,75 +74,106 @@ pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
         stats.files_failed,
     });
 
-    if (stats.files_failed > 0) {
-        std.process.exit(1);
-    }
+    // Return an error rather than calling `std.process.exit` so the
+    // caller's `defer` blocks (allocator deinit, arena cleanup) run.
+    if (stats.files_failed > 0) return error.TestsFailed;
 }
 
-/// Walk `root` recursively, invoking `zig test` on each `.zig` file
-/// that declares at least one `test` block. Skips entries from `skip_dirs`.
+/// Open the project root and recursively walk it, pruning skip dirs.
 fn discoverAndRun(
     allocator: std.mem.Allocator,
-    root: []const u8,
+    project_dir: []const u8,
     stats: *TestStats,
     verbose: bool,
 ) !void {
-    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch |err| {
-        std.debug.print("labelle test: could not open '{s}': {any}\n", .{ root, err });
+    var root_dir = std.fs.cwd().openDir(project_dir, .{ .iterate = true }) catch |err| {
+        std.debug.print("labelle test: could not open '{s}': {any}\n", .{ project_dir, err });
         return error.OpenFailed;
     };
-    defer dir.close();
+    defer root_dir.close();
 
-    var walker = try dir.walk(allocator);
-    defer walker.deinit();
+    var rel_buf: std.ArrayList(u8) = .{};
+    defer rel_buf.deinit(allocator);
 
-    while (try walker.next()) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
-        if (shouldSkipPath(entry.path)) continue;
+    try walkDir(allocator, project_dir, &root_dir, &rel_buf, stats, verbose);
+}
 
-        const rel_path = try std.fs.path.join(allocator, &.{ root, entry.path });
-        defer allocator.free(rel_path);
+/// Recursive directory walker that maintains `rel_buf` as the
+/// project-relative path of the entry currently being processed.
+/// Prunes `skip_dirs` so the walker never descends into them.
+fn walkDir(
+    allocator: std.mem.Allocator,
+    project_dir: []const u8,
+    dir: *std.fs.Dir,
+    rel_buf: *std.ArrayList(u8),
+    stats: *TestStats,
+    verbose: bool,
+) !void {
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        const saved_len = rel_buf.items.len;
+        defer rel_buf.shrinkRetainingCapacity(saved_len);
 
-        stats.files_run += 1;
+        if (saved_len > 0) try rel_buf.append(allocator, std.fs.path.sep);
+        try rel_buf.appendSlice(allocator, entry.name);
 
-        const has_tests = fileHasTestBlock(allocator, rel_path) catch |err| {
-            std.debug.print("labelle test: could not read '{s}': {any}\n", .{ rel_path, err });
-            stats.files_failed += 1;
-            continue;
-        };
-        if (!has_tests) {
-            if (verbose) std.debug.print("  skip {s} (no test blocks)\n", .{rel_path});
-            continue;
-        }
+        switch (entry.kind) {
+            .directory => {
+                if (isSkipDir(entry.name)) continue;
+                var sub = dir.openDir(entry.name, .{ .iterate = true }) catch |err| {
+                    std.debug.print("labelle test: could not open '{s}': {any}\n", .{ rel_buf.items, err });
+                    continue;
+                };
+                defer sub.close();
+                try walkDir(allocator, project_dir, &sub, rel_buf, stats, verbose);
+            },
+            .file => {
+                if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
 
-        stats.files_with_tests += 1;
-        std.debug.print("  test {s}\n", .{rel_path});
-        const ok = try runZigTest(allocator, rel_path);
-        if (!ok) {
-            stats.files_failed += 1;
-            std.debug.print("    FAILED: {s}\n", .{rel_path});
+                // `rel_buf.items` is reused on the next iteration, but
+                // we don't append anything else within this branch, so
+                // the slice is valid for the duration of the file ops.
+                const rel_path = rel_buf.items;
+
+                const full_path = try std.fs.path.join(allocator, &.{ project_dir, rel_path });
+                defer allocator.free(full_path);
+
+                stats.files_run += 1;
+                const has_tests = fileHasTestBlock(allocator, full_path) catch |err| {
+                    std.debug.print("labelle test: could not read '{s}': {any}\n", .{ rel_path, err });
+                    stats.files_failed += 1;
+                    continue;
+                };
+                if (!has_tests) {
+                    if (verbose) std.debug.print("  skip {s} (no test blocks)\n", .{rel_path});
+                    continue;
+                }
+
+                stats.files_with_tests += 1;
+                std.debug.print("  test {s}\n", .{rel_path});
+                const ok = try runZigTest(allocator, project_dir, rel_path);
+                if (!ok) {
+                    stats.files_failed += 1;
+                    std.debug.print("    FAILED: {s}\n", .{rel_path});
+                }
+            },
+            else => {},
         }
     }
 }
 
-/// Return true if `rel_path` (a forward-slash or os-sep separated
-/// relative path produced by `Dir.Walker`) starts with a directory we
-/// want to skip — generated output, cache, vendored deps, etc.
-fn shouldSkipPath(rel_path: []const u8) bool {
-    var iter = std.mem.splitAny(u8, rel_path, "/\\");
-    while (iter.next()) |segment| {
-        if (segment.len == 0) continue;
-        for (skip_dirs) |skip| {
-            if (std.mem.eql(u8, segment, skip)) return true;
-        }
+/// True when `name` is a top-level directory we never descend into.
+fn isSkipDir(name: []const u8) bool {
+    for (skip_dirs) |skip| {
+        if (std.mem.eql(u8, name, skip)) return true;
     }
     return false;
 }
 
 /// Cheap heuristic: scan the source for a `test` keyword followed by
 /// either a string literal or a brace, which catches both
-/// `test "name" { ... }` and `test { ... }` forms. Avoids spawning a
+/// `test "name" { ... }` and `test { ... }` forms — including the
+/// Zig-allowed newline-after-keyword variant. Avoids spawning a
 /// `zig test` process for every .zig file in the tree, most of which
 /// (components, scripts, hooks) won't have inline tests.
 fn fileHasTestBlock(allocator: std.mem.Allocator, path: []const u8) !bool {
@@ -148,14 +183,11 @@ fn fileHasTestBlock(allocator: std.mem.Allocator, path: []const u8) !bool {
     var i: usize = 0;
     while (i < bytes.len) {
         const idx = std.mem.indexOfPos(u8, bytes, i, "test") orelse return false;
-        // Must be at start-of-line or preceded by whitespace so we don't
-        // match identifiers like `latest` or `mytest`.
         const at_word_boundary = idx == 0 or isIdentifierBoundary(bytes[idx - 1]);
         const after = idx + "test".len;
         if (at_word_boundary and after < bytes.len) {
-            // Skip whitespace after the keyword.
             var j = after;
-            while (j < bytes.len and (bytes[j] == ' ' or bytes[j] == '\t')) : (j += 1) {}
+            while (j < bytes.len and std.ascii.isWhitespace(bytes[j])) : (j += 1) {}
             if (j < bytes.len and (bytes[j] == '{' or bytes[j] == '"')) return true;
         }
         i = idx + 1;
@@ -167,10 +199,12 @@ fn isIdentifierBoundary(c: u8) bool {
     return !(std.ascii.isAlphanumeric(c) or c == '_');
 }
 
-/// Run `zig test <path>` with inherited stdio. Returns true on a clean
-/// (exit 0) run, false otherwise.
-fn runZigTest(allocator: std.mem.Allocator, path: []const u8) !bool {
-    var child: std.process.Child = .init(&.{ "zig", "test", path }, allocator);
+/// Run `zig test <rel_path>` from `cwd` with inherited stdio. Running
+/// in `cwd` (the project root) means tests that touch relative paths
+/// see the same filesystem layout as `zig build run` would.
+fn runZigTest(allocator: std.mem.Allocator, cwd: []const u8, rel_path: []const u8) !bool {
+    var child: std.process.Child = .init(&.{ "zig", "test", rel_path }, allocator);
+    child.cwd = cwd;
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
@@ -183,38 +217,42 @@ fn runZigTest(allocator: std.mem.Allocator, path: []const u8) !bool {
 }
 
 // --- Tests ---
+//
+// The specs below are surfaced from `cli.zig` via `pub const`
+// re-exports so `zspec.runAll(@This())` in the cli.zig test root
+// discovers them. We don't add a `test { runAll(@This()) }` block
+// here to avoid double-registering the same tests.
 
 const expect = @import("zspec").expect;
 
-test {
-    @import("zspec").runAll(@This());
-}
-
-pub const ShouldSkipPathSpec = struct {
+pub const IsSkipDirSpec = struct {
     pub const skips = struct {
-        test "skips .labelle subtree" {
-            try expect.equal(shouldSkipPath(".labelle/sokol_desktop/build.zig"), true);
+        test "skips .labelle" {
+            try expect.equal(isSkipDir(".labelle"), true);
         }
-        test "skips zig-out subtree" {
-            try expect.equal(shouldSkipPath("zig-out/bin/foo.zig"), true);
+        test "skips zig-out" {
+            try expect.equal(isSkipDir("zig-out"), true);
         }
-        test "skips nested .zig-cache" {
-            try expect.equal(shouldSkipPath("subdir/.zig-cache/o/x.zig"), true);
+        test "skips .zig-cache" {
+            try expect.equal(isSkipDir(".zig-cache"), true);
         }
-        test "skips .git tree" {
-            try expect.equal(shouldSkipPath(".git/objects/x.zig"), true);
+        test "skips .git" {
+            try expect.equal(isSkipDir(".git"), true);
+        }
+        test "skips node_modules" {
+            try expect.equal(isSkipDir("node_modules"), true);
         }
     };
 
     pub const keeps = struct {
         test "keeps components" {
-            try expect.equal(shouldSkipPath("components/player.zig"), false);
+            try expect.equal(isSkipDir("components"), false);
         }
-        test "keeps scripts/playing" {
-            try expect.equal(shouldSkipPath("scripts/playing/move.zig"), false);
+        test "keeps scripts" {
+            try expect.equal(isSkipDir("scripts"), false);
         }
-        test "keeps top-level zig file" {
-            try expect.equal(shouldSkipPath("util.zig"), false);
+        test "keeps hooks" {
+            try expect.equal(isSkipDir("hooks"), false);
         }
     };
 };
@@ -247,6 +285,9 @@ pub const FileHasTestBlockSpec = struct {
                 \\test "foo works" { }
                 \\
             ), true);
+        }
+        test "newline between keyword and brace" {
+            try expect.equal(try writeAndCheck("test\n{\n    return;\n}\n"), true);
         }
     };
 

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -258,7 +258,7 @@ pub const IsSkipDirSpec = struct {
 };
 
 pub const FileHasTestBlockSpec = struct {
-    fn writeAndCheck(contents: []const u8) !bool {
+    pub fn writeAndCheck(contents: []const u8) !bool {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
         const file = try tmp.dir.createFile("x.zig", .{});


### PR DESCRIPTION
Walks the project source tree (excluding .labelle/, zig-out/,
.zig-cache/, .git/, node_modules/), finds .zig files containing inline
`test` blocks, and runs `zig test <file>` on each. Aggregates results
and exits non-zero on any failure so it can wire into CI alongside
the existing per-plugin `cd libs/<lib> && zig build test` steps.

Closes the gap reported via the issue tracker: the assembler-emitted
build.zig under .labelle/<backend>_<platform>/ has no `test` step, so
inline tests inside components/, scripts/, hooks/, etc. were silently
uncovered.

  labelle test [dir] [--verbose]