### PR TITLE
feat(cli): support assembler 0.14.0 .labelle/tests/ target dir

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -627,9 +627,26 @@ pub fn main() !void {
     // discover the correct hash. With assembler >=0.14.0 there are two
     // (`<backend>_<platform>/` and `tests/`); patching only the exe dir
     // would leave `tests/` with a placeholder fingerprint and break
-    // `labelle test`. Skip the whole pass for docker builds since the
-    // local Zig toolchain may be broken.
-    if (!parsed_args.docker) try runner.fixFingerprints(allocator, output_dir);
+    // `labelle test`.
+    //
+    // For docker builds we skip the exe target — the host Zig toolchain
+    // may not have the native libs the chosen backend needs (that's why
+    // we're routing through docker in the first place). The tests target
+    // is the exception: it uses the null backend (no native libs), so
+    // host Zig can build it even when --docker is set, and skipping
+    // would leave `labelle test` broken on the host after `labelle build
+    // --docker`. Patch `tests/` directly when present.
+    if (!parsed_args.docker) {
+        try runner.fixFingerprints(allocator, output_dir);
+    } else {
+        const tests_dir = try std.fs.path.join(allocator, &.{ output_dir, "tests" });
+        defer allocator.free(tests_dir);
+        const tests_build_zig = try std.fs.path.join(allocator, &.{ tests_dir, "build.zig" });
+        defer allocator.free(tests_build_zig);
+        if (std.fs.cwd().access(tests_build_zig, .{})) |_| {
+            try runner.fixFingerprint(allocator, tests_dir);
+        } else |_| {}
+    }
     try lockfile.writeLockFile(allocator, project_dir, parsed);
     std.debug.print("  generated .labelle/{s}/\n", .{target_name});
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -623,9 +623,13 @@ pub fn main() !void {
     const target_dir = try std.fs.path.join(allocator, &.{ output_dir, target_name });
     defer allocator.free(target_dir);
 
-    // fixFingerprint runs `zig build` locally to discover the correct hash.
-    // Skip it for docker builds since the local Zig toolchain may be broken.
-    if (!parsed_args.docker) try runner.fixFingerprint(allocator, target_dir);
+    // fixFingerprints runs `zig build` locally per emitted target dir to
+    // discover the correct hash. With assembler >=0.14.0 there are two
+    // (`<backend>_<platform>/` and `tests/`); patching only the exe dir
+    // would leave `tests/` with a placeholder fingerprint and break
+    // `labelle test`. Skip the whole pass for docker builds since the
+    // local Zig toolchain may be broken.
+    if (!parsed_args.docker) try runner.fixFingerprints(allocator, output_dir);
     try lockfile.writeLockFile(allocator, project_dir, parsed);
     std.debug.print("  generated .labelle/{s}/\n", .{target_name});
 

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -106,6 +106,30 @@ fn timeoutKillWindows(allocator: std.mem.Allocator, pid: std.os.windows.DWORD, t
     _ = kill_child.wait() catch {};
 }
 
+/// Iterate over every immediate subdir of `.labelle/` that contains a
+/// `build.zig.zon` and patch its fingerprint. The assembler emits one
+/// dir per target (e.g. `raylib_desktop/`, plus `tests/` from 0.14.0),
+/// and each generated zon ships a placeholder fingerprint that needs
+/// replacing with the value Zig computes from the dir's actual path.
+pub fn fixFingerprints(allocator: std.mem.Allocator, output_dir: []const u8) !void {
+    var dir = std.fs.cwd().openDir(output_dir, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    defer dir.close();
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        const sub_path = try std.fs.path.join(allocator, &.{ output_dir, entry.name });
+        defer allocator.free(sub_path);
+        const zon_path = try std.fs.path.join(allocator, &.{ sub_path, "build.zig.zon" });
+        defer allocator.free(zon_path);
+        std.fs.cwd().access(zon_path, .{}) catch continue;
+        try fixFingerprint(allocator, sub_path);
+    }
+}
+
 /// Run `zig build` in output_dir, parse the fingerprint error, and patch build.zig.zon.
 pub fn fixFingerprint(allocator: std.mem.Allocator, output_dir: []const u8) !void {
     const zon_path = try std.fs.path.join(allocator, &.{ output_dir, "build.zig.zon" });

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -81,18 +81,27 @@ pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
     var stats = TestStats{};
     try discoverAndRun(allocator, project_dir, &stats, verbose);
 
-    // Game-side `tests/` are exercised through the assembler-generated
-    // `.labelle/<backend>_<platform>/build.zig`'s `test` step (assembler
-    // >=0.13.0), not via bare `zig test <file>`. The generated build.zig
-    // wires the full module graph the exe sees, so test files can
-    // `@import` game modules the same way `main.zig` does.
+    // Game-side `tests/` are exercised through an assembler-generated
+    // `build.zig`'s `test` step, not via bare `zig test <file>`. The
+    // generated build.zig wires the full module graph the exe sees, so
+    // test files can `@import` game modules the same way `main.zig` does.
     //
-    // Pick the backend dir from `project.labelle` so stale generations
-    // for other backends/platforms (left over in `.labelle/` from prior
-    // runs) don't get exercised with mismatched dep snapshots.
-    const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(cfg.backend), @tagName(cfg.platform) });
-    defer allocator.free(target_name);
-    try runGeneratedTestStep(allocator, project_dir, target_name, &stats, verbose);
+    // Assembler >=0.14.0 emits a backend-agnostic `.labelle/tests/` dir
+    // dedicated to the test step; prefer it when present so we don't
+    // pull raylib (or whatever backend is active) into the test build.
+    // Older assemblers (>=0.13.0, <0.14.0) only emit the exe dir, so
+    // fall back to `.labelle/<backend>_<platform>/`. Picking the backend
+    // from `project.labelle` (rather than the first dir we find) avoids
+    // running stale generations left over from prior backend switches.
+    const tests_dir = try std.fs.path.join(allocator, &.{ project_dir, ".labelle", "tests" });
+    defer allocator.free(tests_dir);
+    if (std.fs.cwd().access(tests_dir, .{})) |_| {
+        try runGeneratedTestStep(allocator, project_dir, "tests", &stats, verbose);
+    } else |_| {
+        const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(cfg.backend), @tagName(cfg.platform) });
+        defer allocator.free(target_name);
+        try runGeneratedTestStep(allocator, project_dir, target_name, &stats, verbose);
+    }
 
     std.debug.print("\nlabelle test: {d} file(s) scanned, {d} ran tests, {d} failed\n", .{
         stats.files_run,

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -93,9 +93,14 @@ pub fn cmdTest(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void
     // fall back to `.labelle/<backend>_<platform>/`. Picking the backend
     // from `project.labelle` (rather than the first dir we find) avoids
     // running stale generations left over from prior backend switches.
-    const tests_dir = try std.fs.path.join(allocator, &.{ project_dir, ".labelle", "tests" });
-    defer allocator.free(tests_dir);
-    if (std.fs.cwd().access(tests_dir, .{})) |_| {
+    //
+    // Probe `tests/build.zig` rather than just the directory so a stale
+    // `.labelle/tests/` left behind by a prior 0.14+ generate (e.g. user
+    // downgraded their assembler pin to 0.13.x) doesn't get preferred
+    // over the still-valid backend dir.
+    const tests_build_zig = try std.fs.path.join(allocator, &.{ project_dir, ".labelle", "tests", "build.zig" });
+    defer allocator.free(tests_build_zig);
+    if (std.fs.cwd().access(tests_build_zig, .{})) |_| {
         try runGeneratedTestStep(allocator, project_dir, "tests", &stats, verbose);
     } else |_| {
         const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(cfg.backend), @tagName(cfg.platform) });


### PR DESCRIPTION
## Summary

Two CLI follow-ups for [labelle-assembler #83](https://github.com/labelle-toolkit/labelle-assembler/issues/83) (PR #84). **Draft until assembler 0.14.0 ships** — once released, projects bumping their `.assembler_version` will automatically take the new code path; older pins stay on the fallback.

- **`runner.fixFingerprints`** now iterates every `.labelle/*/build.zig.zon` instead of patching only the exe target. The assembler now emits a second target dir (`.labelle/tests/`), and patching only the exe dir would leave the test dir with a placeholder fingerprint and break `zig build test` there. Forward-compatible with any future target dirs the assembler may emit.
- **`labelle test`** prefers `.labelle/tests/` over `.labelle/<backend>_<platform>/` when present, so the test build doesn't drag the active rendering backend into the test module graph. Falls back to the exe target dir for assembler <0.14.0.

## Validation

Both code paths exercised locally on `flying-platform-labelle`:

| Scenario | Result |
|---|---|
| Assembler 0.13.0 (pinned) — fallback path | `fixFingerprints` patches `sokol_desktop/`; `labelle test` falls back to `.labelle/sokol_desktop/`; **11/11 test files pass**. |
| Assembler PR #84 (local build) — new path | Both `sokol_desktop/build.zig.zon` and `tests/build.zig.zon` get independently-patched fingerprints (distinct hashes); `labelle test` correctly picks `.labelle/tests/`. |

The PR #84 path surfaced a separate transitive `.path` dep-resolution issue (Zig 0.15 resolves `../../../../labelle-fsm` against the *consumer's* build_root rather than the declaring package's). It hits both target dirs equally and is orthogonal to this PR — flagging on assembler issue #83 separately.

## Test plan
- [ ] `zig build test` (CLI repo) green
- [ ] After assembler 0.14.0 release: bump a sample project's `assembler_version`, run `labelle generate` + `labelle test`, confirm `.labelle/tests/` is used and both fingerprints land
- [ ] Confirm fallback still works for a project pinned to assembler 0.13.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)