### PR TITLE
fix: anchor `local:` assembler path at main checkout when in a git worktree

### DIFF
--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -384,12 +384,22 @@ pub fn spawnGenerate(
 /// Otherwise return a copy of `project_dir` unchanged.
 ///
 /// Worktree detection: `<project_dir>/.git` exists as a regular file (not a
-/// directory). The file is a single-line linkfile: `gitdir: <abs>/.git/worktrees/<name>`.
-/// The main checkout is three `dirname` steps above that gitdir value
-/// (strip `<name>`, then `worktrees`, then `.git`).
+/// directory). The file is a linkfile starting with `gitdir: <path>` where
+/// `<path>` matches `<main>/.git/worktrees/<name>`. We validate this exact
+/// shape — git uses `.git` linkfiles for other layouts (submodules end in
+/// `/.git/modules/<name>`, `--separate-git-dir` can land anywhere) and
+/// stripping three dirname levels would return the wrong directory.
 ///
-/// On any error (no .git, parse failure, etc.) returns project_dir unchanged
-/// so non-git callers and the main checkout keep their existing behavior.
+/// `gitdir:` values can be either absolute or relative — git itself supports
+/// both. Relative values are resolved against the directory containing the
+/// `.git` file (i.e. project_dir).
+///
+/// Linkfiles are typically a single line but can carry additional keys like
+/// `commondir:` — only the first line is parsed.
+///
+/// On any error (no .git, parse failure, non-worktree layout, etc.) returns
+/// project_dir unchanged so non-git callers and the main checkout keep
+/// their existing behavior.
 ///
 /// Mirrors labelle-assembler/src/cache.zig:resolveProjectRoot — duplicated
 /// rather than imported to avoid coupling the CLI release cycle to a
@@ -405,19 +415,33 @@ fn resolveProjectRoot(allocator: std.mem.Allocator, project_dir: []const u8) ![]
         return allocator.dupe(u8, project_dir);
     defer allocator.free(content);
 
-    const line = std.mem.trim(u8, content, " \t\r\n");
+    const eol = std.mem.indexOfAny(u8, content, "\r\n") orelse content.len;
+    const first_line = std.mem.trim(u8, content[0..eol], " \t");
+
     const prefix = "gitdir:";
-    if (!std.mem.startsWith(u8, line, prefix)) return allocator.dupe(u8, project_dir);
+    if (!std.mem.startsWith(u8, first_line, prefix)) return allocator.dupe(u8, project_dir);
 
-    const gitdir = std.mem.trim(u8, line[prefix.len..], " \t");
-    if (gitdir.len == 0) return allocator.dupe(u8, project_dir);
+    const gitdir_raw = std.mem.trim(u8, first_line[prefix.len..], " \t");
+    if (gitdir_raw.len == 0) return allocator.dupe(u8, project_dir);
 
-    var path = gitdir;
-    var i: u8 = 0;
-    while (i < 3) : (i += 1) {
-        path = std.fs.path.dirname(path) orelse return allocator.dupe(u8, project_dir);
-    }
-    return allocator.dupe(u8, path);
+    var gitdir_owned: ?[]u8 = null;
+    defer if (gitdir_owned) |b| allocator.free(b);
+    const gitdir = if (std.fs.path.isAbsolute(gitdir_raw)) gitdir_raw else blk: {
+        const joined = try std.fs.path.join(allocator, &.{ project_dir, gitdir_raw });
+        gitdir_owned = joined;
+        break :blk joined;
+    };
+
+    const wt_dir = std.fs.path.dirname(gitdir) orelse return allocator.dupe(u8, project_dir);
+    if (!std.mem.eql(u8, std.fs.path.basename(wt_dir), "worktrees"))
+        return allocator.dupe(u8, project_dir);
+
+    const dot_git = std.fs.path.dirname(wt_dir) orelse return allocator.dupe(u8, project_dir);
+    if (!std.mem.eql(u8, std.fs.path.basename(dot_git), ".git"))
+        return allocator.dupe(u8, project_dir);
+
+    const main_checkout = std.fs.path.dirname(dot_git) orelse return allocator.dupe(u8, project_dir);
+    return std.fs.cwd().realpathAlloc(allocator, main_checkout) catch allocator.dupe(u8, main_checkout);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -505,5 +529,85 @@ pub const ResolveProjectRoot = struct {
         defer alloc.free(root);
 
         try std.testing.expectEqualStrings(wt_abs, root);
+    }
+
+    test "submodule .git linkfile returns project_dir unchanged" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("super/.git/modules/sub");
+        try tmp.dir.makePath("super/sub");
+
+        const super_abs = try tmp.dir.realpathAlloc(alloc, "super");
+        defer alloc.free(super_abs);
+        const sub_abs = try tmp.dir.realpathAlloc(alloc, "super/sub");
+        defer alloc.free(sub_abs);
+
+        const linkfile = try std.fmt.allocPrint(alloc, "gitdir: {s}/.git/modules/sub\n", .{super_abs});
+        defer alloc.free(linkfile);
+        const f = try tmp.dir.createFile("super/sub/.git", .{});
+        defer f.close();
+        try f.writeAll(linkfile);
+
+        const root = try resolveProjectRoot(alloc, sub_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(sub_abs, root);
+    }
+
+    test "relative gitdir is resolved against project_dir" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("main/.git/worktrees/wt");
+        try tmp.dir.makePath("main/wt");
+
+        const main_abs = try tmp.dir.realpathAlloc(alloc, "main");
+        defer alloc.free(main_abs);
+        const wt_abs = try tmp.dir.realpathAlloc(alloc, "main/wt");
+        defer alloc.free(wt_abs);
+
+        const f = try tmp.dir.createFile("main/wt/.git", .{});
+        defer f.close();
+        try f.writeAll("gitdir: ../.git/worktrees/wt\n");
+
+        const root = try resolveProjectRoot(alloc, wt_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(main_abs, root);
+    }
+
+    test "linkfile with extra keys (commondir) parses first line only" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("main/.git/worktrees/wt");
+        try tmp.dir.makePath("wt");
+
+        const main_abs = try tmp.dir.realpathAlloc(alloc, "main");
+        defer alloc.free(main_abs);
+        const wt_abs = try tmp.dir.realpathAlloc(alloc, "wt");
+        defer alloc.free(wt_abs);
+
+        const linkfile = try std.fmt.allocPrint(
+            alloc,
+            "gitdir: {s}/.git/worktrees/wt\ncommondir: {s}/.git\n",
+            .{ main_abs, main_abs },
+        );
+        defer alloc.free(linkfile);
+        const f = try tmp.dir.createFile("wt/.git", .{});
+        defer f.close();
+        try f.writeAll(linkfile);
+
+        const root = try resolveProjectRoot(alloc, wt_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(main_abs, root);
     }
 };

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -37,11 +37,18 @@ pub fn lookupOverride(allocator: std.mem.Allocator) !?[]u8 {
 /// Resolve `assembler_version = "local:<path>"`: build the sibling
 /// labelle-assembler checkout and return the path to its binary.
 /// `rel_path` is relative to `project_dir` (or absolute).
+///
+/// In a git worktree, `rel_path` is anchored at the main checkout instead
+/// — `local:` paths describe sibling repos that sit next to the main
+/// checkout, not next to the worktree. See resolveProjectRoot.
 fn resolveLocalAssembler(allocator: std.mem.Allocator, rel_path: []const u8, project_dir: []const u8) ![]u8 {
     const source_dir = if (std.fs.path.isAbsolute(rel_path))
         try allocator.dupe(u8, rel_path)
-    else
-        try std.fs.path.join(allocator, &.{ project_dir, rel_path });
+    else blk: {
+        const root = try resolveProjectRoot(allocator, project_dir);
+        defer allocator.free(root);
+        break :blk try std.fs.path.join(allocator, &.{ root, rel_path });
+    };
     defer allocator.free(source_dir);
 
     const real_source = std.fs.cwd().realpathAlloc(allocator, source_dir) catch |err| {
@@ -372,3 +379,131 @@ pub fn spawnGenerate(
         },
     }
 }
+
+/// If `project_dir` is a git worktree, return the path of the main checkout.
+/// Otherwise return a copy of `project_dir` unchanged.
+///
+/// Worktree detection: `<project_dir>/.git` exists as a regular file (not a
+/// directory). The file is a single-line linkfile: `gitdir: <abs>/.git/worktrees/<name>`.
+/// The main checkout is three `dirname` steps above that gitdir value
+/// (strip `<name>`, then `worktrees`, then `.git`).
+///
+/// On any error (no .git, parse failure, etc.) returns project_dir unchanged
+/// so non-git callers and the main checkout keep their existing behavior.
+///
+/// Mirrors labelle-assembler/src/cache.zig:resolveProjectRoot — duplicated
+/// rather than imported to avoid coupling the CLI release cycle to a
+/// specific labelle_assembler version bump.
+fn resolveProjectRoot(allocator: std.mem.Allocator, project_dir: []const u8) ![]u8 {
+    const git_path = try std.fs.path.join(allocator, &.{ project_dir, ".git" });
+    defer allocator.free(git_path);
+
+    const stat = std.fs.cwd().statFile(git_path) catch return allocator.dupe(u8, project_dir);
+    if (stat.kind != .file) return allocator.dupe(u8, project_dir);
+
+    const content = std.fs.cwd().readFileAlloc(allocator, git_path, 4096) catch
+        return allocator.dupe(u8, project_dir);
+    defer allocator.free(content);
+
+    const line = std.mem.trim(u8, content, " \t\r\n");
+    const prefix = "gitdir:";
+    if (!std.mem.startsWith(u8, line, prefix)) return allocator.dupe(u8, project_dir);
+
+    const gitdir = std.mem.trim(u8, line[prefix.len..], " \t");
+    if (gitdir.len == 0) return allocator.dupe(u8, project_dir);
+
+    var path = gitdir;
+    var i: u8 = 0;
+    while (i < 3) : (i += 1) {
+        path = std.fs.path.dirname(path) orelse return allocator.dupe(u8, project_dir);
+    }
+    return allocator.dupe(u8, path);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+const zspec = @import("zspec");
+
+test {
+    zspec.runAll(@This());
+}
+
+pub const ResolveProjectRoot = struct {
+    test "main checkout (.git is a directory) returns project_dir unchanged" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("project/.git");
+        const project_abs = try tmp.dir.realpathAlloc(alloc, "project");
+        defer alloc.free(project_abs);
+
+        const root = try resolveProjectRoot(alloc, project_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(project_abs, root);
+    }
+
+    test "worktree linkfile resolves to main checkout" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("main/.git/worktrees/wt");
+        try tmp.dir.makePath("wt");
+
+        const main_abs = try tmp.dir.realpathAlloc(alloc, "main");
+        defer alloc.free(main_abs);
+        const wt_abs = try tmp.dir.realpathAlloc(alloc, "wt");
+        defer alloc.free(wt_abs);
+
+        const linkfile = try std.fmt.allocPrint(alloc, "gitdir: {s}/.git/worktrees/wt\n", .{main_abs});
+        defer alloc.free(linkfile);
+        const f = try tmp.dir.createFile("wt/.git", .{});
+        defer f.close();
+        try f.writeAll(linkfile);
+
+        const root = try resolveProjectRoot(alloc, wt_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(main_abs, root);
+    }
+
+    test "not a git repo returns project_dir unchanged" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("plain");
+        const plain_abs = try tmp.dir.realpathAlloc(alloc, "plain");
+        defer alloc.free(plain_abs);
+
+        const root = try resolveProjectRoot(alloc, plain_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(plain_abs, root);
+    }
+
+    test "malformed linkfile returns project_dir unchanged" {
+        const alloc = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        try tmp.dir.makePath("wt");
+        const wt_abs = try tmp.dir.realpathAlloc(alloc, "wt");
+        defer alloc.free(wt_abs);
+
+        const f = try tmp.dir.createFile("wt/.git", .{});
+        defer f.close();
+        try f.writeAll("not a gitdir line\n");
+
+        const root = try resolveProjectRoot(alloc, wt_abs);
+        defer alloc.free(root);
+
+        try std.testing.expectEqualStrings(wt_abs, root);
+    }
+};


### PR DESCRIPTION
## Summary

Sibling fix to [labelle-toolkit/labelle-assembler#88](https://github.com/labelle-toolkit/labelle-assembler/pull/88) — same root cause (`local:` paths resolved against the worktree dir instead of the main checkout) at a different surface.

`resolveLocalAssembler` in `cli/assembler.zig:40` joins `project_dir + rel_path` then realpaths the result. In a git worktree, `project_dir` is the worktree's path. A pin like `assembler_version = "local:../labelle-assembler"` then climbs out of `<main>/.claude/worktrees/<name>/` into a non-existent sibling and fails with `local assembler path '...' does not exist`.

## Fix

New `resolveProjectRoot(project_dir)` detects worktrees via the `.git` linkfile (regular file containing `gitdir: <main>/.git/worktrees/<name>`), strips three `dirname` levels to recover the main checkout, and returns it. `resolveLocalAssembler` anchors `local:` resolution there. Falls back to `project_dir` unchanged on any error so non-git callers and the main checkout keep their existing behavior.

`resolveProjectRoot` is **duplicated** rather than imported from `labelle_assembler` to avoid coupling the CLI release cycle to a specific assembler version bump. The function is small (~25 lines) and self-contained.

## Scope of impact

This bug only triggers when someone sets `assembler_version = "local:..."` in `project.labelle` AND runs from a git worktree. It does not block the main `flying-platform-labelle` worktree issue — that's fixed by the assembler PR alone. This is defense-in-depth for projects that pin a sibling assembler checkout for dev workflows.

I scanned the rest of the CLI: every other `project_dir` use joins with files **inside** the project tree (`project.labelle`, `labelle.lock`, asset paths, etc.) where worktree vs. main checkout doesn't matter — those files exist in both. The local-assembler resolver is the only place CLI walks *out* of the project, which is what triggers the overshoot.

## Tests

- 43/43 passing (was 21, +22 with the new in-source test block now reaching zspec discovery and 4 new `ResolveProjectRoot` cases).
- New unit coverage: main checkout (.git as dir), worktree linkfile, non-git, malformed linkfile.
- End-to-end: with this CLI built locally and `assembler_version = "local:../labelle-assembler"` in a worktree of `flying-platform-labelle`, `labelle build` correctly climbs to the main checkout, finds the sibling assembler, builds and runs it. Pre-fix, the same setup fails with `local assembler path does not exist`.

## Test plan

- [ ] CI test run passes (43 tests)
- [ ] Reviewer can reproduce pre-fix in a worktree by setting `assembler_version = "local:../<sibling>"`
- [ ] Reviewer can verify with the patched binary built from this branch

## Cross-ref

- labelle-toolkit/labelle-assembler#87 (root issue)
- labelle-toolkit/labelle-assembler#88 (sibling PR; lands the same fix in the assembler for `local:` plugin paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)