### PR TITLE
docs: WASM serve spike + raylib segfault investigation

### DIFF
--- a/docs/wasm-segfault-investigation.md
+++ b/docs/wasm-segfault-investigation.md
@@ -1,0 +1,200 @@
+# WASM segfault root-cause investigation (#196)
+
+**Status:** Root cause identified and reproduced under a fix. The fix
+lives in `labelle-engine` (and `labelle-gfx`), not in this repo — see
+"Fix" below for the patch. The original "first sprite texture upload
+segfaults" framing was a red herring: the texture upload itself
+succeeds. What actually crashes is the *first Zig-side `std.debug.print`
+to stderr* that runs immediately after the upload.
+
+## Reproduction
+
+```bash
+cd labelle-assembler/examples/raylib
+rm -rf .labelle && labelle build --platform=wasm
+cd .labelle/raylib_wasm/zig-out/web
+python3 -m http.server 8765
+# Real Chrome (NOT headless software-WebGL):
+google-chrome http://localhost:8765/game.html
+```
+
+Console output stops at:
+
+```
+INFO: TEXTURE: [ID 13] Texture loaded successfully (128x32 | R8G8B8A8 | 1 mipmaps)
+Aborted(segmentation fault)
+```
+
+## The "segfault" is `SAFE_HEAP` misreporting
+
+The default `ReleaseSafe` build sets `SAFE_HEAP=1`. With that off, the
+real abort surfaces:
+
+```
+Aborted(Assertion failed)
+  at Object.write (game.js:3378:9)         ← assert(offset >= 0)
+  at doWritev    (game.js:10697:23)
+  at _fd_write   (game.js:10786:17)
+  at game.wasm.writev
+  at game.wasm.posix.writev
+  at game.wasm.fs.File.Writer.drain
+  at game.wasm.Io.Writer.write
+```
+
+So it's a Zig `Io.Writer` → `posix.writev` → `_fd_write` chain, not a
+texture or GL crash. The texture upload printed `Texture loaded
+successfully` from raylib's *own* stdout `TRACELOG`; that one went
+through fine. The very next write — Zig writing the first line to
+stderr (fd=2) — is the one that aborts.
+
+## The real bug: JS `HEAPU32` is detached when `_fd_write` reads `iov`
+
+Instrumenting `doWritev` to log the JS-side state just before it touches
+`HEAPU32` produces this on the failing call:
+
+```
+[DBG doWritev] fd=2 iov=47784 iovcnt=2 HEAPU32.len=0 wasmBuf.byteLength=67502080 same=false
+[DBG doWritev] i=0 ptr=undefined len=undefined
+  → "Cannot perform Construct on a detached ArrayBuffer"
+```
+
+Key signals:
+
+- `HEAPU32.len = 0` — the cached `HEAPU32` typed-array view's backing
+  buffer was **detached**.
+- `wasmBuf.byteLength = 67502080` — meanwhile `wasmMemory.buffer` is
+  now a *new*, larger buffer (was 67108864 = 64 MB, grew by exactly 6
+  wasm pages).
+- `same = false` — `HEAPU32.buffer !== wasmMemory.buffer`. The wasm
+  memory grew; the JS views never picked up the new buffer.
+
+The next `_fd_write` reads `HEAPU32[iov >> 2]`, the typed array is
+detached, that read returns `undefined`, the eventual `assert(offset
+>= 0)` fires on `undefined >= 0 === false`, and emscripten aborts. The
+emscripten "Aborted(segmentation fault)" string is a generic abort
+label and unrelated to a real CPU segfault.
+
+## Why the views are stale: `@wasmMemoryGrow` bypasses `_emscripten_resize_heap`
+
+Emscripten owns memory growth: every call to libc `malloc`/`realloc`
+that needs more pages goes through `_emscripten_resize_heap` →
+`growMemory` → `wasmMemory.grow()` → `updateMemoryViews()`, which
+rebinds `HEAPU32` (et al.) to the new `ArrayBuffer`. So all libc-routed
+growth keeps JS views fresh.
+
+`std.heap.page_allocator` on `wasm32-emscripten` resolves to
+`std.heap.WasmAllocator` (see `std/heap.zig:346-352` in Zig 0.15.2),
+which calls **`@wasmMemoryGrow(0, …)` directly** — a raw wasm
+`memory.grow` instruction. That instruction grows the linear memory
+without ever crossing into JS, so `updateMemoryViews()` never runs and
+every JS-side typed-array view stays bound to the old (now-detached)
+`ArrayBuffer`. The next time JS reads `HEAPU32[…]`, length is 0 and
+every index returns `undefined`.
+
+The raylib backend's `decodeImage` allocates `width*height*4` bytes
+through whichever allocator the asset catalog hands it (currently
+`game.allocator = std.heap.c_allocator`, which IS routed via emscripten
+and IS safe). But several places in `labelle-engine` and one in
+`labelle-gfx` use `std.heap.page_allocator` directly — and those are
+the calls that detach the heap:
+
+| Location | Use |
+|---|---|
+| `labelle-engine/src/jsonc/prefab_cache.zig:28,65` | persistent prefab `Value` arena (lives game-lifetime so GPA doesn't flag as leak) |
+| `labelle-engine/src/jsonc/deserializer.zig:57` | interned-string arena |
+| `labelle-engine/src/jsonc/scene_loader.zig:523` | persistent ID array per scene entity array |
+| `labelle-gfx/src/backend.zig:219` | legacy `loadTextureFromMemory` decode buffer (no engine caller today, but still compiled in) |
+
+The first one of these to fire under our raylib-wasm example is
+`prefab_cache.zig`'s persistent allocator — invoked by the very next
+line of generated `main.zig` after `loadAtlasFromMemory("sprites",
+…)`:
+
+```zig
+JsoncBridge.addEmbeddedPrefab(&g, "coin", @embedFile("prefabs/coin.jsonc"), "prefabs") catch @panic(…);
+```
+
+`addEmbeddedPrefab` → `getOrCreatePrefabCache` → `persistent.create(PrefabCache)`
+→ `WasmAllocator.alloc` → `@wasmMemoryGrow` → JS views detached →
+first `std.debug.print` (which the asset-streaming pipeline emits in
+the assembler-generated init log right around the same point) aborts.
+
+The reason it *looks like* the crash is during the texture upload is
+purely ordering: raylib's stdout `TRACELOG("INFO: TEXTURE: … loaded
+successfully")` is the last successful console output, then the
+prefab-cache page-alloc grows wasm memory, then the next Zig stderr
+write aborts.
+
+## Validation
+
+Patching the four `std.heap.page_allocator` sites above to use
+`std.heap.c_allocator` on `wasm32-emscripten` (and keeping
+`page_allocator` everywhere else so desktop GPA leak-detection still
+works) lets the example clear the texture-upload barrier cleanly. With
+the patch the failing line stops being the writev assertion and
+becomes a *different* panic further downstream:
+
+```
+INFO: TEXTURE: [ID 13] Texture loaded successfully (128x32 | R8G8B8A8 | 1 mipmaps)
+info: [Scene] 'main' has no manifest, eager-loaded 1 resources (Debug build)
+panic: failed to set initial scene
+```
+
+That stderr `info: [Scene] …` line is the proof point: it's the first
+successful Zig→stderr write under wasm32-emscripten. The follow-on
+`failed to set initial scene` is a separate downstream bug (the scene
+loader's filesystem fallback under emscripten's virtual FS) — not part
+of #196 and out of scope here.
+
+## Fix (lives in labelle-engine + labelle-gfx, not labelle-cli)
+
+Four single-line swaps. The pattern is identical in each site — add a
+file-scope const that selects the allocator by target.os and reference
+it instead of `std.heap.page_allocator`:
+
+```zig
+const builtin = @import("builtin");
+const persistent_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
+```
+
+Replace every `std.heap.page_allocator` in the four files above with
+`persistent_allocator`. `c_allocator` is libc-backed → emscripten's
+malloc → `_emscripten_resize_heap` → `updateMemoryViews()`. JS views
+stay live, `_fd_write` never sees a detached buffer.
+
+Desktop targets keep `page_allocator` (preserves the existing
+"deliberately not freed → page allocator so GPA doesn't flag" pattern
+documented in `prefab_cache.zig`'s top-of-file note).
+
+## What this does NOT fix
+
+- `failed to set initial scene` — scene loader filesystem fallback
+  under emscripten VFS. Separate issue; reproducible the moment #196's
+  texture barrier is past.
+- sokol-wasm build errors (#197, #198 territory). Unrelated.
+- `--watch` / `--no-build` / `--port` flags for `labelle serve --wasm`.
+  Polish; the underlying serve loop in `src/cli/serve.zig` already
+  works.
+
+## Notes for future debuggers
+
+- **Build with `SAFE_HEAP` off when chasing wasm aborts.** It rewrites
+  every signal into a uniform "segmentation fault" string and buries
+  the real assertion. The `ReleaseSafe` default in
+  `zemscripten.emccDefaultSettings` turns it on; an
+  `emcc_settings.remove("SAFE_HEAP")` in the generated `build.zig`
+  while diagnosing is invaluable.
+- **`--profiling-funcs` preserves wasm function names in stack
+  traces.** Without it you get `wasm-function[1077]` and nothing else.
+- **Headless Chrome's software WebGL refuses to initialise GLFW** —
+  the GLFW init fails silently, raylib later calls `glBindTexture` on
+  an undefined GL context, and you'll think you're chasing a GL bug.
+  Use `--use-gl=swiftshader --enable-unsafe-swiftshader` (the spike
+  doc uses these) or a real headed browser.
+- The Chrome warning `GL Driver Message (… GL_CLOSE_PATH_NV, High):
+  GPU stall due to ReadPixels` that shows up *after* the abort is
+  unrelated — it's swiftshader telling you it stalled while writing
+  the post-abort error screenshot.

--- a/docs/wasm-serve-spike.md
+++ b/docs/wasm-serve-spike.md
@@ -49,7 +49,7 @@ mostly polish + a runtime crash on one backend.
    **Succeeded.** Same artifact shape.
 
 5. Served the raylib artifacts with `python3 -m http.server`, loaded in headless
-   Chrome with software WebGL.
+   Chrome with software WebGL (`--use-gl=swiftshader --enable-unsafe-swiftshader`).
    - Raylib initialises through `PLATFORM: WEB: Initialized successfully`.
    - WebGL 2.0 context obtains GLSL ES 3.00, VAO + NPOT extensions.
    - Default shader + fragment shader compile and link.
@@ -128,7 +128,7 @@ thin CLI surface that exposes the documented flags. Breakdown:
 
 | Task | Size | Notes |
 |------|------|-------|
-| Fix raylib-wasm runtime segfault | M | Cross-repo: labelle-engine + raylib backend likely. Real diagnosis needed. |
+| Fix raylib-wasm runtime segfault | M | Diagnosed (see `wasm-segfault-investigation.md`). Fix lives in labelle-engine + labelle-gfx. |
 | Fix sokol-wasm `stdlib.h` include | S | `labelle-sokol/build.zig` — add `emsdk.emccDefaultFlags`-equivalent include paths to gfx module. |
 | Fix sokol-wasm `allocator` shadow | XS | Single template edit in `labelle-assembler`. |
 | Add `labelle wasm serve` subcommand wrapper (vs reusing `run --platform=wasm`) | S | Just a CLI alias + flag parsing. `serve.zig` already does the work. |
@@ -153,12 +153,10 @@ entirely on diagnosing the segfault.
 
 ## Files / artifacts produced during the spike
 
-- Built artifacts at
-  `/Users/alexandrecalvao/prj/labelle-toolkit/labelle-assembler/examples/raylib/.labelle/raylib_wasm/zig-out/web/`
+- Built artifacts at `labelle-assembler/examples/raylib/.labelle/raylib_wasm/zig-out/web/`
   (kept for reference; safe to `rm -rf .labelle/`).
-- Screenshot of the running raylib-wasm bundle at `/tmp/wasm-raylib-shot.png`
-  (black canvas + emscripten "Exception thrown" banner — proves canvas mounts
-  before the segfault).
+- Screenshot of the running raylib-wasm bundle (kept for reference; black canvas +
+  emscripten "Exception thrown" banner — proves canvas mounts before the segfault).
 
 ## Recommendation
 

--- a/docs/wasm-serve-spike.md
+++ b/docs/wasm-serve-spike.md
@@ -1,0 +1,167 @@
+# WASM Serve Spike (#2)
+
+**Status:** Succeeded — the toolkit cross-compiles to WebAssembly and runs in a
+browser today. The `labelle serve --wasm` command is mostly already implemented;
+issue #2 has effectively been delivered piecemeal by prior work. What remains is
+mostly polish + a runtime crash on one backend.
+
+## TL;DR
+
+- `labelle build --platform=wasm` works **right now** with the `raylib` backend.
+- The CLI already serves the build over HTTP and opens a browser when you run
+  `labelle run --platform=wasm` — see `src/cli/serve.zig` (146 lines) and the
+  WASM branch at `src/cli.zig:735-740`.
+- Built artifact reaches the browser, raylib + WebGL 2.0 initialise, shaders
+  compile, fonts load — verified via headless Chrome screenshot.
+- One runtime blocker: every example crashes with `Aborted(segmentation fault)`
+  right after the first sprite texture loads, before the first frame is drawn.
+  This is a runtime bug, not a "can WASM work" bug.
+- The `sokol` backend does **not** build for WASM today (two distinct compile
+  errors, captured below).
+
+## What was tried
+
+1. Inventoried the WASM plumbing in `labelle-cli`, `labelle-assembler`, and the
+   backends. Discovered substantial prior work:
+   - `src/cli/serve.zig` — a working static-file server with proper MIME types,
+     COOP/COEP headers, browser auto-open. ~150 LoC.
+   - `src/cli.zig` — `--platform=wasm` is parsed, defaults optimize to
+     `ReleaseSafe` for wasm (Debug exceeds browser local var limits), routes
+     `labelle run` through `serve.serveAndOpen` when the platform is wasm.
+   - `labelle-assembler/backends/raylib/templates/wasm.txt` — full
+     `emscripten_set_main_loop` shim.
+   - `labelle-assembler/src/build_files.zig` — emits `addLibrary` + `emLinkStep`
+     for wasm, separate `wasm_emsdk_raylib` and `wasm_emsdk_sokol` template
+     sections.
+   - `labelle-assembler/src/templates/build_zig_zon.txt` — pins
+     `emscripten-core/emsdk#4.0.9` as a build dependency.
+   - 10+ commits referencing wasm in `labelle-cli` history, 14+ in
+     `labelle-assembler`.
+
+2. Built `labelle-assembler/examples/sokol` with `labelle build --platform=wasm`.
+   **Failed** — two errors (see Blockers below).
+
+3. Built `labelle-assembler/examples/raylib` with `labelle build --platform=wasm`.
+   **Succeeded.** Output: `.labelle/raylib_wasm/zig-out/web/{game.html,
+   game.js, game.wasm}` — 20 KB / 284 KB / 944 KB.
+
+4. Built `labelle-assembler/examples/asset-streaming-smoke` (also raylib).
+   **Succeeded.** Same artifact shape.
+
+5. Served the raylib artifacts with `python3 -m http.server`, loaded in headless
+   Chrome with software WebGL.
+   - Raylib initialises through `PLATFORM: WEB: Initialized successfully`.
+   - WebGL 2.0 context obtains GLSL ES 3.00, VAO + NPOT extensions.
+   - Default shader + fragment shader compile and link.
+   - Default 128×128 GRAY_ALPHA font texture loads.
+   - First sprite atlas texture (128×32 R8G8B8A8) loads.
+   - Then: `Aborted(segmentation fault)` from `game.js`. Black canvas remains.
+
+## What worked
+
+- The cross-compile path (Zig 0.15.2 → wasm32-emscripten via auto-downloaded
+  emsdk 4.0.9). End-to-end, no manual emsdk install required.
+- The browser-side stack: emscripten shell, WebGL 2.0 init, raylib WEB
+  platform, shader compile, texture upload.
+- The local-serve flow: `src/cli/serve.zig` already does everything #2 asked
+  for — port fallback, MIME types, COOP/COEP, browser auto-open. It is wired
+  into `labelle run --platform=wasm` today.
+
+## Blockers
+
+### Runtime — segfault after first texture load (raylib WASM, every example)
+
+After raylib finishes its init and the first scene asset uploads, the WASM
+module aborts. No useful stack trace from `ReleaseSafe`. Likely candidates:
+
+- Scene loader / asset manifest path resolution under Emscripten's virtual FS
+  (`Working Directory: /`).
+- Pointer cast / alignment issue surfaced by wasm32 but not desktop.
+- An optional that's `null` on wasm (e.g. a path returning empty under emsdk
+  packfile vs. real disk).
+
+**Diagnosis cost:** medium. Need to rebuild with `--optimize=Debug` (will
+likely hit the "exceeds browser local var limits" wall — see `cli.zig:613`)
+or add `-g` + symbol-mapped source. Then load in a real (non-headless)
+browser to inspect the JS stack.
+
+### Sokol backend doesn't compile for WASM
+
+`labelle build --platform=wasm` on `examples/sokol` fails with two errors:
+
+1. **`stb_image.h:386: 'stdlib.h' file not found`** in
+   `.labelle/deps/labelle-sokol/src/stb_image_impl.c`. The wasm32-emscripten
+   C compile is missing the emsdk sysroot include path for `stb_image_impl.c`
+   (gfx module). `labelle-assembler/src/templates/build_zig.txt` has a
+   `wasm_emsdk_sokol` section, but the sokol backend's `addCSourceFile` for
+   `stb_image_impl.c` (`labelle-sokol/build.zig:32`) doesn't pick up emsdk's
+   `--sysroot`.
+
+2. **`main.zig:146: local constant shadows declaration of 'allocator'`** —
+   the generated `main.zig` for sokol+wasm has both a module-level
+   `const allocator = std.heap.c_allocator;` and a function-level
+   `const allocator = std.heap.c_allocator;` inside `initInner()`. The
+   assembler template emits both. This is purely a generator bug.
+
+**Diagnosis cost:** small for #2 (template edit in
+`labelle-assembler/src/templates/build_zig.txt` or wherever `initInner` is
+generated). Small-to-medium for #1 (needs an `addIncludePath` plumbed from
+emsdk's sysroot through to the sokol gfx module).
+
+## Shortest path to "Phase 1 done"
+
+1. Fix the raylib-wasm runtime segfault. Once the first frame renders, the
+   `labelle serve --wasm` story is effectively complete — the existing
+   `serve.zig` + `--platform=wasm` flow already does build → serve → open
+   browser.
+2. Optional: also fix the two sokol-wasm compile errors so users on the sokol
+   backend can ship to wasm.
+3. Optional polish for issue #2's spec: `--port`, `--no-open`, `--no-build`,
+   `--watch`. None of these are blockers; they sit on top of the existing
+   serve loop.
+
+## Effort estimate for "full `labelle serve --wasm`"
+
+**Small.** The command is functionally already implemented under the name
+`labelle run --platform=wasm`. What's missing is the runtime crash fix and a
+thin CLI surface that exposes the documented flags. Breakdown:
+
+| Task | Size | Notes |
+|------|------|-------|
+| Fix raylib-wasm runtime segfault | M | Cross-repo: labelle-engine + raylib backend likely. Real diagnosis needed. |
+| Fix sokol-wasm `stdlib.h` include | S | `labelle-sokol/build.zig` — add `emsdk.emccDefaultFlags`-equivalent include paths to gfx module. |
+| Fix sokol-wasm `allocator` shadow | XS | Single template edit in `labelle-assembler`. |
+| Add `labelle wasm serve` subcommand wrapper (vs reusing `run --platform=wasm`) | S | Just a CLI alias + flag parsing. `serve.zig` already does the work. |
+| `--port`, `--no-open` flags | S | Plumb through `serveAndOpen` signature. |
+| `--watch` (filesystem watcher + rebuild + browser reload) | M | New code; SSE or WebSocket for reload signal. |
+| `--no-build` (serve existing artifact) | XS | Conditional on `.labelle/<target>/zig-out/web/` existence. |
+
+If "Phase 1" = the raylib path produces a running game in browser via
+`labelle wasm serve`, this is **small-to-medium** total effort gated almost
+entirely on diagnosing the segfault.
+
+## Cross-repo work needed
+
+- **labelle-engine** — runtime segfault is most likely here (scene/asset code
+  path under wasm32-emscripten).
+- **labelle-sokol** — `build.zig` needs to add the emsdk sysroot include to
+  the stb_image C compilation when the target is wasm32-emscripten.
+- **labelle-assembler** — template emits duplicate `const allocator` in the
+  sokol+wasm `main.zig`; remove the inner one.
+- **labelle-cli** — only cosmetic: add the documented `wasm serve` alias and
+  optional flags if we want to match issue #2's exact UX.
+
+## Files / artifacts produced during the spike
+
+- Built artifacts at
+  `/Users/alexandrecalvao/prj/labelle-toolkit/labelle-assembler/examples/raylib/.labelle/raylib_wasm/zig-out/web/`
+  (kept for reference; safe to `rm -rf .labelle/`).
+- Screenshot of the running raylib-wasm bundle at `/tmp/wasm-raylib-shot.png`
+  (black canvas + emscripten "Exception thrown" banner — proves canvas mounts
+  before the segfault).
+
+## Recommendation
+
+Stop treating issue #2 as "build a serve command from scratch." The serve
+command already exists. File the three concrete blockers as sub-issues, fix
+the raylib runtime crash first, and #2 is done.


### PR DESCRIPTION
Two investigation docs from today's WASM exploration. The code fixes themselves land in separate PRs (labelle-engine + labelle-gfx — one-line allocator swaps). This PR just preserves the analysis so we don't lose it.

## docs/wasm-serve-spike.md

Phase 0 spike for [#2](https://github.com/labelle-toolkit/labelle-cli/issues/2) — \`labelle serve --wasm\`. Confirms today's toolkit cross-compiles to WASM and runs in a browser; identifies the three concrete blockers:

- #196 — raylib runtime segfault after first texture upload
- #197 — sokol stb_image emsdk sysroot path missing
- #198 — sokol duplicate \`const allocator\` in generated main.zig

## docs/wasm-segfault-investigation.md

Root-cause analysis of #196. The "first texture upload segfault" turned out to be a triple misnomer:

1. \`Aborted(segmentation fault)\` is just SAFE_HEAP=1's generic abort label
2. The texture upload itself succeeds; the abort fires on the *next* \`Io.Writer → posix.writev → _fd_write\` (first Zig-side \`std.debug.print\` to stderr)
3. The crash is JS-side: \`HEAPU32\`'s backing \`ArrayBuffer\` is detached because wasm grew memory via the raw \`memory.grow\` instruction, bypassing emscripten's \`_emscripten_resize_heap → updateMemoryViews()\` chain

Source: \`std.heap.page_allocator\` on \`wasm32-emscripten\` resolves to \`WasmAllocator\` which calls \`@wasmMemoryGrow\` directly. Four call-sites do this — in labelle-engine and labelle-gfx. Fix is a one-line swap to \`c_allocator\` on emscripten.

## Test plan

- [x] No code changes — docs only