### PR TITLE
fix: stop persisting backend.platform in labelle.lock

### DIFF
--- a/src/cli/lockfile.zig
+++ b/src/cli/lockfile.zig
@@ -20,12 +20,14 @@ pub fn writeLockFile(allocator: std.mem.Allocator, project_dir: []const u8, cfg:
     try w.print("        .engine = .{{ .version = \"{s}\" }},\n", .{cfg.engine_version});
     try w.print("        .gfx = .{{ .version = \"{s}\" }},\n", .{cfg.gfx_version});
     try w.print("        .labelle = .{{ .version = \"{s}\" }},\n", .{cfg.labelle_version});
-    // NOTE: `platform` is intentionally not persisted. It's a build target picked
-    // from CLI args (e.g. `labelle android run`), not a resolved dependency. Writing
-    // it here caused the lock file to flap between "desktop" and "android" on every
-    // cross-deploy. The lock file is a manifest of resolved versions, not invocation
-    // state.
-    try w.print("        .backend = .{{ .name = \"{s}\" }},\n", .{@tagName(cfg.backend)});
+    // NOTE: `backend` (both `name` and `platform`) is intentionally not persisted.
+    // Both fields are invocation state, not resolved dependencies:
+    //   - `platform` is the build target from CLI args (e.g. `labelle android run`).
+    //   - `name` is forced by the same CLI commands — `ios`/`android` pin `.sokol`
+    //     while a desktop run uses whatever the project config picks (could be
+    //     `.raylib`).
+    // Writing either caused the lock file to flap on every cross-deploy. The lock
+    // file is a manifest of resolved package versions, not build-target state.
 
     if (cfg.ecs != .mock) {
         try w.print("        .ecs = .{{ .name = \"{s}\" }},\n", .{@tagName(cfg.ecs)});

--- a/src/cli/lockfile.zig
+++ b/src/cli/lockfile.zig
@@ -20,7 +20,12 @@ pub fn writeLockFile(allocator: std.mem.Allocator, project_dir: []const u8, cfg:
     try w.print("        .engine = .{{ .version = \"{s}\" }},\n", .{cfg.engine_version});
     try w.print("        .gfx = .{{ .version = \"{s}\" }},\n", .{cfg.gfx_version});
     try w.print("        .labelle = .{{ .version = \"{s}\" }},\n", .{cfg.labelle_version});
-    try w.print("        .backend = .{{ .name = \"{s}\", .platform = \"{s}\" }},\n", .{ @tagName(cfg.backend), @tagName(cfg.platform) });
+    // NOTE: `platform` is intentionally not persisted. It's a build target picked
+    // from CLI args (e.g. `labelle android run`), not a resolved dependency. Writing
+    // it here caused the lock file to flap between "desktop" and "android" on every
+    // cross-deploy. The lock file is a manifest of resolved versions, not invocation
+    // state.
+    try w.print("        .backend = .{{ .name = \"{s}\" }},\n", .{@tagName(cfg.backend)});
 
     if (cfg.ecs != .mock) {
         try w.print("        .ecs = .{{ .name = \"{s}\" }},\n", .{@tagName(cfg.ecs)});


### PR DESCRIPTION
## Summary

\`labelle android run\` rewrote \`labelle.lock\` to set \`.backend.platform = \"android\"\`, and a subsequent desktop \`labelle run\` rewrote it back to \`\"desktop\"\`. The lock file flapped on every cross-deploy — every Android test run in [Flying-Platform/flying-platform-labelle](https://github.com/Flying-Platform/flying-platform-labelle) required a manual revert before commit.

Platform is a build target picked from CLI args (e.g. \`labelle android run\`), not a resolved dependency. It doesn't belong in the lock manifest.

## Fix

Drop the \`.platform\` field from the line \`writeLockFile\` emits. \`backend.name\` (e.g. \`\"sokol\"\`, \`\"raylib\"\`) stays as the stable resolved value.

The lock file is only written, never parsed back by the CLI, so the change is safe — old lock files with \`.platform = \"…\"\` are simply overwritten on the next \`generate\`/\`build\`/\`run\`. No parser-compat shim needed.

## Files changed
- \`src/cli/lockfile.zig\` — drop \`.platform\` from the written \`backend = .{ … }\` entry; comment captures the rationale.

## Test plan
- [x] \`zig build test\` passes
- [x] \`zig build\` clean
- [ ] Cross-deploy a project (\`labelle run\` → \`labelle android run\` → \`labelle run\`) and confirm \`labelle.lock\` no longer changes