### PR TITLE
chore: bump labelle-assembler pin to 0.31.0 (flow-codegen URL dep)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,14 +10,15 @@
         // below to pick up new assembler types; the old mirror
         // approach made every assembler change a double-edit (#151).
         .labelle_assembler = .{
-            // Pinned to labelle-assembler feat/android-immersive-mode —
-            // adds `AndroidConfig.immersive_mode`, consumed by
-            // `generateAndroidManifest()` to emit the fullscreen theme.
-            // Use the full 40-char SHA — abbreviated SHAs in archive
-            // URLs can become ambiguous as upstream gains commits and
-            // GitHub will return 404 in that case.
-            .url = "git+https://github.com/labelle-toolkit/labelle-assembler.git#63e4f84f90df8e16e0aa53746ed089ce5a6e1759",
-            .hash = "labelle_assembler-0.27.0-pG4XEJrMBwCEDYrNr8cd71lGt-u7aRK4R7az5TivXCXh",
+            // Pinned to labelle-assembler 0.31.0 (#155) — depends on
+            // flow-codegen by URL instead of the `../labelle-gui`
+            // sibling path, so labelle-cli (and anything that fetches
+            // it, e.g. the flying-platform fly.io deploy) resolves
+            // cleanly. Use the full 40-char SHA — abbreviated SHAs in
+            // archive URLs can become ambiguous as upstream gains
+            // commits and GitHub will return 404 in that case.
+            .url = "git+https://github.com/labelle-toolkit/labelle-assembler.git#ec4c7e19d2eb736f573f9ca1e50eb1db2007c065",
+            .hash = "labelle_assembler-0.31.0-pG4XEBTfBwD9J_KehQsowaHW9Pj1ms7vHijCgChxcFsx",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",


### PR DESCRIPTION
labelle-cli pinned `labelle-assembler` at `63e4f84` (0.27.0), which declared `flow_codegen` as `.path = "../labelle-gui/flow-codegen"` — a sibling path that doesn't exist when `labelle-assembler` is fetched as a dependency. Building `labelle-cli` from source failed:

```
unable to open '.../labelle-cli/zig-pkg/labelle-gui/flow-codegen': FileNotFound
```

That is what broke the `flying-platform-labelle` fly.io deploy — its workflow builds `labelle-cli` from `main`.

This bumps the pin to assembler **0.31.0** (`ec4c7e1`, [labelle-assembler#155](https://github.com/labelle-toolkit/labelle-assembler/pull/155)), where `flow-codegen` is its own URL-pinned repo. Verified with `zig build -Doptimize=ReleaseSafe` — the exact deploy build step — which now succeeds.

Last in the cascade: flow-codegen repo created · labelle-assembler #155 (merged) · labelle-gui #150 · this PR. Once this lands, the fly.io deploy recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)