### PR TITLE
Preview mode: forward `--` args from `labelle run` to `zig build run --`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -339,6 +339,14 @@ fn appendExtraArg(parsed_args: *ParsedArgs, arg: []const u8) ParseError!void {
     parsed_args.extra_count += 1;
 }
 
+fn appendRunForwardedArgs(argv: *std.ArrayList([]const u8), allocator: std.mem.Allocator, parsed_args: *const ParsedArgs) !void {
+    if (parsed_args.extra_count == 0) return;
+    try argv.append(allocator, "--");
+    for (parsed_args.extra_args[0..parsed_args.extra_count]) |extra| {
+        try argv.append(allocator, extra);
+    }
+}
+
 /// Handle `labelle assembler <subcommand>`.
 fn handleAssemblerCmd(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
     if (cmd_args.len == 0 or std.mem.eql(u8, cmd_args[0], "list")) {
@@ -763,22 +771,17 @@ pub fn main() !void {
             }
             const bin_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "bin", "game" });
             defer allocator.free(bin_path);
-            const run_result = try runner.runZigInherit(allocator, project_dir, &.{bin_path}, timeout_ns);
+            var run_args: std.ArrayList([]const u8) = .{};
+            defer run_args.deinit(allocator);
+            try run_args.append(allocator, bin_path);
+            try appendRunForwardedArgs(&run_args, allocator, &parsed_args);
+            const run_result = try runner.runZigInherit(allocator, project_dir, run_args.items, timeout_ns);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }
         } else {
             try zig_args.append(allocator, "run");
-            // Forward `--`-separated trailing args from `labelle run` to the
-            // game via `zig build run -- <extras>`. Only emit the `--`
-            // separator when there's at least one extra; a dangling `--`
-            // would be harmless but ugly.
-            if (parsed_args.extra_count > 0) {
-                try zig_args.append(allocator, "--");
-                for (parsed_args.extra_args[0..parsed_args.extra_count]) |extra| {
-                    try zig_args.append(allocator, extra);
-                }
-            }
+            try appendRunForwardedArgs(&zig_args, allocator, &parsed_args);
             const run_result = try runner.runZigInherit(allocator, target_dir, zig_args.items, timeout_ns);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
@@ -1004,4 +1007,29 @@ pub const ParseRunArgsPassthroughSpec = struct {
             try std.testing.expectEqualStrings("somedir", pa.extra_args[0]);
         }
     };
+};
+
+pub const AppendRunForwardedArgsSpec = struct {
+    test "skips separator when there are no forwarded args" {
+        var argv: std.ArrayList([]const u8) = .{};
+        defer argv.deinit(std.testing.allocator);
+        var pa = ParsedArgs{ .command = .run };
+
+        try appendRunForwardedArgs(&argv, std.testing.allocator, &pa);
+        try expect.equal(argv.items.len, @as(usize, 0));
+    }
+
+    test "appends separator and all forwarded args in order" {
+        var argv: std.ArrayList([]const u8) = .{};
+        defer argv.deinit(std.testing.allocator);
+        var pa = ParsedArgs{ .command = .run };
+        try appendExtraArg(&pa, "--preview-mode");
+        try appendExtraArg(&pa, "127.0.0.1:54321");
+
+        try appendRunForwardedArgs(&argv, std.testing.allocator, &pa);
+        try expect.equal(argv.items.len, @as(usize, 3));
+        try std.testing.expectEqualStrings("--", argv.items[0]);
+        try std.testing.expectEqualStrings("--preview-mode", argv.items[1]);
+        try std.testing.expectEqualStrings("127.0.0.1:54321", argv.items[2]);
+    }
 };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2,7 +2,7 @@
 ///
 /// Usage:
 ///   labelle generate [dir] [--scene=name] [--optimize=MODE] — generate .labelle/ assembler files
-///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] — generate + build + run
+///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [-- <args>...] — generate + build + run; `--` forwards trailing args to the game
 ///   labelle build [dir] [--scene=name] [--optimize=MODE] — generate + build (no run)
 ///   labelle [dir]                       — alias for `run`
 ///   labelle init <name> [dir]           — scaffold a new project
@@ -62,9 +62,11 @@ fn sceneArgValue(arg: []const u8) []const u8 {
 }
 
 /// Parse --scene=<name> or --scene <name> from args, consuming the iterator as needed.
+/// `args` is `anytype` so tests can pass a `std.process.ArgIteratorGeneral`
+/// over a fixed string instead of the platform `ArgIterator`.
 fn parseSceneFlag(
     arg: []const u8,
-    args: *std.process.ArgIterator,
+    args: anytype,
     scene_override: *?[]const u8,
     cmd_name: []const u8,
 ) SceneResult {
@@ -229,7 +231,12 @@ fn parseDirAndScene(args: *std.process.ArgIterator, cmd_name: []const u8) ?struc
 }
 
 /// Parse [dir], --scene, --timeout, --platform, --optimize, --docker, and --target flags for run command (explicit or implicit).
-fn parseRunArgs(args: *std.process.ArgIterator, cmd_name: []const u8, allow_dir: bool) ?struct { dir: []const u8, scene: ?[]const u8, timeout_ns: ?u64, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool } {
+///
+/// A bare `--` token switches the parser into "passthrough" mode: every
+/// subsequent token is collected verbatim into `parsed_args.extra_args`
+/// without flag interpretation, so callers can forward args to the game
+/// binary via `zig build run -- <extras>` (see run_cmd handler).
+fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_args: *ParsedArgs) ?struct { dir: []const u8, scene: ?[]const u8, timeout_ns: ?u64, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool } {
     var dir: []const u8 = ".";
     var dir_set = !allow_dir;
     var scene: ?[]const u8 = null;
@@ -239,8 +246,17 @@ fn parseRunArgs(args: *std.process.ArgIterator, cmd_name: []const u8, allow_dir:
     var docker_build = false;
     var docker_target: ?[]const u8 = null;
     var bake = false;
+    var passthrough = false;
 
     while (args.next()) |arg| {
+        if (passthrough) {
+            appendExtraArg(parsed_args, arg) catch return null;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--")) {
+            passthrough = true;
+            continue;
+        }
         switch (parseSceneFlag(arg, args, &scene, cmd_name)) {
             .parsed => continue,
             .err => return null,
@@ -362,7 +378,7 @@ pub fn main() !void {
             parsed_args.bake = result.bake;
         } else if (std.mem.eql(u8, first, "run")) {
             parsed_args.command = .run;
-            const result = parseRunArgs(&args, "run", true) orelse return;
+            const result = parseRunArgs(&args, "run", true, &parsed_args) orelse return;
             parsed_args.project_dir = result.dir;
             parsed_args.scene_override = result.scene;
             parsed_args.timeout_ns = result.timeout_ns;
@@ -461,7 +477,7 @@ pub fn main() !void {
             parsed_args.command = .targets;
         } else {
             // No command — treat as project dir, default to run
-            const result = parseRunArgs(&args, "run", false) orelse return;
+            const result = parseRunArgs(&args, "run", false, &parsed_args) orelse return;
             parsed_args.project_dir = first;
             parsed_args.scene_override = result.scene;
             parsed_args.timeout_ns = result.timeout_ns;
@@ -753,6 +769,16 @@ pub fn main() !void {
             }
         } else {
             try zig_args.append(allocator, "run");
+            // Forward `--`-separated trailing args from `labelle run` to the
+            // game via `zig build run -- <extras>`. Only emit the `--`
+            // separator when there's at least one extra; a dangling `--`
+            // would be harmless but ugly.
+            if (parsed_args.extra_count > 0) {
+                try zig_args.append(allocator, "--");
+                for (parsed_args.extra_args[0..parsed_args.extra_count]) |extra| {
+                    try zig_args.append(allocator, extra);
+                }
+            }
             const run_result = try runner.runZigInherit(allocator, target_dir, zig_args.items, timeout_ns);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
@@ -881,6 +907,101 @@ pub const ParsePlatformValueSpec = struct {
         }
         test "returns null for unknown value" {
             try expect.equal(parsePlatformValue("windows"), null);
+        }
+    };
+};
+
+/// Build an in-memory ArgIterator over a fixed argv-like string for
+/// tests of `parseRunArgs`. `parseRunArgs` takes `anytype` so it
+/// accepts both the platform `std.process.ArgIterator` and
+/// `std.process.ArgIteratorGeneral` returned here.
+fn testIter(line: []const u8) std.process.ArgIteratorGeneral(.{}) {
+    return std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, line) catch unreachable;
+}
+
+pub const ParseRunArgsPassthroughSpec = struct {
+    pub const no_separator = struct {
+        test "empty extras when no `--` token" {
+            var iter = testIter("");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            const result = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings(".", result.dir);
+            try expect.equal(pa.extra_count, @as(usize, 0));
+        }
+
+        test "scene flag without `--` does not enter passthrough" {
+            var iter = testIter("--scene=main");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            const result = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings("main", result.scene.?);
+            try expect.equal(pa.extra_count, @as(usize, 0));
+        }
+    };
+
+    pub const single_trailing_arg = struct {
+        test "one token after `--` lands in extras" {
+            var iter = testIter("-- --preview-mode");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            const result = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings(".", result.dir);
+            try expect.equal(pa.extra_count, @as(usize, 1));
+            try std.testing.expectEqualStrings("--preview-mode", pa.extra_args[0]);
+        }
+    };
+
+    pub const multiple_trailing_args = struct {
+        test "multiple tokens after `--` preserved in order" {
+            var iter = testIter("-- --preview-mode 127.0.0.1:54321");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            _ = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try expect.equal(pa.extra_count, @as(usize, 2));
+            try std.testing.expectEqualStrings("--preview-mode", pa.extra_args[0]);
+            try std.testing.expectEqualStrings("127.0.0.1:54321", pa.extra_args[1]);
+        }
+
+        test "inner `--` after first `--` is a passthrough token, not a re-trigger" {
+            // Once the parser is in passthrough mode it stays there; a
+            // second `--` is forwarded verbatim. zig build run uses the
+            // first `--` as separator and forwards the rest, so an inner
+            // `--` reaches the game unchanged.
+            var iter = testIter("-- --foo -- --bar");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            _ = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try expect.equal(pa.extra_count, @as(usize, 3));
+            try std.testing.expectEqualStrings("--foo", pa.extra_args[0]);
+            try std.testing.expectEqualStrings("--", pa.extra_args[1]);
+            try std.testing.expectEqualStrings("--bar", pa.extra_args[2]);
+        }
+    };
+
+    pub const mixed_labelle_flags_and_passthrough = struct {
+        test "labelle flags before `--` consumed, after `--` forwarded" {
+            var iter = testIter("mydir --scene=main -- --foo bar");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            const result = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings("mydir", result.dir);
+            try std.testing.expectEqualStrings("main", result.scene.?);
+            try expect.equal(pa.extra_count, @as(usize, 2));
+            try std.testing.expectEqualStrings("--foo", pa.extra_args[0]);
+            try std.testing.expectEqualStrings("bar", pa.extra_args[1]);
+        }
+
+        test "positional dir after `--` is forwarded, not parsed as dir" {
+            // After `--` everything is opaque, so a bare word doesn't
+            // collide with the project_dir slot.
+            var iter = testIter("-- somedir");
+            defer iter.deinit();
+            var pa = ParsedArgs{ .command = .run };
+            const result = parseRunArgs(&iter, "run", true, &pa) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings(".", result.dir);
+            try expect.equal(pa.extra_count, @as(usize, 1));
+            try std.testing.expectEqualStrings("somedir", pa.extra_args[0]);
         }
     };
 };

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -11,7 +11,7 @@ pub fn printHelp() void {
         \\  init <name> [dir]    Create a new labelle project
         \\  generate [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>]  Generate .labelle/ assembler files
         \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build the project
-        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build + run (default)
+        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>] [-- <args>...]  Generate + build + run (default; `--` forwards trailing args to the game)
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
         \\  install assembler <ver>  Download and cache an assembler binary
@@ -36,6 +36,7 @@ pub fn printHelp() void {
         \\  labelle build --docker
         \\  labelle build --docker --target=x86_64-windows
         \\  labelle run --docker
+        \\  labelle run -- --preview-mode 127.0.0.1:54321
         \\  labelle install 0.2.0
         \\  labelle upgrade core 0.2.0
         \\  labelle test


### PR DESCRIPTION
Closes #193. Part of the PIE preview umbrella (labelle-toolkit/labelle-gui#59).

## Summary

- `parseRunArgs` switches into passthrough mode on a bare `--`; subsequent tokens land in `ParsedArgs.extra_args` verbatim, untouched by flag parsing.
- The `run_cmd` handler appends `-- <extras>` to `zig_args` (right after `"run"`) only when `extra_count > 0`. The no-extras path is byte-identical to today, so existing invocations are unchanged.
- Scope per the issue: `run` only. `build` and `generate` don't run the binary, so passthrough there would be a no-op.

## Mechanics

```
labelle run mygame -- --preview-mode 127.0.0.1:54321
  → zig build run -- --preview-mode 127.0.0.1:54321   # in .labelle/<backend>_<platform>/
```

`parseRunArgs` / `parseSceneFlag` iterator params relaxed to `anytype` so the new zspec tests can drive them with `std.process.ArgIteratorGeneral` over a fixed string. Production callers still pass `*std.process.ArgIterator` and compile unchanged.

## Test plan

- [x] `zig build test` — 53 passed (was 46; +7 zspec regressions in `ParseRunArgsPassthroughSpec` covering: empty extras / no `--`, single trailing arg, multiple trailing args in order, inner `--` after the separator stays as a passthrough token, mixed labelle-flag + `--` + forwarded args, positional after `--` not parsed as project dir).
- [ ] Manual: `labelle run <dir> -- --preview-mode 127.0.0.1:54321` against a project that wires `--preview-mode` (depends on labelle-assembler#94).
- [x] `labelle run <dir>` (no `--`) — `zig_args` is unchanged so existing CI builds keep passing.

## Out of scope

- `build` / `generate` passthrough — unnecessary since they don't exec the binary.
- WASM / iOS / Android run paths — they don't go through `zig build run`, so extras are silently ignored there for now. Easy to extend per-platform later if the umbrella needs it.

## Refs

- Issue: #193
- Umbrella: labelle-toolkit/labelle-gui#59
- Sibling: labelle-toolkit/labelle-assembler#94 (parses `--preview-mode` in generated `main.zig`), labelle-toolkit/labelle-engine#517 (engine primitives)