### PR TITLE
feat(android): Android Studio project generation

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -519,6 +519,7 @@ pub fn main(proc_init: std.process.Init) !void {
                 if (std.mem.startsWith(u8, arg, "-") or
                     std.mem.eql(u8, arg, "build") or
                     std.mem.eql(u8, arg, "run") or
+                    std.mem.eql(u8, arg, "studio") or
                     std.mem.eql(u8, arg, "deploy") or
                     std.mem.eql(u8, arg, "doctor") or
                     std.mem.eql(u8, arg, "help"))

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -10,6 +10,7 @@
 ///   android/run.zig       — adb install + launch
 ///   android/deploy.zig    — GitHub Releases upload (labelle.games v1)
 ///   android/doctor.zig    — SDK/NDK probe + report
+///   android/studio.zig    — Android Studio (Gradle) project generation
 const std = @import("std");
 const project_config = @import("project_config.zig");
 
@@ -19,6 +20,7 @@ const package_mod = @import("android/package.zig");
 const run_mod = @import("android/run.zig");
 const deploy_mod = @import("android/deploy.zig");
 const doctor_mod = @import("android/doctor.zig");
+const studio_mod = @import("android/studio.zig");
 
 // ── Public re-exports ──────────────────────────────────────────────
 // Keeps `android.buildAndPackage`, `android.deployToDevice`, etc.
@@ -33,6 +35,7 @@ pub const deployToDevice = run_mod.deployToDevice;
 pub const deployToDeviceWithAbis = run_mod.deployToDeviceWithAbis;
 pub const DeployOpts = deploy_mod.DeployOpts;
 pub const cmdDeploy = deploy_mod.cmdDeploy;
+pub const androidStudio = studio_mod.androidStudio;
 
 // ── Shared types ───────────────────────────────────────────────────
 // These cross submodule boundaries (flag parsing here populates them,
@@ -206,6 +209,8 @@ pub fn handleAndroid(
             .emulator = emulator,
             .signing = signing,
         });
+    } else if (std.mem.eql(u8, cmd, "studio")) {
+        try studio_mod.androidStudio(allocator, target_dir, cfg);
     } else if (std.mem.eql(u8, cmd, "doctor")) {
         try doctor_mod.runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {
@@ -242,6 +247,7 @@ pub fn printHelp() void {
         \\Commands:
         \\  build      Build for Android device (arm64)
         \\  run        Build and deploy to device/emulator
+        \\  studio     Generate an Android Studio (Gradle) project
         \\  deploy     Build and upload to GitHub Releases (for Obtainium OTA)
         \\  doctor     Probe the Android SDK/NDK environment and report
         \\             the status of every required tool

--- a/src/cli/android.zig
+++ b/src/cli/android.zig
@@ -210,7 +210,7 @@ pub fn handleAndroid(
             .signing = signing,
         });
     } else if (std.mem.eql(u8, cmd, "studio")) {
-        try studio_mod.androidStudio(allocator, target_dir, cfg);
+        try studio_mod.androidStudio(allocator, target_dir, cfg, release_mode);
     } else if (std.mem.eql(u8, cmd, "doctor")) {
         try doctor_mod.runDoctor(allocator, cfg.android);
     } else if (std.mem.eql(u8, cmd, "help")) {

--- a/src/cli/android/package.zig
+++ b/src/cli/android/package.zig
@@ -510,7 +510,7 @@ fn defaultPackageName(allocator: std.mem.Allocator, name: []const u8) ![]const u
 }
 
 /// Copy a directory tree recursively.
-fn copyDirectory(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
+pub fn copyDirectory(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
     const io = config.globalIo();
     const cwd = std.Io.Dir.cwd();
     // Don't swallow createDirPath errors. PathAlreadyExists is fine — every

--- a/src/cli/android/studio.zig
+++ b/src/cli/android/studio.zig
@@ -48,6 +48,7 @@ pub fn androidStudio(
     allocator: std.mem.Allocator,
     target_dir: []const u8,
     cfg: project_config.ProjectConfig,
+    release_mode: ReleaseMode,
 ) !void {
     const android_cfg = cfg.android orelse AndroidConfig{};
     const app_name = if (android_cfg.app_name.len > 0) android_cfg.app_name else cfg.title;
@@ -58,7 +59,7 @@ pub fn androidStudio(
     // Build the device .so first so the project is runnable as soon
     // as it is opened. arm64-v8a only in v1.
     std.debug.print("labelle: step 1 — building libgame.so for arm64-v8a...\n", .{});
-    try build_mod.androidBuild(allocator, target_dir, false, .debug);
+    try build_mod.androidBuild(allocator, target_dir, false, release_mode);
 
     const so_src = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
     defer allocator.free(so_src);
@@ -71,7 +72,10 @@ pub fn androidStudio(
     const studio_dir = try std.fs.path.join(allocator, &.{ target_dir, "..", "..", "android-studio" });
     defer allocator.free(studio_dir);
 
-    const main_dir = try std.fs.path.join(allocator, &.{ studio_dir, "app", "src", "main" });
+    const app_dir = try std.fs.path.join(allocator, &.{ studio_dir, "app" });
+    defer allocator.free(app_dir);
+
+    const main_dir = try std.fs.path.join(allocator, &.{ app_dir, "src", "main" });
     defer allocator.free(main_dir);
 
     const jni_dir = try std.fs.path.join(allocator, &.{ main_dir, "jniLibs", "arm64-v8a" });
@@ -93,19 +97,22 @@ pub fn androidStudio(
     defer allocator.free(assets_src);
     const assets_dst = try std.fs.path.join(allocator, &.{ main_dir, "assets" });
     defer allocator.free(assets_dst);
-    // Best-effort: a game without an assets/ directory is still valid.
-    package.copyDirectory(allocator, assets_src, assets_dst) catch {};
+    // A game without an assets/ directory is still valid — skip the
+    // copy in that case, but let genuine I/O errors surface.
+    if (std.Io.Dir.cwd().access(config.globalIo(), assets_src, .{})) |_| {
+        try package.copyDirectory(allocator, assets_src, assets_dst);
+    } else |_| {}
 
     // ── Generated files ───────────────────────────────────────────
     try writeFile(allocator, studio_dir, "settings.gradle.kts", try settingsGradle(allocator, app_name));
-    try writeFile(allocator, studio_dir, "build.gradle.kts", rootBuildGradle());
-    try writeFile(allocator, studio_dir, "gradle.properties", gradleProperties());
+    try writeFile(allocator, studio_dir, "build.gradle.kts", try rootBuildGradle(allocator));
+    try writeFile(allocator, studio_dir, "gradle.properties", try gradleProperties(allocator));
 
     const wrapper_props = try gradleWrapperProperties(allocator);
     try writeFile(allocator, wrapper_dir, "gradle-wrapper.properties", wrapper_props);
 
     const app_gradle = try appBuildGradle(allocator, package_name, android_cfg);
-    try writeFile(allocator, std.fs.path.dirname(main_dir).?, "build.gradle.kts", app_gradle);
+    try writeFile(allocator, app_dir, "build.gradle.kts", app_gradle);
 
     const manifest = try generateStudioManifest(allocator, app_name, android_cfg);
     try writeFile(allocator, main_dir, "AndroidManifest.xml", manifest);
@@ -155,18 +162,21 @@ fn settingsGradle(allocator: std.mem.Allocator, app_name: []const u8) ![]const u
 
 /// Root `build.gradle.kts` — declares the Android Gradle Plugin
 /// version for the `:app` module without applying it at the root.
-fn rootBuildGradle() []const u8 {
-    return "plugins {\n" ++
+/// Returns an owned slice (the content is static, but `writeFile`
+/// takes ownership and frees it).
+fn rootBuildGradle(allocator: std.mem.Allocator) ![]const u8 {
+    return allocator.dupe(u8, "plugins {\n" ++
         "    id(\"com.android.application\") version \"" ++ agp_version ++ "\" apply false\n" ++
-        "}\n";
+        "}\n");
 }
 
 /// `gradle.properties` — JVM args + AndroidX opt-in. Plain NativeActivity
 /// games need neither, but Android Studio's project sync expects them.
-fn gradleProperties() []const u8 {
-    return "org.gradle.jvmargs=-Xmx2048m\n" ++
+/// Returns an owned slice (see `rootBuildGradle`).
+fn gradleProperties(allocator: std.mem.Allocator) ![]const u8 {
+    return allocator.dupe(u8, "org.gradle.jvmargs=-Xmx2048m\n" ++
         "android.useAndroidX=true\n" ++
-        "android.nonTransitiveRClass=true\n";
+        "android.nonTransitiveRClass=true\n");
 }
 
 /// `gradle/wrapper/gradle-wrapper.properties` — points at the Gradle
@@ -284,7 +294,9 @@ test "settingsGradle embeds the app name as the root project name" {
 }
 
 test "rootBuildGradle pins the Android Gradle Plugin version" {
-    const out = rootBuildGradle();
+    const allocator = std.testing.allocator;
+    const out = try rootBuildGradle(allocator);
+    defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "com.android.application") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, agp_version) != null);
     // Root build must not apply the plugin.

--- a/src/cli/android/studio.zig
+++ b/src/cli/android/studio.zig
@@ -1,0 +1,336 @@
+/// Android Studio project generation — `labelle android studio`.
+///
+/// Mirrors `labelle ios xcode`: builds the game's `libgame.so`, then
+/// scaffolds a self-contained Gradle project around it so users can
+/// open the project in Android Studio for signing, release builds,
+/// Play Store packaging, or just IDE-driven debugging.
+///
+/// The generated tree is:
+///
+///   android-studio/
+///     settings.gradle.kts
+///     build.gradle.kts
+///     gradle.properties
+///     gradle/wrapper/gradle-wrapper.properties
+///     app/build.gradle.kts
+///     app/src/main/AndroidManifest.xml
+///     app/src/main/jniLibs/arm64-v8a/libgame.so
+///     app/src/main/assets/...
+///
+/// v1 scope: arm64-v8a only (the device ABI). The generated Gradle
+/// project ships no Gradle wrapper JAR/scripts — Android Studio's
+/// "use Gradle wrapper" prompt or a locally installed `gradle` fills
+/// that in. Multi-ABI jniLibs and a vendored wrapper are deferred
+/// (see the PR description).
+const std = @import("std");
+const config = @import("../config.zig");
+const project_config = @import("../project_config.zig");
+const android = @import("../android.zig");
+const build_mod = @import("build.zig");
+const package = @import("package.zig");
+
+const AndroidConfig = project_config.AndroidConfig;
+const ReleaseMode = android.ReleaseMode;
+
+/// Gradle/AGP versions the generated project pins. Kept here as named
+/// constants so a future bump is a one-line change.
+const agp_version = "8.5.2";
+const gradle_distribution = "gradle-8.9-bin.zip";
+const ndk_version = "27.0.12077973";
+
+/// Generate an Android Studio (Gradle) project under
+/// `android-studio/` next to the game's `.labelle/` directory.
+///
+/// `target_dir` is the generated `.labelle/<backend>_<platform>/`
+/// directory (same value the other Android subcommands receive), so
+/// the project lands two levels up alongside `.labelle/`.
+pub fn androidStudio(
+    allocator: std.mem.Allocator,
+    target_dir: []const u8,
+    cfg: project_config.ProjectConfig,
+) !void {
+    const android_cfg = cfg.android orelse AndroidConfig{};
+    const app_name = if (android_cfg.app_name.len > 0) android_cfg.app_name else cfg.title;
+
+    const package_name = try package.resolvePackageName(allocator, cfg);
+    defer allocator.free(package_name);
+
+    // Build the device .so first so the project is runnable as soon
+    // as it is opened. arm64-v8a only in v1.
+    std.debug.print("labelle: step 1 — building libgame.so for arm64-v8a...\n", .{});
+    try build_mod.androidBuild(allocator, target_dir, false, .debug);
+
+    const so_src = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "lib", "libgame.so" });
+    defer allocator.free(so_src);
+    std.Io.Dir.cwd().access(config.globalIo(), so_src, .{}) catch {
+        std.debug.print("labelle: build did not produce {s}\n", .{so_src});
+        return error.BinaryNotFound;
+    };
+
+    // Output directory: <target_dir>/../../android-studio
+    const studio_dir = try std.fs.path.join(allocator, &.{ target_dir, "..", "..", "android-studio" });
+    defer allocator.free(studio_dir);
+
+    const main_dir = try std.fs.path.join(allocator, &.{ studio_dir, "app", "src", "main" });
+    defer allocator.free(main_dir);
+
+    const jni_dir = try std.fs.path.join(allocator, &.{ main_dir, "jniLibs", "arm64-v8a" });
+    defer allocator.free(jni_dir);
+
+    const wrapper_dir = try std.fs.path.join(allocator, &.{ studio_dir, "gradle", "wrapper" });
+    defer allocator.free(wrapper_dir);
+
+    try std.Io.Dir.cwd().createDirPath(config.globalIo(), jni_dir);
+    try std.Io.Dir.cwd().createDirPath(config.globalIo(), wrapper_dir);
+
+    // ── Native library ────────────────────────────────────────────
+    const so_dst = try std.fs.path.join(allocator, &.{ jni_dir, "libgame.so" });
+    defer allocator.free(so_dst);
+    try std.Io.Dir.cwd().copyFile(so_src, std.Io.Dir.cwd(), so_dst, config.globalIo(), .{});
+
+    // ── Assets ────────────────────────────────────────────────────
+    const assets_src = try std.fs.path.join(allocator, &.{ target_dir, "assets" });
+    defer allocator.free(assets_src);
+    const assets_dst = try std.fs.path.join(allocator, &.{ main_dir, "assets" });
+    defer allocator.free(assets_dst);
+    // Best-effort: a game without an assets/ directory is still valid.
+    package.copyDirectory(allocator, assets_src, assets_dst) catch {};
+
+    // ── Generated files ───────────────────────────────────────────
+    try writeFile(allocator, studio_dir, "settings.gradle.kts", try settingsGradle(allocator, app_name));
+    try writeFile(allocator, studio_dir, "build.gradle.kts", rootBuildGradle());
+    try writeFile(allocator, studio_dir, "gradle.properties", gradleProperties());
+
+    const wrapper_props = try gradleWrapperProperties(allocator);
+    try writeFile(allocator, wrapper_dir, "gradle-wrapper.properties", wrapper_props);
+
+    const app_gradle = try appBuildGradle(allocator, package_name, android_cfg);
+    try writeFile(allocator, std.fs.path.dirname(main_dir).?, "build.gradle.kts", app_gradle);
+
+    const manifest = try generateStudioManifest(allocator, app_name, android_cfg);
+    try writeFile(allocator, main_dir, "AndroidManifest.xml", manifest);
+
+    std.debug.print("\nlabelle: Android Studio project generated!\n", .{});
+    std.debug.print("  location: android-studio/\n\n", .{});
+    std.debug.print("Next steps:\n", .{});
+    std.debug.print("  1. Open the android-studio/ directory in Android Studio\n", .{});
+    std.debug.print("  2. Let it create the Gradle wrapper / sync the project\n", .{});
+    std.debug.print("  3. Build & run, or configure signing for a release build\n", .{});
+}
+
+/// Write `data` to `<dir>/<name>` and free `data` afterward. The
+/// generated-content helpers all return owned slices, so funnelling
+/// them through here keeps the call site free of per-file defers.
+fn writeFile(allocator: std.mem.Allocator, dir: []const u8, name: []const u8, data: []const u8) !void {
+    defer allocator.free(data);
+    const path = try std.fs.path.join(allocator, &.{ dir, name });
+    defer allocator.free(path);
+    try std.Io.Dir.cwd().writeFile(config.globalIo(), .{ .sub_path = path, .data = data });
+}
+
+/// `settings.gradle.kts` — names the Gradle build and includes the
+/// single `:app` module.
+fn settingsGradle(allocator: std.mem.Allocator, app_name: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(allocator,
+        \\pluginManagement {{
+        \\    repositories {{
+        \\        google()
+        \\        mavenCentral()
+        \\        gradlePluginPortal()
+        \\    }}
+        \\}}
+        \\
+        \\dependencyResolutionManagement {{
+        \\    repositories {{
+        \\        google()
+        \\        mavenCentral()
+        \\    }}
+        \\}}
+        \\
+        \\rootProject.name = "{s}"
+        \\include(":app")
+        \\
+    , .{app_name});
+}
+
+/// Root `build.gradle.kts` — declares the Android Gradle Plugin
+/// version for the `:app` module without applying it at the root.
+fn rootBuildGradle() []const u8 {
+    return "plugins {\n" ++
+        "    id(\"com.android.application\") version \"" ++ agp_version ++ "\" apply false\n" ++
+        "}\n";
+}
+
+/// `gradle.properties` — JVM args + AndroidX opt-in. Plain NativeActivity
+/// games need neither, but Android Studio's project sync expects them.
+fn gradleProperties() []const u8 {
+    return "org.gradle.jvmargs=-Xmx2048m\n" ++
+        "android.useAndroidX=true\n" ++
+        "android.nonTransitiveRClass=true\n";
+}
+
+/// `gradle/wrapper/gradle-wrapper.properties` — points at the Gradle
+/// distribution. The wrapper JAR/scripts themselves are not vendored
+/// (see module doc comment).
+fn gradleWrapperProperties(allocator: std.mem.Allocator) ![]const u8 {
+    return std.fmt.allocPrint(allocator,
+        \\distributionBase=GRADLE_USER_HOME
+        \\distributionPath=wrapper/dists
+        \\distributionUrl=https\://services.gradle.org/distributions/{s}
+        \\zipStoreBase=GRADLE_USER_HOME
+        \\zipStorePath=wrapper/dists
+        \\
+    , .{gradle_distribution});
+}
+
+/// `app/build.gradle.kts` — the Android application module. Packages
+/// the prebuilt `libgame.so` from `jniLibs/` and the staged assets;
+/// it does NOT compile any Zig — `labelle` owns the native build.
+fn appBuildGradle(
+    allocator: std.mem.Allocator,
+    package_name: []const u8,
+    cfg: AndroidConfig,
+) ![]const u8 {
+    return std.fmt.allocPrint(allocator,
+        \\plugins {{
+        \\    id("com.android.application")
+        \\}}
+        \\
+        \\android {{
+        \\    namespace = "{s}"
+        \\    compileSdk = {d}
+        \\    ndkVersion = "{s}"
+        \\
+        \\    defaultConfig {{
+        \\        applicationId = "{s}"
+        \\        minSdk = {d}
+        \\        targetSdk = {d}
+        \\        versionCode = 1
+        \\        versionName = "1.0"
+        \\        ndk {{
+        \\            abiFilters += listOf("arm64-v8a")
+        \\        }}
+        \\    }}
+        \\
+        \\    buildTypes {{
+        \\        release {{
+        \\            isMinifyEnabled = false
+        \\        }}
+        \\    }}
+        \\
+        \\    // The .so is built by `labelle` and dropped into
+        \\    // src/main/jniLibs/ — Gradle just packages it.
+        \\    sourceSets {{
+        \\        getByName("main") {{
+        \\            jniLibs.srcDirs("src/main/jniLibs")
+        \\        }}
+        \\    }}
+        \\}}
+        \\
+    , .{ package_name, cfg.target_sdk_version, ndk_version, package_name, cfg.min_sdk_version, cfg.target_sdk_version });
+}
+
+/// `AndroidManifest.xml` for the Gradle project. Unlike the
+/// aapt-packaged manifest in `package.zig`, this one carries no
+/// `package=` attribute (AGP injects `applicationId` from
+/// `build.gradle.kts`) and no version attributes.
+fn generateStudioManifest(
+    allocator: std.mem.Allocator,
+    app_name: []const u8,
+    cfg: AndroidConfig,
+) ![]const u8 {
+    const orientation = switch (cfg.orientation) {
+        .portrait => "portrait",
+        .landscape => "landscape",
+        .all => "unspecified",
+    };
+
+    const theme_attr: []const u8 = if (cfg.immersive_mode)
+        "\n            android:theme=\"@android:style/Theme.NoTitleBar.Fullscreen\""
+    else
+        "";
+
+    return std.fmt.allocPrint(allocator,
+        \\<?xml version="1.0" encoding="utf-8"?>
+        \\<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        \\
+        \\    <uses-feature android:glEsVersion="0x00030000" android:required="true" />
+        \\
+        \\    <application android:hasCode="false" android:label="{s}">
+        \\        <activity android:name="android.app.NativeActivity"
+        \\            android:configChanges="orientation|keyboardHidden|screenSize"
+        \\            android:screenOrientation="{s}"{s}
+        \\            android:exported="true">
+        \\            <meta-data android:name="android.app.lib_name" android:value="game" />
+        \\            <intent-filter>
+        \\                <action android:name="android.intent.action.MAIN" />
+        \\                <category android:name="android.intent.category.LAUNCHER" />
+        \\            </intent-filter>
+        \\        </activity>
+        \\    </application>
+        \\</manifest>
+        \\
+    , .{ app_name, orientation, theme_attr });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "settingsGradle embeds the app name as the root project name" {
+    const allocator = std.testing.allocator;
+    const out = try settingsGradle(allocator, "My Cool Game");
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "rootProject.name = \"My Cool Game\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "include(\":app\")") != null);
+}
+
+test "rootBuildGradle pins the Android Gradle Plugin version" {
+    const out = rootBuildGradle();
+    try std.testing.expect(std.mem.indexOf(u8, out, "com.android.application") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, agp_version) != null);
+    // Root build must not apply the plugin.
+    try std.testing.expect(std.mem.indexOf(u8, out, "apply false") != null);
+}
+
+test "gradleWrapperProperties references the pinned distribution" {
+    const allocator = std.testing.allocator;
+    const out = try gradleWrapperProperties(allocator);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, gradle_distribution) != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "distributionUrl=") != null);
+}
+
+test "appBuildGradle wires applicationId, sdk versions and abiFilters" {
+    const allocator = std.testing.allocator;
+    const cfg = AndroidConfig{ .min_sdk_version = 28, .target_sdk_version = 34 };
+    const out = try appBuildGradle(allocator, "com.test.game", cfg);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "applicationId = \"com.test.game\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "namespace = \"com.test.game\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "minSdk = 28") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "targetSdk = 34") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "arm64-v8a") != null);
+}
+
+test "generateStudioManifest omits package and version attributes" {
+    const allocator = std.testing.allocator;
+    const cfg = AndroidConfig{};
+    const out = try generateStudioManifest(allocator, "Test", cfg);
+    defer allocator.free(out);
+    // AGP injects applicationId/versionCode — the manifest must not.
+    try std.testing.expect(std.mem.indexOf(u8, out, "package=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "android:versionCode") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "android:label=\"Test\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "NativeActivity") != null);
+}
+
+test "generateStudioManifest honours orientation and immersive_mode" {
+    const allocator = std.testing.allocator;
+    const portrait = try generateStudioManifest(allocator, "T", .{ .orientation = .portrait });
+    defer allocator.free(portrait);
+    try std.testing.expect(std.mem.indexOf(u8, portrait, "android:screenOrientation=\"portrait\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, portrait, "android:theme=") == null);
+
+    const immersive = try generateStudioManifest(allocator, "T", .{ .immersive_mode = true });
+    defer allocator.free(immersive);
+    try std.testing.expect(std.mem.indexOf(u8, immersive, "Theme.NoTitleBar.Fullscreen") != null);
+}


### PR DESCRIPTION
Closes #137 — Android Phase 4.

## What this does

Adds `labelle android studio`, which generates a self-contained
Gradle project around the game's prebuilt `libgame.so`, mirroring
`labelle ios xcode`. This lets users open the project in Android
Studio for IDE-driven debugging, release signing, and Play Store
packaging without leaving the labelle CLI.

Generated tree:

```
android-studio/
  settings.gradle.kts
  build.gradle.kts
  gradle.properties
  gradle/wrapper/gradle-wrapper.properties
  app/build.gradle.kts
  app/src/main/AndroidManifest.xml
  app/src/main/jniLibs/arm64-v8a/libgame.so
  app/src/main/assets/...
```

## Implementation

- New `src/cli/android/studio.zig` submodule — builds the device
  `.so` (reusing `android/build.zig`), scaffolds the Gradle files,
  stages assets + the native library into `jniLibs/`, and prints
  next steps.
- Re-exported through the `android.zig` dispatcher (`androidStudio`),
  consistent with the other Android submodules.
- Wired `studio` into the `handleAndroid` dispatch, the CLI argument
  parser (`cli.zig`), and the `android` help text.
- `package.zig`'s `copyDirectory` is now `pub` so the studio module
  reuses it instead of duplicating the recursion.

The generated Gradle project carries **no native build logic** —
`labelle` owns the Zig build; Gradle just packages the `.so` from
`jniLibs/`. The Studio `AndroidManifest.xml` omits `package=` and
version attributes (AGP injects `applicationId`/`versionCode` from
`build.gradle.kts`), unlike the aapt-packaged manifest in `package.zig`.

## Tests

6 new unit tests covering the Gradle/manifest generators
(`settings.gradle.kts`, root `build.gradle.kts`, wrapper properties,
`app/build.gradle.kts`, and the Studio manifest including orientation
and immersive-mode handling). `zig build` and `zig build test` both
pass — 114/114 tests.

## Deferred (genuinely large, not in v1)

- **Multi-ABI jniLibs** — x86_64 emulator support / fat APK. v1 ships
  arm64-v8a only (the device ABI), matching the issue's `jniLibs/arm64-v8a/`
  sketch. Adding x86_64 would mean reusing `buildAllAbis` and is a clean
  follow-up.
- **Vendored Gradle wrapper** — the wrapper JAR + `gradlew`/`gradlew.bat`
  scripts are not generated. `gradle-wrapper.properties` is written, and
  Android Studio regenerates the wrapper on first project sync (or a
  locally installed `gradle` works). Bundling binary wrapper artifacts in
  the CLI is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)