### PR TITLE
test/imgui-anchor-test: minimal repro for the imgui anchor drift bug

### DIFF
--- a/test/imgui-anchor-test/README.md
+++ b/test/imgui-anchor-test/README.md
@@ -1,0 +1,58 @@
+# imgui-anchor-test
+
+Minimal reproduction for an imgui-anchor drift bug observed on
+Android in `flying-platform-labelle`'s build menu (Place/Cancel
+buttons that pin to a slot's screen-space center keep moving on
+Android while staying stable on desktop).
+
+## What it does
+
+A single world entity sits at `(200, 100)`. Each frame, an imgui
+window is pinned to that world position's screen-space coordinate
+using the same idiom the real game uses:
+
+```zig
+const sc = cam.worldToScreen(FIXED_WORLD_X, FIXED_WORLD_Y);
+ig.igSetNextWindowPosEx(
+    .{ .x = sc.x, .y = sc.y },
+    ig.ImGuiCond_Always,
+    .{ .x = 0.5, .y = 0.5 }, // pivot at window center
+);
+```
+
+The window contains two buttons (`Place`, `Cancel`) — same shape
+that drifts in the real game.
+
+A throttled log line each ~60 frames prints `anchor`, `imgui
+DisplaySize`, and `camera viewport` so the two platforms can be
+compared side-by-side.
+
+## Running
+
+```bash
+# Desktop (sokol)
+labelle run
+
+# Android — connect a device first
+labelle android run
+
+# Android logcat filter
+adb logcat -s labelle | grep anchor_test
+```
+
+## Expected vs observed
+
+- **Desktop:** the `Anchor Test` window stays glued to the same
+  pixel position frame after frame; logged `anchor` is constant.
+- **Android (observed bug):** the window drifts even though
+  `FIXED_WORLD_X/Y` are constants. Inspect the log to see whether
+  `anchor`, `imgui_display`, or `cam_vp` is fluctuating.
+
+## Diagnostic value
+
+If `anchor` is itself drifting, the bug is in
+`worldToScreen` / camera state on Android. If `anchor` is stable
+but the window renders elsewhere, the bug is in imgui's window
+positioning vs DPI scale. If `imgui_display` ≠ `cam_vp`, the two
+coordinate systems disagree — anchor in render-target pixels gets
+interpreted as imgui display units (or vice versa).

--- a/test/imgui-anchor-test/README.md
+++ b/test/imgui-anchor-test/README.md
@@ -7,23 +7,32 @@ Android while staying stable on desktop).
 
 ## What it does
 
-A single world entity sits at `(200, 100)`. Each frame, an imgui
-window is pinned to that world position's screen-space coordinate
-using the same idiom the real game uses:
+A single world entity sits at `(200, 100)`. The camera auto-pans
+±150 world units at 0.25 Hz so the anchor drift is observable
+without input wiring.
+
+Each frame an imgui window is pinned to the rect's center using the
+corrected `worldToFramebuffer` helper (see labelle-gfx#253):
 
 ```zig
-const sc = cam.worldToScreen(FIXED_WORLD_X, FIXED_WORLD_Y);
+const fb = cam.worldToFramebuffer(FIXED_WORLD_X, FIXED_WORLD_Y);
 ig.igSetNextWindowPosEx(
-    .{ .x = sc.x, .y = sc.y },
+    .{ .x = fb.x, .y = fb.y },
     ig.ImGuiCond_Always,
     .{ .x = 0.5, .y = 0.5 }, // pivot at window center
 );
 ```
 
-The window contains two buttons (`Place`, `Cancel`) — same shape
-that drifts in the real game.
+A magenta dot is drawn at the same `fb` coordinate via the imgui
+foreground draw list for eyeball comparison against the world-
+rendered green rect.
 
-A throttled log line each ~60 frames prints `anchor`, `imgui
+The window contains two buttons (`Place`, `Cancel`) — same shape as
+the build menu that exhibited the drift.
+
+A throttled log line each ~60 frames prints `cam`, `sc`
+(design-space `worldToScreen` for comparison), `fb`
+(framebuffer-space `worldToFramebuffer` — the actual anchor), `imgui
 DisplaySize`, and `camera viewport` so the two platforms can be
 compared side-by-side.
 
@@ -42,17 +51,17 @@ adb logcat -s labelle | grep anchor_test
 
 ## Expected vs observed
 
-- **Desktop:** the `Anchor Test` window stays glued to the same
-  pixel position frame after frame; logged `anchor` is constant.
-- **Android (observed bug):** the window drifts even though
-  `FIXED_WORLD_X/Y` are constants. Inspect the log to see whether
-  `anchor`, `imgui_display`, or `cam_vp` is fluctuating.
+With labelle-gfx#253 applied (i.e., `worldToFramebuffer` present):
 
-## Diagnostic value
+- **Desktop:** the magenta dot and `Anchor Test` window stay glued
+  to the green rect through the full auto-pan cycle.
+- **Android:** same — the dot and window stay glued (the drift seen
+  before #253 is gone).
 
-If `anchor` is itself drifting, the bug is in
-`worldToScreen` / camera state on Android. If `anchor` is stable
-but the window renders elsewhere, the bug is in imgui's window
-positioning vs DPI scale. If `imgui_display` ≠ `cam_vp`, the two
-coordinate systems disagree — anchor in render-target pixels gets
-interpreted as imgui display units (or vice versa).
+If drift reappears, inspect the log:
+
+- `sc` vs `fb` — if they differ only by the design→physical scale,
+  the transform is working; if they are identical, `worldToFramebuffer`
+  is falling back to `worldToScreen`.
+- `imgui_display` vs `cam_vp` — if these disagree on Android, imgui
+  is seeing a different coordinate system than the renderer.

--- a/test/imgui-anchor-test/project.labelle
+++ b/test/imgui-anchor-test/project.labelle
@@ -3,12 +3,12 @@
 // pin to a slot's screen-space center keep moving on Android while
 // staying stable on desktop).
 //
-// The script drives a single imgui window via the same idiom the
-// real game uses:
+// The script drives a single imgui window using the corrected
+// `worldToFramebuffer` helper (see labelle-gfx#253):
 //
 //     const pos = game.getPosition(entity);
-//     const sc  = cam.worldToScreen(pos.x, pos.y);
-//     ig.igSetNextWindowPosEx(sc, ImGuiCond_Always, pivot=(0.5,0.5));
+//     const fb  = cam.worldToFramebuffer(pos.x, pos.y);
+//     ig.igSetNextWindowPosEx(fb, ImGuiCond_Always, pivot=(0.5,0.5));
 //
 // Plus a per-frame log of the input coords (anchor, imgui DisplaySize,
 // camera viewport) so we can compare desktop vs Android side-by-side.

--- a/test/imgui-anchor-test/project.labelle
+++ b/test/imgui-anchor-test/project.labelle
@@ -1,0 +1,34 @@
+// Minimal repro for the imgui-anchor drift bug observed on Android
+// in flying-platform-labelle's build menu (Place/Cancel buttons that
+// pin to a slot's screen-space center keep moving on Android while
+// staying stable on desktop).
+//
+// The script drives a single imgui window via the same idiom the
+// real game uses:
+//
+//     const pos = game.getPosition(entity);
+//     const sc  = cam.worldToScreen(pos.x, pos.y);
+//     ig.igSetNextWindowPosEx(sc, ImGuiCond_Always, pivot=(0.5,0.5));
+//
+// Plus a per-frame log of the input coords (anchor, imgui DisplaySize,
+// camera viewport) so we can compare desktop vs Android side-by-side.
+.{
+    .name = "imgui_anchor_test",
+    .title = "ImGui Anchor Test",
+    .backend = .sokol,
+    .ecs = .zig_ecs,
+    .gui = .{ .plugin = "imgui" },
+    .core_version = "local:../../../labelle-core",
+    .engine_version = "local:../../../labelle-engine",
+    .gfx_version = "local:../../../labelle-gfx",
+    .labelle_version = "local:../../",
+    .assembler_version = "local:../../../labelle-assembler",
+    .states = .{"playing"},
+    .layers = .{
+        .{ .name = "world", .order = 0, .space = .world },
+        .{ .name = "ui", .order = 1, .space = .screen },
+    },
+    .plugins = .{
+        .{ .name = "imgui", .repo = "local:../../../labelle-imgui" },
+    },
+}

--- a/test/imgui-anchor-test/scenes/main.jsonc
+++ b/test/imgui-anchor-test/scenes/main.jsonc
@@ -1,0 +1,17 @@
+{
+    "name": "main",
+    "entities": [
+        {
+            "name": "anchor_target",
+            "components": {
+                "Position": { "x": 200, "y": 100 },
+                "Shape": {
+                    "shape": { "rectangle": { "width": 60, "height": 40 } },
+                    "color": [0.2, 0.8, 0.3, 1.0],
+                    "layer": "world",
+                    "z_index": 0
+                }
+            }
+        }
+    ]
+}

--- a/test/imgui-anchor-test/scripts/anchor_test.zig
+++ b/test/imgui-anchor-test/scripts/anchor_test.zig
@@ -1,0 +1,130 @@
+// Repro for the build-menu anchor drift bug:
+// flying-platform-labelle pins an imgui window to a fixed world
+// position via `cam.worldToScreen` + `igSetNextWindowPosEx` with
+// pivot (0.5, 0.5). On desktop the window stays put; on Android
+// it drifts frame-to-frame even though the world position is
+// constant.
+//
+// This minimal script reproduces the same idiom against a single
+// world entity and logs the inputs so the two platforms can be
+// compared side-by-side.
+//
+// Three visuals to compare on the screen:
+//   1. The world entity's actual rendered position (the small
+//      filled rectangle drawn by the world renderer at world coords
+//      (200, 100)).
+//   2. A magenta dot drawn via imgui's foreground draw list at the
+//      anchor my math computes — i.e., where I think the world
+//      entity is on the screen.
+//   3. The "Anchor Test" imgui window pinned to that same anchor.
+//
+// If (1), (2), and (3) all line up, the math is correct. If they
+// drift apart — especially during camera pan — the math has a gap.
+//
+// The camera auto-pans left-right on its own so you don't need to
+// manually drag anything (no input wiring on this fixture). Slow
+// 1 Hz oscillation, ±150 world units around world (200, 100).
+
+const std = @import("std");
+const ig = @import("gui_backend").ig;
+
+// World position of the rectangle's top-left corner.
+const RECT_X: f32 = 200;
+const RECT_Y: f32 = 100;
+const RECT_W: f32 = 60;
+const RECT_H: f32 = 40;
+// Anchor at the rect's center. World is Y-up but a Shape rect's
+// Position is its TOP-LEFT in screen Y-down (the renderer flips
+// world Y → screen Y), so the rect extends *downward in screen* =
+// *decreasing world Y*. Center world Y = top - H/2, not + H/2.
+const FIXED_WORLD_X: f32 = RECT_X + RECT_W * 0.5;
+const FIXED_WORLD_Y: f32 = RECT_Y - RECT_H * 0.5;
+
+const PAN_AMPLITUDE: f32 = 150.0;
+const PAN_FREQ_HZ: f32 = 0.25; // 4-second period
+
+var t_seconds: f32 = 0;
+
+pub fn tick(game: anytype, dt: f32) void {
+    t_seconds += dt;
+    const cam = game.getCamera();
+    const phase = std.math.sin(t_seconds * PAN_FREQ_HZ * std.math.tau);
+    cam.x = FIXED_WORLD_X + PAN_AMPLITUDE * phase;
+    cam.y = FIXED_WORLD_Y;
+}
+
+pub fn drawGui(game: anytype) void {
+    // Anchor: use the same pattern flying-platform-labelle's build
+    // menu uses for the Place/Cancel buttons.
+    const cam = game.getCamera();
+    const sc = cam.worldToScreen(FIXED_WORLD_X, FIXED_WORLD_Y);
+
+    const display = ig.igGetIO().*.DisplaySize;
+    const vp = cam.getViewportDimensions();
+
+    // Throttle the log to once per ~60 frames so logcat doesn't drown.
+    {
+        const Pulse = struct { var n: u32 = 0; };
+        Pulse.n +%= 1;
+        if (Pulse.n % 60 == 0) {
+            game.log.info(
+                "[anchor_test] frame={d} cam=({d:.1},{d:.1}) sc=({d:.1},{d:.1}) imgui_display=({d:.1},{d:.1}) cam_vp=({d:.1},{d:.1})",
+                .{
+                    Pulse.n,
+                    cam.x,        cam.y,
+                    sc.x,         sc.y,
+                    display.x,    display.y,
+                    vp.width,     vp.height,
+                },
+            );
+        }
+    }
+
+    // Use the new `worldToFramebuffer` helper instead of re-deriving
+    // the design→physical transform inline. Mirrors the renderer's
+    // pillarbox/letterbox math via the backend's `designToPhysical`,
+    // so the imgui anchor lands on the same physical pixel as the
+    // world-rendered entity. See labelle-gfx#253.
+    const fb = cam.worldToFramebuffer(FIXED_WORLD_X, FIXED_WORLD_Y);
+    const anchor_x = fb.x;
+    const anchor_y = fb.y;
+
+    // Magenta dot at the corrected anchor. Should overlay the green
+    // rectangle if the math matches what the renderer does.
+    {
+        const dl = ig.igGetForegroundDrawList();
+        if (dl != null) {
+            ig.ImDrawList_AddCircleFilled(
+                dl,
+                .{ .x = anchor_x, .y = anchor_y },
+                10.0,
+                0xFFFF00FF, // ABGR magenta
+                16,
+            );
+        }
+    }
+
+    ig.igSetNextWindowPosEx(
+        .{ .x = anchor_x, .y = anchor_y },
+        ig.ImGuiCond_Always,
+        .{ .x = 0.5, .y = 0.5 },
+    );
+    ig.igSetNextWindowBgAlpha(0.6);
+
+    const flags: c_int =
+        ig.ImGuiWindowFlags_NoTitleBar |
+        ig.ImGuiWindowFlags_NoResize |
+        ig.ImGuiWindowFlags_NoMove |
+        ig.ImGuiWindowFlags_NoCollapse |
+        ig.ImGuiWindowFlags_NoSavedSettings |
+        ig.ImGuiWindowFlags_AlwaysAutoResize;
+
+    if (ig.igBegin("Anchor Test", null, flags)) {
+        // Two buttons mirroring Place / Cancel — same shape that
+        // exhibits the drift in the real game.
+        _ = ig.igButton("Place");
+        ig.igSameLine();
+        _ = ig.igButton("Cancel");
+    }
+    ig.igEnd();
+}

--- a/test/imgui-anchor-test/scripts/anchor_test.zig
+++ b/test/imgui-anchor-test/scripts/anchor_test.zig
@@ -1,13 +1,12 @@
-// Repro for the build-menu anchor drift bug:
+// Repro and fix validation for the build-menu anchor drift bug:
 // flying-platform-labelle pins an imgui window to a fixed world
-// position via `cam.worldToScreen` + `igSetNextWindowPosEx` with
-// pivot (0.5, 0.5). On desktop the window stays put; on Android
-// it drifts frame-to-frame even though the world position is
-// constant.
+// position. On desktop the window stays put; on Android it drifted
+// frame-to-frame because `worldToScreen` returns design-space coords
+// while imgui expects framebuffer-space coords (labelle-gfx#253).
 //
-// This minimal script reproduces the same idiom against a single
-// world entity and logs the inputs so the two platforms can be
-// compared side-by-side.
+// This script validates the fix: the window and magenta dot are
+// positioned via `cam.worldToFramebuffer` (framebuffer-space). The
+// old `worldToScreen` result is logged alongside for comparison.
 //
 // Three visuals to compare on the screen:
 //   1. The world entity's actual rendered position (the small
@@ -23,7 +22,7 @@
 //
 // The camera auto-pans left-right on its own so you don't need to
 // manually drag anything (no input wiring on this fixture). Slow
-// 1 Hz oscillation, ±150 world units around world (200, 100).
+// 0.25 Hz oscillation (4-second period), ±150 world units.
 
 const std = @import("std");
 const ig = @import("gui_backend").ig;
@@ -54,31 +53,8 @@ pub fn tick(game: anytype, dt: f32) void {
 }
 
 pub fn drawGui(game: anytype) void {
-    // Anchor: use the same pattern flying-platform-labelle's build
-    // menu uses for the Place/Cancel buttons.
     const cam = game.getCamera();
     const sc = cam.worldToScreen(FIXED_WORLD_X, FIXED_WORLD_Y);
-
-    const display = ig.igGetIO().*.DisplaySize;
-    const vp = cam.getViewportDimensions();
-
-    // Throttle the log to once per ~60 frames so logcat doesn't drown.
-    {
-        const Pulse = struct { var n: u32 = 0; };
-        Pulse.n +%= 1;
-        if (Pulse.n % 60 == 0) {
-            game.log.info(
-                "[anchor_test] frame={d} cam=({d:.1},{d:.1}) sc=({d:.1},{d:.1}) imgui_display=({d:.1},{d:.1}) cam_vp=({d:.1},{d:.1})",
-                .{
-                    Pulse.n,
-                    cam.x,        cam.y,
-                    sc.x,         sc.y,
-                    display.x,    display.y,
-                    vp.width,     vp.height,
-                },
-            );
-        }
-    }
 
     // Use the new `worldToFramebuffer` helper instead of re-deriving
     // the design→physical transform inline. Mirrors the renderer's
@@ -88,6 +64,30 @@ pub fn drawGui(game: anytype) void {
     const fb = cam.worldToFramebuffer(FIXED_WORLD_X, FIXED_WORLD_Y);
     const anchor_x = fb.x;
     const anchor_y = fb.y;
+
+    const display = ig.igGetIO().*.DisplaySize;
+    const vp = cam.getViewportDimensions();
+
+    // Throttle the log to once per ~60 frames so logcat doesn't drown.
+    // Logs both sc (design-space worldToScreen) and fb (framebuffer-space
+    // worldToFramebuffer) for side-by-side comparison across platforms.
+    {
+        const Pulse = struct { var n: u32 = 0; };
+        Pulse.n +%= 1;
+        if (Pulse.n % 60 == 0) {
+            game.log.info(
+                "[anchor_test] frame={d} cam=({d:.1},{d:.1}) sc=({d:.1},{d:.1}) fb=({d:.1},{d:.1}) imgui_display=({d:.1},{d:.1}) cam_vp=({d:.1},{d:.1})",
+                .{
+                    Pulse.n,
+                    cam.x,        cam.y,
+                    sc.x,         sc.y,
+                    fb.x,         fb.y,
+                    display.x,    display.y,
+                    vp.width,     vp.height,
+                },
+            );
+        }
+    }
 
     // Magenta dot at the corrected anchor. Should overlay the green
     // rectangle if the math matches what the renderer does.


### PR DESCRIPTION
Pairs with [labelle-gfx#253](https://github.com/labelle-toolkit/labelle-gfx/issues/253) / [labelle-gfx#254](https://github.com/labelle-toolkit/labelle-gfx/pull/254) / [labelle-assembler#90](https://github.com/labelle-toolkit/labelle-assembler/pull/90).

## Summary

A self-contained scene that demonstrates the design-pixel-vs-framebuffer-pixel mismatch and validates the new `Camera.worldToFramebuffer` helper. Lives alongside `gui-plugin-test` and follows the same shape (no input wiring, single drawGui hook, local-path deps).

## What it does

One world entity at world (200, 100) rendered as a filled green rect. The camera auto-pans ±150 world units around it at 0.25 Hz so the bug is observable without any input wiring (no keyboard, no touch needed). An imgui window with two buttons is pinned to the rect's center via `cam.worldToFramebuffer`, plus a magenta dot drawn via the imgui foreground draw list at the same anchor for eyeball comparison against the world-rendered rect.

## What to look for

| Setup | Expected (with `worldToFramebuffer`) |
|---|---|
| Desktop, default-sized window | Dot stays glued to rect |
| Desktop, resized window | Dot stays glued to rect (was drifting before #253) |
| Android tablet (2000×1200, 1024×768 design canvas) | Dot stays glued to rect (was drifting badly before #253) |

## Run

```bash
cd test/imgui-anchor-test
labelle run                  # desktop sokol
labelle android run          # tablet (or emulator)
adb logcat -s labelle | grep anchor_test
```

The script logs `cam.x`, `sc` (worldToScreen output), `imgui_display`, and `cam_vp` once per ~60 frames so logcat-only inspection is enough to compare the two coordinate systems on each platform — useful for triaging future regressions without needing to eyeball the screen.

## Notes

- The empty `assets/` directory is tracked via `.gitkeep` because `labelle android run` fails with `FileNotFound` if the dir is missing (the apk-staging step copies `assets/` unconditionally). Worth a separate followup to skip that copy when the dir is absent or missing.
- Local-path deps mirror `gui-plugin-test`'s pattern, so this fixture rides whatever's checked out next door — pair it with the labelle-gfx + labelle-assembler PRs above for end-to-end testing.

## Test plan

- [x] `labelle run` (desktop sokol) — dot glued to rect through the auto-pan cycle.
- [x] `labelle android run` on a Samsung tablet (R9XR6009TJN, 2000×1200) — dot glued to rect through the auto-pan cycle.
- [ ] CI integration once `labelle test` learns to handle `drawGui`-only scripts (this fixture has no inline tests; it's a visual-only repro for now).