### PR TITLE
Write .initial_prefab from the --scene plumbing (#565)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -652,9 +652,11 @@ pub fn main(proc_init: std.process.Init) !void {
         return;
     };
 
-    // Apply --scene override
+    // Normalize the deprecated `.initial_scene` alias (RFC #560 / #565)
+    // into `.initial_prefab`, then apply the --scene override on top.
+    parsed.normalizeInitialPrefab();
     if (parsed_args.scene_override) |scene| {
-        parsed.initial_scene = scene;
+        parsed.initial_prefab = scene;
     }
 
     // Apply --platform override

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1258,3 +1258,52 @@ pub const AppendRunForwardedArgsSpec = struct {
         try std.testing.expectEqualStrings("127.0.0.1:54321", argv.items[2]);
     }
 };
+
+/// Regression tests for the `--scene` / `.initial_prefab` override chain
+/// introduced in RFC #560 / issue #565.  Covers the four cases that the
+/// CLI logic at cli.zig:650-655 must handle correctly:
+///
+///  1. Legacy `.initial_scene` is promoted to `.initial_prefab` when the new
+///     field is absent.
+///  2. `.initial_prefab` wins when both fields are present in the config.
+///  3. A `--scene` CLI override applied *after* normalization takes precedence
+///     over whatever the config file said (legacy or new).
+///  4. Neither field set → normalization is a no-op (null stays null).
+pub const InitialPrefabNormalizationSpec = struct {
+    test "normalizeInitialPrefab promotes legacy initial_scene when initial_prefab is null" {
+        var cfg = project_config.ProjectConfig{ .name = "test_project", .initial_scene = "legacy_scene" };
+        cfg.normalizeInitialPrefab();
+        try std.testing.expectEqualStrings("legacy_scene", cfg.initial_prefab.?);
+        try std.testing.expectEqual(@as(?[]const u8, null), cfg.initial_scene);
+    }
+
+    test "normalizeInitialPrefab keeps initial_prefab when both fields are set" {
+        var cfg = project_config.ProjectConfig{ .name = "test_project", .initial_prefab = "new_prefab", .initial_scene = "legacy_scene" };
+        cfg.normalizeInitialPrefab();
+        try std.testing.expectEqualStrings("new_prefab", cfg.initial_prefab.?);
+        try std.testing.expectEqual(@as(?[]const u8, null), cfg.initial_scene);
+    }
+
+    test "--scene override takes precedence over normalized initial_scene" {
+        var cfg = project_config.ProjectConfig{ .name = "test_project", .initial_scene = "legacy_scene" };
+        cfg.normalizeInitialPrefab();
+        // Simulate the --scene CLI override applied after normalization (cli.zig:653-655)
+        cfg.initial_prefab = "override_scene";
+        try std.testing.expectEqualStrings("override_scene", cfg.initial_prefab.?);
+    }
+
+    test "--scene override takes precedence over initial_prefab from config" {
+        var cfg = project_config.ProjectConfig{ .name = "test_project", .initial_prefab = "config_prefab" };
+        cfg.normalizeInitialPrefab();
+        // Simulate the --scene CLI override applied after normalization
+        cfg.initial_prefab = "override_scene";
+        try std.testing.expectEqualStrings("override_scene", cfg.initial_prefab.?);
+    }
+
+    test "normalizeInitialPrefab is a no-op when neither field is set" {
+        var cfg = project_config.ProjectConfig{ .name = "test_project" };
+        cfg.normalizeInitialPrefab();
+        try std.testing.expectEqual(@as(?[]const u8, null), cfg.initial_prefab);
+        try std.testing.expectEqual(@as(?[]const u8, null), cfg.initial_scene);
+    }
+};

--- a/src/cli/project_config.zig
+++ b/src/cli/project_config.zig
@@ -245,7 +245,16 @@ pub const ProjectConfig = struct {
     gfx_version: []const u8 = GFX_VERSION,
     labelle_version: []const u8 = CLI_VERSION,
 
-    /// Explicit initial scene name.
+    /// Explicit initial prefab name. RFC #560 / issue #565 (unify scenes
+    /// and prefabs) renamed `.initial_scene` to `.initial_prefab`. The
+    /// legacy `.initial_scene` field below is still accepted for backward
+    /// compatibility but is deprecated; `initial_prefab` wins when both
+    /// are set. Mirrors `labelle-assembler` `src/config.zig`.
+    initial_prefab: ?[]const u8 = null,
+    /// Deprecated legacy alias for `initial_prefab`. Still accepted in
+    /// `project.labelle` so existing projects keep parsing; when both are
+    /// set, `initial_prefab` wins. Prefer reading
+    /// `resolvedInitialPrefab()` instead of this field directly.
     initial_scene: ?[]const u8 = null,
     /// Sprite atlas / sound / font resources.
     resources: []const ResourceDef = &.{},
@@ -290,5 +299,34 @@ pub const ProjectConfig = struct {
     /// Returns true if a GUI plugin is resolved and active.
     pub fn hasGui(self: ProjectConfig) bool {
         return self.resolved_gui != null;
+    }
+
+    /// Returns the effective initial-prefab name, preferring the new
+    /// `initial_prefab` field and falling back to the deprecated
+    /// `initial_scene` legacy alias. `initial_prefab` wins when both are
+    /// set. Mirrors `labelle-assembler` `src/config.zig`.
+    pub fn resolvedInitialPrefab(self: ProjectConfig) ?[]const u8 {
+        return self.initial_prefab orelse self.initial_scene;
+    }
+
+    /// Normalizes the deprecated `initial_scene` alias into
+    /// `initial_prefab` and clears the legacy field. Emits a deprecation
+    /// warning when the legacy alias was present. RFC #560 / issue #565.
+    pub fn normalizeInitialPrefab(self: *ProjectConfig) void {
+        if (self.initial_scene) |legacy| {
+            if (self.initial_prefab == null) {
+                std.debug.print(
+                    "project.labelle: `.initial_scene` is deprecated; rename it to `.initial_prefab` (`.initial_scene` will be removed in a future release)\n",
+                    .{},
+                );
+                self.initial_prefab = legacy;
+            } else {
+                std.debug.print(
+                    "project.labelle: both `.initial_prefab` and `.initial_scene` are set; `.initial_scene` is deprecated and ignored\n",
+                    .{},
+                );
+            }
+            self.initial_scene = null;
+        }
     }
 };


### PR DESCRIPTION
The labelle-cli companion to the `.initial_scene` → `.initial_prefab` rename — ticket #565, RFC #560. Pairs with labelle-assembler PR #156.

## Changes

- `src/cli.zig` — the `--scene` override now writes `parsed.initial_prefab`; calls `normalizeInitialPrefab()` after parsing `project.labelle`.
- `build.zig.zon` — pins `labelle_assembler` to the #565 assembler branch commit (which defines `initial_prefab` / `normalizeInitialPrefab`).

## Tests

`zig build test` — 88/88 pass against the assembler #565 branch (verified during implementation).

## Caveats — please read

1. **Stacked on labelle-assembler PR #156.** This branch pins `labelle_assembler` to that PR's branch-tip commit. Once #156 squash-merges, re-pin `build.zig.zon` to the merge commit so this branch resolves cleanly. A comment in `build.zig.zon` says so.
2. **CI build of this branch is currently blocked by an unrelated issue** — the in-flight `flow-codegen` extraction in `labelle-gui` (a transitive path dependency of the assembler). This is pre-existing and affects any CLI build right now, not #565. The #565 code change itself is verified (88/88, above). Holding merge until the flow-codegen extraction settles is expected.

Resolves #565 (CLI side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)