### PR TITLE
feat(cli/test): --no-libs flag to skip project-tree walk

### DIFF
--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -19,7 +19,7 @@ pub fn printHelp() void {
         \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle (pkg: core, engine, gfx, cli, assembler, all)
         \\  update [ver] [--no-path]  Update the labelle CLI itself
         \\  clean [--dry-run] [--project=dir]  Remove unused cached package versions
-        \\  test [dir] [--verbose]  Run inline `test` blocks across the project source tree
+        \\  test [dir] [--verbose] [--no-libs]  Run inline `test` blocks across the project source tree
         \\  help                 Show this help
         \\  version              Show CLI version
         \\
@@ -40,6 +40,7 @@ pub fn printHelp() void {
         \\  labelle upgrade core 0.2.0
         \\  labelle test
         \\  labelle test ../my-game --verbose
+        \\  labelle test --no-libs
         \\
     , .{gen.CLI_VERSION});
 }

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -34,7 +34,7 @@ const TestStats = struct {
     files_failed: usize = 0,
 };
 
-const usage = "  usage: labelle test [dir] [--verbose]\n";
+const usage = "  usage: labelle test [dir] [--verbose] [--no-libs]\n";
 
 /// Run in-file Zig tests across the project's source tree.
 ///
@@ -45,11 +45,18 @@ const usage = "  usage: labelle test [dir] [--verbose]\n";
 pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
     var project_dir: []const u8 = ".";
     var verbose = false;
+    var skip_libs = false;
     var dir_set = false;
 
     for (cmd_args) |arg| {
         if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
             verbose = true;
+        } else if (std.mem.eql(u8, arg, "--no-libs")) {
+            // Skip the project-tree walk entirely. Useful in CI where a
+            // separate job already runs `cd libs/<lib> && zig build test`
+            // and the comprehensive `labelle test` job only needs the
+            // game-side `.labelle/<backend>_<platform>/` step.
+            skip_libs = true;
         } else if (std.mem.startsWith(u8, arg, "--")) {
             std.debug.print("labelle test: unknown flag '{s}'\n", .{arg});
             std.debug.print(usage, .{});
@@ -79,7 +86,9 @@ pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
     };
 
     var stats = TestStats{};
-    try discoverAndRun(allocator, project_dir, &stats, verbose);
+    if (!skip_libs) {
+        try discoverAndRun(allocator, project_dir, &stats, verbose);
+    }
 
     // Game-side `tests/` are exercised through the assembler-generated
     // `.labelle/<backend>_<platform>/build.zig`'s `test` step (assembler


### PR DESCRIPTION
## Summary

Adds an opt-out flag (\`--no-libs\`) so \`labelle test\` skips the project-tree walk and only runs the assembler-generated game-side test step.

Closes #184.

## Why

The default walks \`libs/<lib>/\` and runs each lib's \`zig build test\`, then runs \`zig build test\` in \`.labelle/<backend>_<platform>/\`. That's the right one-shot for local dev.

In CI with two parallel jobs, it duplicates work:

```yaml
test-libs:   # cd libs/<lib> && zig build test  ×N   ← fast lib feedback
test-game:   # labelle generate && labelle test       ← also re-walks libs/
```

\`--no-libs\` lets \`test-game\` cover only the game-side step:

```yaml
test-game:   # labelle generate && labelle test --no-libs
```

## Behavior

- Default (no flag): unchanged. Walks \`libs/\`, then \`.labelle/<backend>_<platform>/\`.
- With \`--no-libs\`: skips the walk; only the generated test step runs.

## Verified locally on flying-platform-labelle

\`\`\`
\$ labelle test --no-libs
  build-test .labelle/sokol_desktop

labelle test: 0 file(s) scanned, 1 ran tests, 0 failed
\`\`\`

(0 scanned because the walk is skipped; 1 \"ran tests\" is the assembler-emitted step.)

## Test plan
- [x] \`zig build\` (CLI compiles)
- [x] \`zig build test\` (38/38 zspec tests pass)
- [x] Manual run against flying-platform-labelle, with and without \`--no-libs\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)