### PR TITLE
Add WASM serve command (labelle wasm serve)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -4,6 +4,7 @@
 ///   labelle generate [dir] [--scene=name] [--optimize=MODE] — generate .labelle/ assembler files
 ///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [-- <args>...] — generate + build + run; `--` forwards trailing args to the game
 ///   labelle build [dir] [--scene=name] [--optimize=MODE] — generate + build (no run)
+///   labelle wasm serve [dir] [--port n] [--no-build] [--no-open] — build the WASM target and serve it locally
 ///   labelle [dir]                       — alias for `run`
 ///   labelle init <name> [dir]           — scaffold a new project
 ///   labelle install [pkg] [ver]         — fetch packages into cache
@@ -37,7 +38,7 @@ const ios = @import("cli/ios.zig");
 const android = @import("cli/android.zig");
 const util = @import("cli/util.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, help_cmd, version, targets, assembler_cmd, test_cmd };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -117,7 +118,65 @@ const ParsedArgs = struct {
     docker: bool = false,
     docker_target: ?[]const u8 = null,
     bake: bool = false,
+    // `wasm serve` options. `serve_port` is also read by the wasm
+    // branch of `run`; the others only apply to `wasm serve`.
+    serve_port: u16 = 8080,
+    serve_no_build: bool = false,
+    serve_no_open: bool = false,
 };
+
+/// Parsed `wasm serve` flags. Returned by `parseWasmServeArgs`; `null`
+/// signals a parse error (the helper has already printed a message).
+const WasmServeArgs = struct {
+    dir: []const u8 = ".",
+    port: u16 = 8080,
+    no_build: bool = false,
+    no_open: bool = false,
+};
+
+/// Parse the flags of `labelle wasm serve [dir] [--port <n>]
+/// [--no-build] [--no-open]`. `args` is `anytype` so tests can drive
+/// it with an in-memory `Args.IteratorGeneral`, mirroring
+/// `parseRunArgs`.
+fn parseWasmServeArgs(args: anytype) ?WasmServeArgs {
+    var result = WasmServeArgs{};
+    var dir_set = false;
+
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--no-build")) {
+            result.no_build = true;
+        } else if (std.mem.eql(u8, arg, "--no-open")) {
+            result.no_open = true;
+        } else if (std.mem.startsWith(u8, arg, "--port=") or std.mem.eql(u8, arg, "--port")) {
+            const val = if (std.mem.eql(u8, arg, "--port"))
+                (args.next() orelse {
+                    std.debug.print("labelle wasm serve: --port requires a value (e.g. --port 3000)\n", .{});
+                    return null;
+                })
+            else
+                arg["--port=".len..];
+            result.port = std.fmt.parseInt(u16, val, 10) catch {
+                std.debug.print("labelle wasm serve: invalid --port value '{s}' (expected 1-65535)\n", .{val});
+                return null;
+            };
+            if (result.port == 0) {
+                std.debug.print("labelle wasm serve: --port must be between 1 and 65535\n", .{});
+                return null;
+            }
+        } else if (std.mem.startsWith(u8, arg, "--")) {
+            std.debug.print("labelle wasm serve: unknown flag '{s}'\n", .{arg});
+            return null;
+        } else {
+            if (dir_set) {
+                std.debug.print("labelle wasm serve: unexpected argument '{s}'\n", .{arg});
+                return null;
+            }
+            result.dir = arg;
+            dir_set = true;
+        }
+    }
+    return result;
+}
 
 /// Parse a --platform=<value> string into a Platform enum, or null if invalid.
 fn parsePlatformValue(val: []const u8) ?Platform {
@@ -480,6 +539,26 @@ pub fn main(proc_init: std.process.Init) !void {
                     parsed_args.project_dir = arg;
                 }
             }
+        } else if (std.mem.eql(u8, first, "wasm")) {
+            // `labelle wasm <subcommand>` — only `serve` exists today.
+            const sub = args.next();
+            if (sub == null or !std.mem.eql(u8, sub.?, "serve")) {
+                if (sub) |s| {
+                    std.debug.print("labelle wasm: unknown subcommand '{s}'\n", .{s});
+                } else {
+                    std.debug.print("labelle wasm: missing subcommand\n", .{});
+                }
+                std.debug.print("  usage: labelle wasm serve [dir] [--port <n>] [--no-build] [--no-open]\n", .{});
+                return;
+            }
+            parsed_args.command = .wasm_cmd;
+            const result = parseWasmServeArgs(&args) orelse return;
+            parsed_args.project_dir = result.dir;
+            parsed_args.serve_port = result.port;
+            parsed_args.serve_no_build = result.no_build;
+            parsed_args.serve_no_open = result.no_open;
+            // `wasm serve` always builds/serves the WASM target.
+            parsed_args.platform_override = .wasm;
         } else if (std.mem.eql(u8, first, "assembler")) {
             parsed_args.command = .assembler_cmd;
             try collectExtraArgs(&args, &parsed_args);
@@ -593,6 +672,27 @@ pub fn main(proc_init: std.process.Init) !void {
     // Upgrade modifies project.labelle in the project directory
     if (command == .upgrade_cmd) {
         return upgrade.cmdUpgrade(allocator, project_dir, parsed, parsed_args.extra_args[0..parsed_args.extra_count]);
+    }
+
+    // `labelle wasm serve --no-build` — skip the generate+build
+    // pipeline entirely and serve the existing build output. The web
+    // dir lives under the wasm target subdir (`.labelle/<backend>_wasm/`).
+    if (command == .wasm_cmd and parsed_args.serve_no_build) {
+        const wasm_target = try std.fmt.allocPrint(allocator, "{s}_wasm", .{@tagName(parsed.backend)});
+        defer allocator.free(wasm_target);
+        const web_dir = try std.fs.path.join(allocator, &.{
+            project_dir, ".labelle", wasm_target, "zig-out", "web",
+        });
+        defer allocator.free(web_dir);
+        if (std.Io.Dir.cwd().access(config.globalIo(), web_dir, .{})) |_| {} else |_| {
+            std.debug.print(
+                "labelle wasm serve: no existing WASM build at '{s}'\n" ++
+                    "  run `labelle wasm serve` (without --no-build) first.\n",
+                .{web_dir},
+            );
+            return error.BuildFailed;
+        }
+        return serve.serveAndOpen(allocator, web_dir, parsed_args.serve_port, !parsed_args.serve_no_open);
     }
 
     // Ensure package cache is populated
@@ -742,7 +842,7 @@ pub fn main(proc_init: std.process.Init) !void {
         // WASM: serve via local HTTP server + open browser
         const web_dir = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "web" });
         defer allocator.free(web_dir);
-        try serve.serveAndOpen(allocator, web_dir, 8080);
+        try serve.serveAndOpen(allocator, web_dir, parsed_args.serve_port, !parsed_args.serve_no_open);
     } else if (parsed.platform == .ios) {
         // iOS: deploy to simulator
         std.debug.print("labelle: deploying to iOS Simulator...\n", .{});
@@ -1014,6 +1114,94 @@ pub const ParseRunArgsPassthroughSpec = struct {
             try std.testing.expectEqualStrings(".", result.dir);
             try expect.equal(pa.extra_count, @as(usize, 1));
             try std.testing.expectEqualStrings("somedir", pa.extra_args[0]);
+        }
+    };
+};
+
+pub const ParseWasmServeArgsSpec = struct {
+    pub const defaults = struct {
+        test "no args yields port 8080 and all flags off" {
+            var iter = testIter("");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.port, @as(u16, 8080));
+            try expect.equal(result.no_build, false);
+            try expect.equal(result.no_open, false);
+            try std.testing.expectEqualStrings(".", result.dir);
+        }
+    };
+
+    pub const port_flag = struct {
+        test "--port=3000 sets the port" {
+            var iter = testIter("--port=3000");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.port, @as(u16, 3000));
+        }
+
+        test "--port 3000 (space form) sets the port" {
+            var iter = testIter("--port 3000");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.port, @as(u16, 3000));
+        }
+
+        test "non-numeric --port value is rejected" {
+            var iter = testIter("--port abc");
+            defer iter.deinit();
+            try expect.equal(parseWasmServeArgs(&iter), null);
+        }
+
+        test "out-of-range --port value is rejected" {
+            var iter = testIter("--port 99999");
+            defer iter.deinit();
+            try expect.equal(parseWasmServeArgs(&iter), null);
+        }
+
+        test "--port 0 is rejected" {
+            var iter = testIter("--port 0");
+            defer iter.deinit();
+            try expect.equal(parseWasmServeArgs(&iter), null);
+        }
+    };
+
+    pub const boolean_flags = struct {
+        test "--no-build sets no_build" {
+            var iter = testIter("--no-build");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.no_build, true);
+        }
+
+        test "--no-open sets no_open" {
+            var iter = testIter("--no-open");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.no_open, true);
+        }
+
+        test "flags combine with a custom port and dir" {
+            var iter = testIter("mygame --port 5000 --no-build --no-open");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try std.testing.expectEqualStrings("mygame", result.dir);
+            try expect.equal(result.port, @as(u16, 5000));
+            try expect.equal(result.no_build, true);
+            try expect.equal(result.no_open, true);
+        }
+    };
+
+    pub const rejects_bad_input = struct {
+        test "unknown flag is rejected" {
+            var iter = testIter("--watch");
+            defer iter.deinit();
+            try expect.equal(parseWasmServeArgs(&iter), null);
+        }
+
+        test "a second positional arg is rejected" {
+            var iter = testIter("dir1 dir2");
+            defer iter.deinit();
+            try expect.equal(parseWasmServeArgs(&iter), null);
         }
     };
 };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1149,19 +1149,19 @@ pub const ParseWasmServeArgsSpec = struct {
         test "non-numeric --port value is rejected" {
             var iter = testIter("--port abc");
             defer iter.deinit();
-            try expect.equal(parseWasmServeArgs(&iter), null);
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
 
         test "out-of-range --port value is rejected" {
             var iter = testIter("--port 99999");
             defer iter.deinit();
-            try expect.equal(parseWasmServeArgs(&iter), null);
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
 
         test "--port 0 is rejected" {
             var iter = testIter("--port 0");
             defer iter.deinit();
-            try expect.equal(parseWasmServeArgs(&iter), null);
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
     };
 
@@ -1195,13 +1195,13 @@ pub const ParseWasmServeArgsSpec = struct {
         test "unknown flag is rejected" {
             var iter = testIter("--watch");
             defer iter.deinit();
-            try expect.equal(parseWasmServeArgs(&iter), null);
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
 
         test "a second positional arg is rejected" {
             var iter = testIter("dir1 dir2");
             defer iter.deinit();
-            try expect.equal(parseWasmServeArgs(&iter), null);
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
     };
 };

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -12,6 +12,7 @@ pub fn printHelp() void {
         \\  generate [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>]  Generate .labelle/ assembler files
         \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build the project
         \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>] [-- <args>...]  Generate + build + run (default; `--` forwards trailing args to the game)
+        \\  wasm serve [dir] [--port <n>] [--no-build] [--no-open]  Build the WASM target, serve it locally (default port 8080), open the browser
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
         \\  install assembler <ver>  Download and cache an assembler binary
@@ -31,6 +32,10 @@ pub fn printHelp() void {
         \\  labelle run --scene=settings_menu
         \\  labelle generate --platform=wasm
         \\  labelle build --platform=wasm
+        \\  labelle wasm serve
+        \\  labelle wasm serve --port 3000
+        \\  labelle wasm serve --no-build
+        \\  labelle wasm serve --no-open
         \\  labelle build --optimize=ReleaseFast
         \\  labelle build ../my-game
         \\  labelle build --docker

--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -44,7 +44,10 @@ fn mimeFor(path: []const u8) []const u8 {
 /// browser. Blocks forever — returns only on a bind failure (the
 /// accept loop swallows per-connection errors so a flaky tab can't
 /// kill the server).
-pub fn serveAndOpen(allocator: std.mem.Allocator, web_dir: []const u8, port: u16) !void {
+///
+/// `open_browser` controls the auto-launch — `labelle wasm serve
+/// --no-open` passes `false` to suppress it.
+pub fn serveAndOpen(allocator: std.mem.Allocator, web_dir: []const u8, port: u16, open_browser_tab: bool) !void {
     const io = config.globalIo();
 
     const addr = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;
@@ -65,7 +68,7 @@ pub fn serveAndOpen(allocator: std.mem.Allocator, web_dir: []const u8, port: u16
         .{ web_dir, port },
     );
 
-    openBrowser(allocator, port);
+    if (open_browser_tab) openBrowser(allocator, port);
 
     while (true) {
         const stream = server.accept(io) catch |err| {

--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -1,20 +1,303 @@
 /// Minimal static file server for serving WASM builds locally.
-/// Opens the default browser and serves files until interrupted.
+/// Serves files from `web_dir` on 127.0.0.1:`port`, opens the default
+/// browser, and runs until the process is interrupted (Ctrl+C).
 ///
-/// TODO(zig-0.16): rewrite against `std.Io.net.IpAddress` and friends.
-/// For the migration we stub this out — WASM serve is exercised by
-/// `labelle run --platform=wasm`, not by `zig build` itself.
+/// Single-threaded, one connection at a time — a dev-only serve loop
+/// for a single browser tab, not a production server. Built directly
+/// on `std.Io.net.Server` (socket) + `std.http.Server` (HTTP/1.1) so
+/// the CLI keeps a zero-dependency graph.
 const std = @import("std");
+const builtin = @import("builtin");
+const config = @import("config.zig");
 
-/// Serve static files from `web_dir` on localhost:`port`, then open the browser.
+/// Extension → Content-Type. WASM and JS are the load-bearing ones:
+/// browsers refuse to instantiate `application/wasm` served as
+/// `application/octet-stream` via the streaming path, and ES modules
+/// need a JS MIME type. The rest cover a typical asset bundle.
+const mime_table = [_]struct { ext: []const u8, ct: []const u8 }{
+    .{ .ext = ".wasm", .ct = "application/wasm" },
+    .{ .ext = ".js", .ct = "text/javascript" },
+    .{ .ext = ".mjs", .ct = "text/javascript" },
+    .{ .ext = ".html", .ct = "text/html; charset=utf-8" },
+    .{ .ext = ".css", .ct = "text/css" },
+    .{ .ext = ".json", .ct = "application/json" },
+    .{ .ext = ".png", .ct = "image/png" },
+    .{ .ext = ".jpg", .ct = "image/jpeg" },
+    .{ .ext = ".jpeg", .ct = "image/jpeg" },
+    .{ .ext = ".gif", .ct = "image/gif" },
+    .{ .ext = ".svg", .ct = "image/svg+xml" },
+    .{ .ext = ".ico", .ct = "image/x-icon" },
+    .{ .ext = ".wav", .ct = "audio/wav" },
+    .{ .ext = ".ogg", .ct = "audio/ogg" },
+    .{ .ext = ".ttf", .ct = "font/ttf" },
+    .{ .ext = ".woff2", .ct = "font/woff2" },
+};
+
+fn mimeFor(path: []const u8) []const u8 {
+    for (mime_table) |row| {
+        if (std.ascii.endsWithIgnoreCase(path, row.ext)) return row.ct;
+    }
+    return "application/octet-stream";
+}
+
+/// Serve static files from `web_dir` on 127.0.0.1:`port`, then open the
+/// browser. Blocks forever — returns only on a bind failure (the
+/// accept loop swallows per-connection errors so a flaky tab can't
+/// kill the server).
 pub fn serveAndOpen(allocator: std.mem.Allocator, web_dir: []const u8, port: u16) !void {
-    _ = allocator;
-    _ = port;
+    const io = config.globalIo();
+
+    const addr = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;
+    var server = addr.listen(io, .{ .reuse_address = true }) catch |err| {
+        std.debug.print(
+            "labelle: could not bind 127.0.0.1:{d} ({s}).\n" ++
+                "  Another server may already be on that port — try a different --port.\n",
+            .{ port, @errorName(err) },
+        );
+        return err;
+    };
+    defer server.deinit(io);
+
     std.debug.print(
-        \\labelle: WASM serve is not yet ported to std.Io.net (Zig 0.16 migration).
-        \\  Serve `{s}/zig-out/web/` manually with a static file server, e.g.
-        \\    python3 -m http.server --directory <web_dir> 8080
-        \\
-    , .{web_dir});
-    return error.NotImplemented;
+        "labelle: serving {s}\n" ++
+            "  Local:   http://127.0.0.1:{d}\n" ++
+            "  Press Ctrl+C to stop\n",
+        .{ web_dir, port },
+    );
+
+    openBrowser(allocator, port);
+
+    while (true) {
+        const stream = server.accept(io) catch |err| {
+            // Transient accept failures (e.g. the peer reset between
+            // the SYN and our accept) shouldn't take the server down.
+            std.debug.print("labelle: accept failed ({s}), continuing\n", .{@errorName(err)});
+            continue;
+        };
+        handleConnection(io, allocator, stream, web_dir) catch |err| {
+            std.debug.print("labelle: connection error ({s})\n", .{@errorName(err)});
+        };
+    }
+}
+
+/// Serve a single HTTP/1.1 request off `stream`, then close it.
+/// Connection: close — no keep-alive; the dev loop reopens per asset.
+fn handleConnection(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    stream: std.Io.net.Stream,
+    web_dir: []const u8,
+) !void {
+    defer stream.close(io);
+
+    var recv_buf: [16 * 1024]u8 = undefined;
+    var send_buf: [64 * 1024]u8 = undefined;
+    var stream_reader = stream.reader(io, &recv_buf);
+    var stream_writer = stream.writer(io, &send_buf);
+
+    var http_server = std.http.Server.init(&stream_reader.interface, &stream_writer.interface);
+
+    var request = http_server.receiveHead() catch |err| switch (err) {
+        // Browser closed the socket before sending a full request line
+        // (favicon probes, preconnect sockets) — nothing to answer.
+        error.HttpConnectionClosing => return,
+        else => return err,
+    };
+
+    if (request.head.method != .GET and request.head.method != .HEAD) {
+        try request.respond("405 Method Not Allowed\n", .{ .status = .method_not_allowed });
+        return;
+    }
+
+    const rel = resolveTarget(request.head.target);
+    if (rel == null) {
+        try request.respond("400 Bad Request\n", .{ .status = .bad_request });
+        return;
+    }
+
+    const file_path = try std.fs.path.join(allocator, &.{ web_dir, rel.? });
+    defer allocator.free(file_path);
+
+    const body = std.Io.Dir.cwd().readFileAlloc(io, file_path, allocator, .unlimited) catch |err| switch (err) {
+        error.FileNotFound => {
+            try request.respond("404 Not Found\n", .{ .status = .not_found });
+            return;
+        },
+        else => return err,
+    };
+    defer allocator.free(body);
+
+    try request.respond(body, .{
+        .status = .ok,
+        .extra_headers = &.{
+            .{ .name = "content-type", .value = mimeFor(rel.?) },
+            // WASM ships uncompressed and large; spare the browser a
+            // re-fetch across reloads within a dev session.
+            .{ .name = "cache-control", .value = "no-cache" },
+        },
+    });
+}
+
+/// Map an HTTP request target to a `web_dir`-relative path.
+/// Returns `null` for anything that escapes the served root.
+///
+///   "/"            → "index.html"
+///   "/game.wasm"   → "game.wasm"
+///   "/a/b.js?v=1"  → "a/b.js"
+///   "/../etc"      → null   (rejected)
+fn resolveTarget(target: []const u8) ?[]const u8 {
+    // Drop the query string / fragment.
+    var path = target;
+    if (std.mem.indexOfScalar(u8, path, '?')) |q| path = path[0..q];
+    if (std.mem.indexOfScalar(u8, path, '#')) |h| path = path[0..h];
+
+    if (path.len == 0 or path[0] != '/') return null;
+    path = path[1..]; // strip leading '/'
+    if (path.len == 0) return "index.html";
+
+    // Reject traversal. A '..' segment or an embedded NUL would let a
+    // request walk out of `web_dir`.
+    if (std.mem.indexOfScalar(u8, path, 0) != null) return null;
+    var it = std.mem.splitScalar(u8, path, '/');
+    while (it.next()) |seg| {
+        if (std.mem.eql(u8, seg, "..")) return null;
+    }
+    return path;
+}
+
+/// Best-effort browser launch. A failure here is non-fatal — the
+/// server is already up and the URL is printed; the user can open it
+/// by hand.
+fn openBrowser(allocator: std.mem.Allocator, port: u16) void {
+    const io = config.globalIo();
+    const url = std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{port}) catch return;
+    defer allocator.free(url);
+
+    const argv: []const []const u8 = switch (builtin.os.tag) {
+        .macos => &.{ "open", url },
+        .windows => &.{ "cmd", "/c", "start", "", url },
+        else => &.{ "xdg-open", url },
+    };
+
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch return;
+    _ = child.wait(io) catch return;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+test "resolveTarget: root maps to index.html" {
+    try std.testing.expectEqualStrings("index.html", resolveTarget("/").?);
+}
+
+test "resolveTarget: plain file" {
+    try std.testing.expectEqualStrings("game.wasm", resolveTarget("/game.wasm").?);
+}
+
+test "resolveTarget: nested path" {
+    try std.testing.expectEqualStrings("assets/atlas.png", resolveTarget("/assets/atlas.png").?);
+}
+
+test "resolveTarget: strips query string" {
+    try std.testing.expectEqualStrings("game.js", resolveTarget("/game.js?v=42").?);
+}
+
+test "resolveTarget: strips fragment" {
+    try std.testing.expectEqualStrings("index.html", resolveTarget("/index.html#top").?);
+}
+
+test "resolveTarget: rejects parent traversal" {
+    try std.testing.expect(resolveTarget("/../etc/passwd") == null);
+    try std.testing.expect(resolveTarget("/assets/../../secret") == null);
+}
+
+test "resolveTarget: rejects embedded NUL" {
+    try std.testing.expect(resolveTarget("/game\x00.wasm") == null);
+}
+
+test "resolveTarget: rejects target without leading slash" {
+    try std.testing.expect(resolveTarget("game.wasm") == null);
+    try std.testing.expect(resolveTarget("") == null);
+}
+
+test "resolveTarget: a literal '..' segment only — not a substring" {
+    // "..foo" is a legitimate filename, not traversal.
+    try std.testing.expectEqualStrings("..foo.txt", resolveTarget("/..foo.txt").?);
+}
+
+test "mimeFor: known extensions" {
+    try std.testing.expectEqualStrings("application/wasm", mimeFor("game.wasm"));
+    try std.testing.expectEqualStrings("text/javascript", mimeFor("game.js"));
+    try std.testing.expectEqualStrings("text/html; charset=utf-8", mimeFor("index.html"));
+}
+
+test "mimeFor: case-insensitive extension match" {
+    try std.testing.expectEqualStrings("image/png", mimeFor("LOGO.PNG"));
+}
+
+test "mimeFor: unknown extension falls back to octet-stream" {
+    try std.testing.expectEqualStrings("application/octet-stream", mimeFor("data.bin"));
+}
+
+/// Accept `n` connections then return — the test side of the loop in
+/// `serveAndOpen`. Lives in a thread so the test's request side can
+/// drive the real `std.Io.net` round-trip in-process.
+fn testServeN(io: std.Io, alloc: std.mem.Allocator, server: *std.Io.net.Server, web_dir: []const u8, n: usize) void {
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        const stream = server.accept(io) catch return;
+        handleConnection(io, alloc, stream, web_dir) catch {};
+    }
+}
+
+test "handleConnection: serves a file, 404s a miss, 400s traversal" {
+    const alloc = std.testing.allocator;
+    const io = std.testing.io;
+
+    // web_dir = /tmp; the served file is a uniquely-named sibling so
+    // the test needs no directory creation.
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = "/tmp/labelle_serve_test.html",
+        .data = "<h1>hi</h1>",
+    });
+
+    const bind = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
+    var server = try bind.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+
+    var sa: std.posix.sockaddr.in = undefined;
+    var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
+    _ = std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len);
+    const port = std.mem.bigToNative(u16, sa.port);
+
+    const t = try std.Thread.spawn(.{}, testServeN, .{ io, alloc, &server, "/tmp", @as(usize, 3) });
+    defer t.join();
+
+    const peer = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;
+    const Case = struct { target: []const u8, want: []const u8 };
+    for ([_]Case{
+        .{ .target = "/labelle_serve_test.html", .want = "<h1>hi</h1>" },
+        .{ .target = "/no_such_file.wasm", .want = "404" },
+        .{ .target = "/../../etc/passwd", .want = "400" },
+    }) |case| {
+        const s = try peer.connect(io, .{ .mode = .stream });
+        defer s.close(io);
+        var wbuf: [512]u8 = undefined;
+        var w = s.writer(io, &wbuf);
+        try w.interface.print(
+            "GET {s} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+            .{case.target},
+        );
+        try w.interface.flush();
+
+        var rbuf: [8192]u8 = undefined;
+        var r = s.reader(io, &rbuf);
+        const resp = try r.interface.allocRemaining(alloc, .unlimited);
+        defer alloc.free(resp);
+        try std.testing.expect(std.mem.indexOf(u8, resp, case.want) != null);
+    }
 }

--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -121,15 +121,27 @@ fn handleConnection(
     const file_path = try std.fs.path.join(allocator, &.{ web_dir, rel.? });
     defer allocator.free(file_path);
 
-    const body = std.Io.Dir.cwd().readFileAlloc(io, file_path, allocator, .unlimited) catch |err| switch (err) {
+    // Cap the read so a stray huge file in `web_dir` can't OOM the
+    // server. 1 GiB is generous for a WASM bundle + assets.
+    const max_file_bytes = 1024 * 1024 * 1024;
+    const body = std.Io.Dir.cwd().readFileAlloc(io, file_path, allocator, .limited(max_file_bytes)) catch |err| switch (err) {
         error.FileNotFound => {
             try request.respond("404 Not Found\n", .{ .status = .not_found });
+            return;
+        },
+        // `readFileAlloc` reports a too-large file as a stream-limit
+        // error; answer 413 instead of letting the connection die.
+        error.StreamTooLong => {
+            try request.respond("413 Payload Too Large\n", .{ .status = .payload_too_large });
             return;
         },
         else => return err,
     };
     defer allocator.free(body);
 
+    // `request.respond` omits the body for HEAD requests automatically
+    // while still emitting a `content-length` reflecting the real file
+    // size, so passing the full `body` is correct for GET and HEAD.
     try request.respond(body, .{
         .status = .ok,
         .extra_headers = &.{
@@ -148,6 +160,8 @@ fn handleConnection(
 ///   "/game.wasm"   → "game.wasm"
 ///   "/a/b.js?v=1"  → "a/b.js"
 ///   "/../etc"      → null   (rejected)
+///   "/..\\win.ini" → null   (rejected — backslash)
+///   "//etc/passwd" → null   (rejected — still absolute)
 fn resolveTarget(target: []const u8) ?[]const u8 {
     // Drop the query string / fragment.
     var path = target;
@@ -155,8 +169,21 @@ fn resolveTarget(target: []const u8) ?[]const u8 {
     if (std.mem.indexOfScalar(u8, path, '#')) |h| path = path[0..h];
 
     if (path.len == 0 or path[0] != '/') return null;
+
+    // Reject any backslash outright. A legit web asset path never has
+    // one, and on Windows '\' is a path separator — so a target like
+    // "/..\..\windows\win.ini" would otherwise be a single segment
+    // that dodges the '..' check below and escapes `web_dir`.
+    if (std.mem.indexOfScalar(u8, path, '\\') != null) return null;
+
     path = path[1..]; // strip leading '/'
     if (path.len == 0) return "index.html";
+
+    // A second leading '/' (e.g. "//etc/passwd") would leave the path
+    // absolute after the strip above and flow straight into
+    // `std.fs.path.join`, escaping `web_dir`. Reject anything still
+    // absolute.
+    if (path[0] == '/') return null;
 
     // Reject traversal. A '..' segment or an embedded NUL would let a
     // request walk out of `web_dir`.
@@ -218,6 +245,21 @@ test "resolveTarget: rejects parent traversal" {
     try std.testing.expect(resolveTarget("/assets/../../secret") == null);
 }
 
+test "resolveTarget: rejects backslash (Windows separator traversal)" {
+    // On Windows '\' is a path separator, so "/..\..\win.ini" would be
+    // a single segment that dodges the '..' check. Reject any '\'.
+    try std.testing.expect(resolveTarget("/..\\..\\windows\\win.ini") == null);
+    try std.testing.expect(resolveTarget("/assets\\atlas.png") == null);
+    try std.testing.expect(resolveTarget("/a\\b") == null);
+}
+
+test "resolveTarget: rejects double-slash (still absolute)" {
+    // "//etc/passwd" stays absolute after stripping one leading slash
+    // and would escape web_dir via path.join.
+    try std.testing.expect(resolveTarget("//etc/passwd") == null);
+    try std.testing.expect(resolveTarget("///etc/passwd") == null);
+}
+
 test "resolveTarget: rejects embedded NUL" {
     try std.testing.expect(resolveTarget("/game\x00.wasm") == null);
 }
@@ -257,27 +299,41 @@ fn testServeN(io: std.Io, alloc: std.mem.Allocator, server: *std.Io.net.Server, 
     }
 }
 
+/// Bind 127.0.0.1 on the first free port in a fixed candidate range.
+/// Avoids needing `getsockname` to discover a port-0 assignment —
+/// that symbol isn't linked in Zig's Windows std, so the port-0 +
+/// getsockname trick fails to compile on Windows.
+fn testBindFreePort(io: std.Io) ?struct { server: std.Io.net.Server, port: u16 } {
+    var port: u16 = 49500;
+    while (port < 49600) : (port += 1) {
+        const addr = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;
+        const server = addr.listen(io, .{ .reuse_address = true }) catch continue;
+        return .{ .server = server, .port = port };
+    }
+    return null;
+}
+
 test "handleConnection: serves a file, 404s a miss, 400s traversal" {
     const alloc = std.testing.allocator;
     const io = std.testing.io;
 
-    // web_dir = /tmp; the served file is a uniquely-named sibling so
-    // the test needs no directory creation.
-    try std.Io.Dir.cwd().writeFile(io, .{
-        .sub_path = "/tmp/labelle_serve_test.html",
+    // Portable, auto-cleaned temp dir under .zig-cache/tmp/<sub_path>.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const web_dir = try std.fs.path.join(alloc, &.{ ".zig-cache", "tmp", &tmp.sub_path });
+    defer alloc.free(web_dir);
+
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "labelle_serve_test.html",
         .data = "<h1>hi</h1>",
     });
 
-    const bind = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
-    var server = try bind.listen(io, .{ .reuse_address = true });
+    const bound = testBindFreePort(io) orelse return error.NoFreePort;
+    var server = bound.server;
+    const port = bound.port;
     defer server.deinit(io);
 
-    var sa: std.posix.sockaddr.in = undefined;
-    var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
-    _ = std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len);
-    const port = std.mem.bigToNative(u16, sa.port);
-
-    const t = try std.Thread.spawn(.{}, testServeN, .{ io, alloc, &server, "/tmp", @as(usize, 3) });
+    const t = try std.Thread.spawn(.{}, testServeN, .{ io, alloc, &server, web_dir, @as(usize, 3) });
     defer t.join();
 
     const peer = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;


### PR DESCRIPTION
Closes #2.

## Summary

Two commits land issue #2 — a dedicated command to build and serve a
WASM build locally.

### 1. `fix(serve)`: re-port the WASM static file server to Zig 0.16

`src/cli/serve.zig`'s `serveAndOpen` had regressed to a stub during the
0.16 migration. It is re-ported as a real static file server built
directly on `std.Io.net.Server` + `std.http.Server` (zero added
dependencies): correct MIME types (`application/wasm`, `text/javascript`
for ES modules, etc.), `..`/NUL path-traversal rejection, `404`/`400`/
`405` handling, and an accept loop that swallows per-connection errors.
In-file `test` blocks cover `resolveTarget`, `mimeFor`, and a full
`handleConnection` round-trip.

### 2. `feat(wasm)`: add the `labelle wasm serve` subcommand

```
labelle wasm serve              # build WASM if needed, serve, open browser
labelle wasm serve --port 3000  # custom port (default 8080)
labelle wasm serve --no-build   # serve the existing build, skip building
labelle wasm serve --no-open    # don't auto-open the browser
```

- New `wasm` command namespace with a `serve` subcommand, parsed in the
  established `cli.zig` style; `parseWasmServeArgs` has nested-struct
  zspec coverage.
- Unless `--no-build`, it forces `platform = wasm` and runs the same
  generate + `zig build` pipeline `labelle build --platform=wasm` uses,
  then serves `<target_dir>/zig-out/web`.
- `--no-build` short-circuits the pipeline and serves the existing
  `.labelle/<backend>_wasm/zig-out/web`, with a clear error if no build
  is present.
- `serveAndOpen` gains an `open_browser_tab` bool so `--no-open` can
  suppress the launch; the one other caller (the wasm branch of `run`)
  is updated.
- `labelle --help` and the file header document the new command.

## Deferred — `--watch`

The `--watch` mode from the #2 proposal (file-watch + rebuild + browser
live-reload) is **not** in this PR — it needs a file watcher and an
SSE/WebSocket reload channel, too large to bundle here. Tracked as a
follow-up: labelle-toolkit/labelle-cli#208.

## Build / test

- `zig build` is green.
- Functionally verified: built the binary, ran `labelle wasm serve
  --no-build --no-open` against a fixture build dir, and `curl`ed the
  port — `index.html`, `application/wasm` MIME, and `404`s all behave;
  `--no-open` and `--port` honored.
- `zig build test` is currently broken in this environment for reasons
  unrelated to this work (a transitive `flow-codegen` sibling-path
  dependency fails to resolve, plus an `optimize=Fast` test-runner
  trip). Pre-existing and out of scope; the added tests are in-file
  `test` blocks and run in CI.