### PR TITLE
chore: bump zspec 0.7.0 → 0.8.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,8 +20,8 @@
             .hash = "labelle_assembler-0.8.0-pG4XEOZJBACiCUdlxNpfp_v7gB1ZbTobMOd587m3cwKt",
         },
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.7.0.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

Picks up [apotema/zspec#41](https://github.com/apotema/zspec/pull/41) — \`expect.equal\` / \`expect.notEqual\` now handle slices and error unions via smart-dispatch — plus the new \`expect.toReturnError\` matcher.

This PR **only** bumps the dep. Call-site migration (replacing the \`std.testing.expectEqualStrings\` / \`std.testing.expectError\` workarounds in \`src/cli/test.zig\`'s \`ParseTestArgsSpec\`) is intentionally left for a follow-up after #189 lands so the diffs stay isolated and easy to read.

## Tests

- 46/46 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)