### PR TITLE
Delegate install / clean / upgrade to the assembler binary (#217 phase 1)

### DIFF
--- a/src/cli/assembler_proc.zig
+++ b/src/cli/assembler_proc.zig
@@ -1,0 +1,129 @@
+//! Reusable CLI → assembler subprocess-invocation helper.
+//!
+//! Issue #217 makes `labelle-cli` a thin driver over the standalone
+//! `labelle-assembler` binary: the CLI parses argv, locates the binary,
+//! and forwards a subcommand to it as a subprocess. This module is the
+//! one place that knows how to do that — phase 1 uses it for the cache
+//! commands (`install` / `clean` / `upgrade`); later phases reuse it for
+//! `generate` / `build` / `run` / `init`.
+//!
+//! What it does:
+//!   - locates the assembler binary (env var > project.labelle pin >
+//!     CLI-paired default), via `assembler.zig`'s existing resolver,
+//!   - spawns `labelle-assembler <subcommand> [args...]` with inherited
+//!     stdio (the binary's output streams straight to the user),
+//!   - waits and maps the child's exit code onto a Zig error so callers
+//!     can propagate failure.
+//!
+//! Bootstrap caveat: the assembler can't fetch itself, so the CLI must
+//! locate the binary before delegating. `assembler.resolveAssembler`
+//! reads `assembler_version` from project.labelle. Cache commands may run
+//! with no project.labelle in cwd (e.g. `labelle clean` from anywhere);
+//! in that case `resolveAssembler` returns null and we fall back to
+//! `assembler.resolveDefault`, which resolves/downloads the assembler
+//! version paired with this CLI build (`assembler.DEFAULT_ASSEMBLER_VERSION`).
+//! See `runSubcommand` for the exact resolution order.
+
+const std = @import("std");
+const config = @import("config.zig");
+const assembler = @import("assembler.zig");
+
+/// A located assembler binary, ready to be invoked. Returned by `resolve`
+/// so a caller that runs several subcommands can resolve once and reuse.
+pub const Assembler = struct {
+    /// Absolute path to the `labelle-assembler` executable. Heap-owned.
+    path: []u8,
+
+    /// Free the owned path.
+    pub fn deinit(self: Assembler, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+    }
+
+    /// Run `labelle-assembler <subcommand> [args...]` with inherited
+    /// stdio. See `runSubcommand` for exit-code semantics.
+    pub fn run(
+        self: Assembler,
+        allocator: std.mem.Allocator,
+        subcommand: []const u8,
+        args: []const []const u8,
+    ) !void {
+        return spawnAndWait(allocator, self.path, subcommand, args);
+    }
+};
+
+/// Locate the assembler binary.
+///
+/// Resolution order (delegated to `assembler.zig`):
+///   1. `LABELLE_ASSEMBLER` env var — local-dev override.
+///   2. `assembler_version` in `<project_dir>/project.labelle` — the
+///      pinned version, resolved from (or downloaded into) the cache.
+///   3. No project / no pin — the assembler version paired with this CLI
+///      build (`assembler.DEFAULT_ASSEMBLER_VERSION`), downloaded if absent.
+///
+/// `project_dir` is where the CLI looks for `project.labelle`. Pass `"."`
+/// for commands that may run outside a project (the resolver tolerates a
+/// missing manifest and falls through to step 3).
+///
+/// Caller owns the returned `Assembler` and must `deinit` it.
+pub fn resolve(allocator: std.mem.Allocator, project_dir: []const u8) !Assembler {
+    const path = try assembler.resolveAssembler(allocator, project_dir) orelse
+        try assembler.resolveDefault(allocator);
+    return .{ .path = path };
+}
+
+/// One-shot convenience: locate the assembler and run a single subcommand.
+/// Equivalent to `resolve` + `Assembler.run` + `deinit`.
+///
+/// On a non-zero exit code, returns `error.AssemblerFailed`; the binary's
+/// own stderr (inherited) already explains the failure.
+pub fn runSubcommand(
+    allocator: std.mem.Allocator,
+    project_dir: []const u8,
+    subcommand: []const u8,
+    args: []const []const u8,
+) !void {
+    const asm_bin = try resolve(allocator, project_dir);
+    defer asm_bin.deinit(allocator);
+    try asm_bin.run(allocator, subcommand, args);
+}
+
+/// Spawn `exe_path <subcommand> [args...]`, inherit stdio, wait, and map
+/// the result onto a Zig error. Shared by `Assembler.run` and
+/// `runSubcommand`.
+fn spawnAndWait(
+    allocator: std.mem.Allocator,
+    exe_path: []const u8,
+    subcommand: []const u8,
+    args: []const []const u8,
+) !void {
+    const io = config.globalIo();
+
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    try argv.append(allocator, subcommand);
+    try argv.appendSlice(allocator, args);
+
+    var child = std.process.spawn(io, .{
+        .argv = argv.items,
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| {
+        std.debug.print("labelle: could not launch assembler '{s}': {any}\n", .{ exe_path, err });
+        return error.AssemblerFailed;
+    };
+
+    const term = try child.wait(io);
+    switch (term) {
+        .exited => |code| if (code != 0) {
+            // The assembler already printed a diagnostic on its inherited
+            // stderr; surface the code so the CLI exits non-zero too.
+            return error.AssemblerFailed;
+        },
+        else => {
+            std.debug.print("labelle: assembler '{s}' terminated abnormally\n", .{exe_path});
+            return error.AssemblerFailed;
+        },
+    }
+}

--- a/src/cli/clean.zig
+++ b/src/cli/clean.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
-const gen = @import("generator");
-const config = @import("config.zig");
+const assembler_proc = @import("assembler_proc.zig");
 
 /// Remove unused cached package versions from ~/.labelle/packages/.
+///
+/// Issue #217 phase 1: delegated to the standalone `labelle-assembler`
+/// binary (`labelle-assembler clean ...`). The CLI keeps the same
+/// user-facing flags — `--dry-run` and `--project=<dir>` — and translates
+/// `--project=` to the assembler's `--project-root`.
 pub fn cmdClean(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
     var dry_run = false;
     var project_dir: []const u8 = ".";
@@ -18,93 +22,13 @@ pub fn cmdClean(allocator: std.mem.Allocator, cmd_args: []const []const u8) !voi
         }
     }
 
-    const packages_dir = gen.getPackagesDir(allocator) catch {
-        std.debug.print("labelle: could not determine packages directory\n", .{});
-        return;
-    };
-    defer allocator.free(packages_dir);
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    if (dry_run) try argv.append(allocator, "--dry-run");
+    try argv.appendSlice(allocator, &.{ "--project-root", project_dir });
 
-    std.debug.print("labelle: scanning {s}...\n", .{packages_dir});
-
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    const arena_alloc = arena.allocator();
-
-    var kept = std.StringHashMap(std.StringHashMap(void)).init(arena_alloc);
-
-    const pkg_names = [_][]const u8{ "core", "engine", "gfx", "cli" };
-    const default_versions = [_][]const u8{ gen.CORE_VERSION, gen.ENGINE_VERSION, gen.GFX_VERSION, gen.CLI_VERSION };
-
-    for (pkg_names, 0..) |name, i| {
-        var version_set = std.StringHashMap(void).init(arena_alloc);
-        try version_set.put(default_versions[i], {});
-        try kept.put(name, version_set);
-    }
-
-    var project_arena = std.heap.ArenaAllocator.init(allocator);
-    defer project_arena.deinit();
-    if (config.readProjectConfigQuiet(project_arena.allocator(), project_dir)) |cfg| {
-        const project_refs = [_]struct { name: []const u8, version: []const u8 }{
-            .{ .name = "core", .version = cfg.core_version },
-            .{ .name = "engine", .version = cfg.engine_version },
-            .{ .name = "gfx", .version = cfg.gfx_version },
-            .{ .name = "cli", .version = cfg.labelle_version },
-        };
-        for (project_refs) |ref| {
-            if (gen.isLocalVersion(ref.version)) continue;
-            if (kept.getPtr(ref.name)) |set| {
-                try set.put(ref.version, {});
-            }
-        }
-        std.debug.print("  found project.labelle in '{s}'\n", .{project_dir});
-    } else |_| {
-        std.debug.print("  no project.labelle found — keeping CLI default versions only\n", .{});
-    }
-
-    var removed_count: u32 = 0;
-
-    const io = config.globalIo();
-    for (pkg_names) |pkg_name| {
-        const pkg_dir_path = std.fs.path.join(arena_alloc, &.{ packages_dir, pkg_name }) catch continue;
-
-        var pkg_dir = std.Io.Dir.cwd().openDir(io, pkg_dir_path, .{ .iterate = true }) catch continue;
-        defer pkg_dir.close(io);
-
-        const version_set = kept.get(pkg_name) orelse continue;
-
-        var iter = pkg_dir.iterate();
-        while (iter.next(io) catch null) |entry| {
-            if (entry.kind != .directory and entry.kind != .sym_link) continue;
-
-            if (version_set.contains(entry.name)) continue;
-
-            if (dry_run) {
-                std.debug.print("  would remove {s}/{s}\n", .{ pkg_name, entry.name });
-            } else {
-                const full_path = std.fs.path.join(arena_alloc, &.{ pkg_dir_path, entry.name }) catch continue;
-
-                if (entry.kind == .sym_link) {
-                    std.Io.Dir.cwd().deleteFile(io, full_path) catch |err| {
-                        std.debug.print("  could not remove {s}/{s}: {any}\n", .{ pkg_name, entry.name, err });
-                        continue;
-                    };
-                } else {
-                    std.Io.Dir.cwd().deleteTree(io, full_path) catch |err| {
-                        std.debug.print("  could not remove {s}/{s}: {any}\n", .{ pkg_name, entry.name, err });
-                        continue;
-                    };
-                }
-                std.debug.print("  removed {s}/{s}\n", .{ pkg_name, entry.name });
-            }
-            removed_count += 1;
-        }
-    }
-
-    if (removed_count == 0) {
-        std.debug.print("  nothing to clean\n", .{});
-    } else if (dry_run) {
-        std.debug.print("  {d} version(s) would be removed (use without --dry-run to delete)\n", .{removed_count});
-    } else {
-        std.debug.print("  cleaned {d} old version(s)\n", .{removed_count});
-    }
+    // `clean` can run from anywhere — pass project_dir so the assembler
+    // resolver checks that project's pinned version; with no
+    // project.labelle it falls back to the CLI-paired default.
+    try assembler_proc.runSubcommand(allocator, project_dir, "clean", argv.items);
 }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1,12 +1,16 @@
 const std = @import("std");
-const gen = @import("generator");
-const config = @import("config.zig");
-const cache = @import("cache.zig");
 const assembler = @import("assembler.zig");
+const assembler_proc = @import("assembler_proc.zig");
 
 /// Fetch and cache packages without modifying any project.
+///
+/// Issue #217 phase 1: package-cache work is delegated to the standalone
+/// `labelle-assembler` binary (`labelle-assembler install ...`). The one
+/// exception is `install assembler <version>`, which downloads the
+/// assembler *binary* itself — a CLI-owned bootstrap concern the
+/// assembler can't perform for itself.
 pub fn cmdInstall(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
-    // Handle `labelle install assembler <version>` and `labelle install assembler`
+    // `labelle install assembler <version>` — CLI bootstrap. Stays here.
     if (cmd_args.len >= 1 and std.mem.eql(u8, cmd_args[0], "assembler")) {
         if (cmd_args.len < 2) {
             std.debug.print("labelle install assembler: missing version argument\n", .{});
@@ -17,60 +21,24 @@ pub fn cmdInstall(allocator: std.mem.Allocator, cmd_args: []const []const u8) !v
         return assembler.cmdInstallAssembler(allocator, cmd_args[1]);
     }
 
+    // Every other form delegates to the assembler binary.
+    //
+    //   labelle install               → install deps for current project
+    //   labelle install <version>     → cache core/engine/gfx at a version
+    //   labelle install <pkg> <ver>   → cache one package
+    //
+    // The assembler `install` subcommand takes the project form via
+    // `--project-root`; the version/package forms are bare positionals.
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+
     if (cmd_args.len == 0) {
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        defer arena.deinit();
-        const parsed = config.readProjectConfig(arena.allocator(), ".") catch {
-            std.debug.print("labelle install: no project.labelle found. Usage:\n", .{});
-            std.debug.print("  labelle install              — install deps for current project\n", .{});
-            std.debug.print("  labelle install <version>    — cache all packages at a version\n", .{});
-            std.debug.print("  labelle install core <ver>   — cache a specific package\n", .{});
-            return error.MissingArgument;
-        };
-        try cache.ensureCache(allocator, parsed);
-        std.debug.print("labelle: all packages cached\n", .{});
-        return;
-    }
-
-    if (cmd_args.len == 1) {
-        const version = cmd_args[0];
-        std.debug.print("labelle: caching all packages at version {s}...\n", .{version});
-
-        const packages = [_][]const u8{ "core", "engine", "gfx" };
-        for (packages) |pkg| {
-            if (!try gen.isFrameworkCached(allocator, pkg, version)) {
-                std.debug.print("  fetching {s} {s}...\n", .{ pkg, version });
-                try cache.fetchFrameworkWithFallback(allocator, pkg, version);
-            } else {
-                std.debug.print("  {s} {s} already cached\n", .{ pkg, version });
-            }
-        }
-
-        if (!try gen.isAssemblerCached(allocator, version)) {
-            std.debug.print("  fetching assembler {s}...\n", .{version});
-            try cache.fetchAssemblerWithFallback(allocator, version);
-        } else {
-            std.debug.print("  assembler {s} already cached\n", .{version});
-        }
-
-        std.debug.print("labelle: done\n", .{});
-        return;
-    }
-
-    const pkg_name = cmd_args[0];
-    const version = cmd_args[1];
-
-    if (std.mem.eql(u8, pkg_name, "core") or std.mem.eql(u8, pkg_name, "engine") or std.mem.eql(u8, pkg_name, "gfx")) {
-        std.debug.print("labelle: fetching {s} {s}...\n", .{ pkg_name, version });
-        try cache.fetchFrameworkWithFallback(allocator, pkg_name, version);
-    } else if (std.mem.eql(u8, pkg_name, "assembler")) {
-        std.debug.print("labelle: fetching assembler {s}...\n", .{version});
-        try cache.fetchAssemblerWithFallback(allocator, version);
+        // No args — install the current project's deps. The assembler
+        // needs `--project-root` to find project.labelle.
+        try argv.appendSlice(allocator, &.{ "--project-root", "." });
     } else {
-        std.debug.print("labelle install: unknown package '{s}'\n", .{pkg_name});
-        std.debug.print("  known packages: core, engine, gfx, assembler\n", .{});
-        return error.UnknownPackage;
+        try argv.appendSlice(allocator, cmd_args);
     }
 
-    std.debug.print("labelle: done\n", .{});
+    try assembler_proc.runSubcommand(allocator, ".", "install", argv.items);
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -2,71 +2,60 @@ const std = @import("std");
 const gen = @import("generator");
 const assembler = @import("assembler.zig");
 const config = @import("config.zig");
+const assembler_proc = @import("assembler_proc.zig");
 
 /// Bump version fields in project.labelle.
+///
+/// Issue #217 phase 1: framework/cli version bumps are delegated to the
+/// standalone `labelle-assembler` binary (`labelle-assembler upgrade
+/// ...`). Two cases stay CLI-owned because they touch `assembler_version`
+/// — pinning the assembler *binary* version is a CLI-bootstrap concern,
+/// and the assembler doesn't manage its own pin:
+///   - `upgrade assembler [version]`
+///   - `upgrade all` (which also bumps `assembler_version`)
 pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: gen.ProjectConfig, cmd_args: []const []const u8) !void {
+    const is_assembler = cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "assembler");
+    const is_all = cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "all");
+
+    // Everything except `assembler` / `all` delegates to the binary.
+    if (!is_assembler and !is_all) {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(allocator);
+        try argv.appendSlice(allocator, &.{ "--project-root", project_dir });
+        try argv.appendSlice(allocator, cmd_args);
+        return assembler_proc.runSubcommand(allocator, project_dir, "upgrade", argv.items);
+    }
+
+    // ── CLI-owned: cases that touch assembler_version ────────────────
     const labelle_path = try std.fs.path.join(allocator, &.{ project_dir, "project.labelle" });
     defer allocator.free(labelle_path);
 
     var content = try std.Io.Dir.cwd().readFileAlloc(config.globalIo(), labelle_path, allocator, .limited(1024 * 1024));
 
-    if (cmd_args.len == 0) {
+    if (is_all) {
         std.debug.print("labelle: upgrading to compatible set (core={s}, engine={s}, gfx={s}, cli={s})...\n", .{ gen.CORE_VERSION, gen.ENGINE_VERSION, gen.GFX_VERSION, gen.CLI_VERSION });
         content = try replaceAndFree(allocator, content, "core_version", cfg.core_version, gen.CORE_VERSION);
         content = try replaceAndFree(allocator, content, "engine_version", cfg.engine_version, gen.ENGINE_VERSION);
         content = try replaceAndFree(allocator, content, "gfx_version", cfg.gfx_version, gen.GFX_VERSION);
         content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, gen.CLI_VERSION);
-    } else {
-        const pkg = cmd_args[0];
-        const default_version: []const u8 = if (std.mem.eql(u8, pkg, "core"))
-            gen.CORE_VERSION
-        else if (std.mem.eql(u8, pkg, "engine"))
-            gen.ENGINE_VERSION
-        else if (std.mem.eql(u8, pkg, "gfx"))
-            gen.GFX_VERSION
-        else if (std.mem.eql(u8, pkg, "assembler"))
-            assembler.DEFAULT_ASSEMBLER_VERSION
-        else
-            gen.CLI_VERSION;
-        const version = if (cmd_args.len > 1) cmd_args[1] else default_version;
-
-        if (std.mem.eql(u8, pkg, "core")) {
-            content = try replaceAndFree(allocator, content, "core_version", cfg.core_version, version);
-        } else if (std.mem.eql(u8, pkg, "engine")) {
-            content = try replaceAndFree(allocator, content, "engine_version", cfg.engine_version, version);
-        } else if (std.mem.eql(u8, pkg, "gfx")) {
-            content = try replaceAndFree(allocator, content, "gfx_version", cfg.gfx_version, version);
-        } else if (std.mem.eql(u8, pkg, "labelle") or std.mem.eql(u8, pkg, "cli")) {
-            content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, version);
-        } else if (std.mem.eql(u8, pkg, "assembler")) {
-            // If assembler_version already exists, replace it; otherwise append it before the closing `}`
-            if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
-                const old_asm = cfg.assembler_version orelse "0.0.0";
-                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, version);
-            } else {
-                // Insert assembler_version before the final closing brace
-                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", version);
-            }
-        } else if (std.mem.eql(u8, pkg, "all")) {
-            content = try replaceAndFree(allocator, content, "core_version", cfg.core_version, gen.CORE_VERSION);
-            content = try replaceAndFree(allocator, content, "engine_version", cfg.engine_version, gen.ENGINE_VERSION);
-            content = try replaceAndFree(allocator, content, "gfx_version", cfg.gfx_version, gen.GFX_VERSION);
-            content = try replaceAndFree(allocator, content, "labelle_version", cfg.labelle_version, gen.CLI_VERSION);
-            // Also upgrade assembler if it exists (or add it)
-            if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
-                const old_asm = cfg.assembler_version orelse "0.0.0";
-                content = try replaceAndFree(allocator, content, "assembler_version", old_asm, assembler.DEFAULT_ASSEMBLER_VERSION);
-            } else {
-                content = try insertBeforeClosingBrace(allocator, content, "assembler_version", assembler.DEFAULT_ASSEMBLER_VERSION);
-            }
+        // Also upgrade assembler if it exists (or add it).
+        if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
+            const old_asm = cfg.assembler_version orelse "0.0.0";
+            content = try replaceAndFree(allocator, content, "assembler_version", old_asm, assembler.DEFAULT_ASSEMBLER_VERSION);
         } else {
-            std.debug.print("labelle upgrade: unknown package '{s}'\n", .{pkg});
-            std.debug.print("  packages: core, engine, gfx, cli, assembler, all\n", .{});
-            allocator.free(content);
-            return error.UnknownPackage;
+            content = try insertBeforeClosingBrace(allocator, content, "assembler_version", assembler.DEFAULT_ASSEMBLER_VERSION);
         }
-
-        std.debug.print("labelle: upgrading {s} to {s}...\n", .{ pkg, version });
+        std.debug.print("labelle: upgrading all to compatible set...\n", .{});
+    } else {
+        // is_assembler
+        const version = if (cmd_args.len > 1) cmd_args[1] else assembler.DEFAULT_ASSEMBLER_VERSION;
+        if (std.mem.indexOf(u8, content, ".assembler_version")) |_| {
+            const old_asm = cfg.assembler_version orelse "0.0.0";
+            content = try replaceAndFree(allocator, content, "assembler_version", old_asm, version);
+        } else {
+            content = try insertBeforeClosingBrace(allocator, content, "assembler_version", version);
+        }
+        std.debug.print("labelle: upgrading assembler to {s}...\n", .{version});
     }
 
     try std.Io.Dir.cwd().writeFile(config.globalIo(), .{


### PR DESCRIPTION
Phase 1 of #217 — make the CLI delegate cache-management commands to the standalone `labelle-assembler` binary instead of running the assembler's `generator` code in-process.

## Changes

- **`src/cli/assembler_proc.zig`** (new) — the reusable CLI→assembler subprocess harness. Later phases of #217 reuse it:
  - `resolve(allocator, project_dir)` — locates the binary once (env var > `project.labelle` pin > CLI-paired default), returns an owned `Assembler{ path }`.
  - `Assembler.run(allocator, subcommand, args)` — spawns `labelle-assembler <subcommand> [args]` with inherited stdio, maps non-zero exit to `error.AssemblerFailed`.
  - `runSubcommand(...)` — one-shot resolve + run + deinit.
  - Binary resolution delegates to the existing `assembler.zig` resolver — not reinvented.
- **`src/cli/{install,clean,upgrade}.zig`** — migrated to delegate via the harness. User-facing argv/flags unchanged.

## Scope notes

- The `labelle_assembler` build dependency is **retained** — other commands still use the `generator` module. It is dropped in #217's final phase.
- `install assembler <ver>` / `upgrade assembler` / `upgrade all` stay CLI-side: they download/pin the assembler *binary* via `assembler_version` — chicken-and-egg state the assembler can't manage for itself.
- No-project fallback: cache commands with no `project.labelle` in cwd use the assembler version paired with this CLI build.

`zig build` + `zig build test`: exit 0. (The unrelated `flow-codegen` issue did not trigger — the pinned assembler already uses the URL-based flow-codegen dep.)

Pairs with labelle-assembler PR #156… see the assembler's phase-1 PR. Part of #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)