### PR TITLE
Delegate code generation to the assembler binary (#217 phase 2)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -31,6 +31,7 @@ const lockfile = @import("cli/lockfile.zig");
 const cache = @import("cli/cache.zig");
 const runner = @import("cli/runner.zig");
 const assembler = @import("cli/assembler.zig");
+const assembler_proc = @import("cli/assembler_proc.zig");
 const bake_mod = @import("cli/bake.zig");
 const docker = @import("cli/docker.zig");
 const serve = @import("cli/serve.zig");
@@ -733,20 +734,27 @@ pub fn main(proc_init: std.process.Init) !void {
         };
     }
 
-    // Route through the standalone labelle-assembler binary.
-    // Resolution order: LABELLE_ASSEMBLER env var > assembler_version
-    // in project.labelle. If neither is set, auto-downloads the default version.
-    const asm_path = try assembler.resolveAssembler(allocator, project_dir) orelse
-        try assembler.resolveDefault(allocator);
-    defer allocator.free(asm_path);
-    std.debug.print("  using assembler: {s}\n", .{asm_path});
-    try assembler.spawnGenerate(
+    // Issue #217 phase 2: delegate code generation to the standalone
+    // labelle-assembler binary via the shared subprocess harness, instead
+    // of calling the in-process `gen.generate()`. The harness resolves the
+    // binary (LABELLE_ASSEMBLER env var > assembler_version in
+    // project.labelle > auto-downloaded default) and forwards `generate`.
+    //
+    // `build` / `run` are not assembler subcommands: the subsequent
+    // `zig build` invocation and binary launch stay CLI-side (see below).
+    // The CLI owns docker orchestration, the WASM serve loop, the
+    // iOS/Android deploy paths and `--timeout` — generation is the only
+    // step the assembler binary delegates.
+    const asm_bin = try assembler_proc.resolve(allocator, project_dir);
+    defer asm_bin.deinit(allocator);
+    std.debug.print("  using assembler: {s}\n", .{asm_bin.path});
+    try assembler_proc.generate(
+        asm_bin,
         allocator,
-        asm_path,
         project_dir,
         parsed_args.scene_override,
-        parsed.platform,
-        parsed.backend,
+        @tagName(parsed.platform),
+        @tagName(parsed.backend),
     );
 
     // Target subdir: .labelle/raylib_desktop/, etc.

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -340,54 +340,11 @@ pub fn cmdListAssemblers(allocator: std.mem.Allocator) !void {
     }
 }
 
-/// Spawn `labelle-assembler generate` against the given project and
-/// inherit stdio so the user sees the binary's diagnostics directly.
-/// Forwards the same overrides the in-process path applies (scene,
-/// platform, backend) so the binary produces identical output.
-///
-/// On a non-zero exit code, returns `error.AssemblerFailed`. The
-/// binary's stderr already explains what went wrong.
-pub fn spawnGenerate(
-    allocator: std.mem.Allocator,
-    exe_path: []const u8,
-    project_dir: []const u8,
-    scene_override: ?[]const u8,
-    platform: gen.Platform,
-    backend: gen.Backend,
-) !void {
-    const io = config.globalIo();
-    var argv: std.ArrayList([]const u8) = .empty;
-    defer argv.deinit(allocator);
-
-    try argv.appendSlice(allocator, &.{ exe_path, "generate", "--project-root", project_dir });
-
-    if (scene_override) |s| try argv.appendSlice(allocator, &.{ "--scene", s });
-
-    // Always forward platform/backend so the binary doesn't have to
-    // re-derive what the CLI may have already mutated (e.g. for the
-    // `labelle ios` subcommand which forces sokol+ios).
-    try argv.appendSlice(allocator, &.{ "--platform", @tagName(platform) });
-    try argv.appendSlice(allocator, &.{ "--backend", @tagName(backend) });
-
-    var child = try std.process.spawn(io, .{
-        .argv = argv.items,
-        .stdin = .inherit,
-        .stdout = .inherit,
-        .stderr = .inherit,
-    });
-
-    const term = try child.wait(io);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            std.debug.print("labelle: assembler '{s}' exited with code {d}\n", .{ exe_path, code });
-            return error.AssemblerFailed;
-        },
-        else => {
-            std.debug.print("labelle: assembler '{s}' terminated abnormally\n", .{exe_path});
-            return error.AssemblerFailed;
-        },
-    }
-}
+// Issue #217 phase 2: `generate` subprocess invocation moved to the
+// shared harness `cli/assembler_proc.zig` (`assembler_proc.generate`).
+// This module keeps only the bootstrap concern — locating/downloading the
+// assembler binary — which the harness builds on via `resolveAssembler` /
+// `resolveDefault`.
 
 /// If `project_dir` is a git worktree, return the path of the main checkout.
 /// Otherwise return a copy of `project_dir` unchanged.

--- a/src/cli/assembler_proc.zig
+++ b/src/cli/assembler_proc.zig
@@ -87,6 +87,44 @@ pub fn runSubcommand(
     try asm_bin.run(allocator, subcommand, args);
 }
 
+/// Run `labelle-assembler generate` against `project_dir`.
+///
+/// Issue #217 phase 2: the CLI's `generate` / `build` / `run` commands
+/// delegate code generation to the assembler binary instead of calling
+/// the in-process `generate()`. `build` / `run` then invoke `zig build`
+/// (and launch the binary) themselves — those steps stay CLI-side because
+/// the CLI owns docker orchestration, WASM serve, the iOS/Android deploy
+/// paths and `--timeout`; only the generation step is delegated.
+///
+/// `platform` / `backend` are forwarded as plain strings (`@tagName` of
+/// the CLI's enums) so this module needs no dependency on the assembler's
+/// type definitions. The assembler validates them against its own enums.
+/// `scene_override` mirrors the user-facing `--scene` flag.
+///
+/// On a non-zero exit code, returns `error.AssemblerFailed`; the binary's
+/// inherited stderr already explains the failure.
+pub fn generate(
+    asm_bin: Assembler,
+    allocator: std.mem.Allocator,
+    project_dir: []const u8,
+    scene_override: ?[]const u8,
+    platform: []const u8,
+    backend: []const u8,
+) !void {
+    var args: std.ArrayList([]const u8) = .empty;
+    defer args.deinit(allocator);
+
+    try args.appendSlice(allocator, &.{ "--project-root", project_dir });
+    if (scene_override) |s| try args.appendSlice(allocator, &.{ "--scene", s });
+    // Always forward platform/backend — the CLI may have mutated them
+    // (e.g. `labelle ios` forces sokol+ios) and the binary must not
+    // re-derive its own values from project.labelle.
+    try args.appendSlice(allocator, &.{ "--platform", platform });
+    try args.appendSlice(allocator, &.{ "--backend", backend });
+
+    try asm_bin.run(allocator, "generate", args.items);
+}
+
 /// Spawn `exe_path <subcommand> [args...]`, inherit stdio, wait, and map
 /// the result onto a Zig error. Shared by `Assembler.run` and
 /// `runSubcommand`.

--- a/src/cli/docker.zig
+++ b/src/cli/docker.zig
@@ -113,7 +113,7 @@ fn copyTree(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !voi
 /// No staleness on iterative builds: this only acts on entries that are
 /// *currently symlinks*, but every `labelle build --docker` invocation
 /// runs the assembler's `generate` step first (cli.zig calls
-/// `assembler.spawnGenerate` unconditionally before `docker.runBuild`).
+/// `assembler_proc.generate` unconditionally before `docker.runBuild`).
 /// The assembler's `linkDir` is idempotent and explicitly recreates each
 /// game-dir symlink even when the path is already a real directory left
 /// over from a prior `materializeSymlinks` run — it detects the


### PR DESCRIPTION
Phase 2 of #217 — the CLI's `generate` / `build` / `run` now delegate *code generation* to the standalone `labelle-assembler` binary instead of running the assembler's in-process `generate()` from the `generator` module.

**Stacked on phase 1** (base `feat/217-phase1-cache-delegation`).

## Design decision: `build`/`run` stay CLI wrappers

Only *generation* is delegated. `build` and `run` remain CLI-side — they wrap `assembler generate` + a `zig build` invocation + binary launch. The CLI legitimately owns docker build orchestration, the WASM serve + browser-open loop, iOS-Simulator / Android-device deploy, `--timeout`, and `fixFingerprints` — none of which the assembler knows about. Moving those behind the assembler would be a large unscoped expansion; #217's end state only requires that generation stop happening in-process. The assembler command surface is unchanged, so `PROTOCOL_VERSION` stays at 2.

## Changes (CLI only — assembler needed no changes; its `generate` subcommand already had parity)

- `src/cli/assembler_proc.zig` — adds `generate()` to the phase-1 harness: builds the `generate` argv (`--project-root`, `--scene`/`--platform`/`--backend` forwarded) and runs it via `Assembler.run`.
- `src/cli.zig` — `generate`/`build`/`run` use `assembler_proc.resolve` + `assembler_proc.generate` instead of the bespoke resolve + `spawnGenerate`.
- `src/cli/assembler.zig` — removes the now-dead `spawnGenerate` (subprocess invocation lives only in the shared harness); keeps the bootstrap concern (locating/downloading the binary).

`zig build` + `zig build test`: exit 0 (verified).

Part of #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)