### PR TITLE
feat(run): add --screenshot=<path> [--after=<dur>] flag (#227)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2,7 +2,7 @@
 ///
 /// Usage:
 ///   labelle generate [dir] [--scene=name] [--optimize=MODE] — generate .labelle/ assembler files
-///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [-- <args>...] — generate + build + run; `--` forwards trailing args to the game
+///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [--screenshot=<path> [--after=<dur>]] [-- <args>...] — generate + build + run; `--screenshot` captures a frame to <path> (raylib picks PNG/BMP by extension); `--` forwards trailing args to the game
 ///   labelle build [dir] [--scene=name] [--optimize=MODE] — generate + build (no run)
 ///   labelle wasm serve [dir] [--port n] [--no-build] [--no-open] — build the WASM target and serve it locally
 ///   labelle [dir]                       — alias for `run`
@@ -125,6 +125,15 @@ const ParsedArgs = struct {
     serve_port: u16 = 8080,
     serve_no_build: bool = false,
     serve_no_open: bool = false,
+    // labelle-cli#227 — out-of-band screenshot capture. `--screenshot`
+    // takes a destination path (raylib picks the format from the
+    // extension); `--after` is an optional delay (parsed via
+    // `parseDuration`, default 0 = fire on the first frame). Wired
+    // through to the spawned game via `LABELLE_SCREENSHOT_PATH` +
+    // `LABELLE_SCREENSHOT_AFTER_SEC` env vars so the assembler
+    // templates stay argv-agnostic.
+    screenshot_path: ?[]const u8 = null,
+    screenshot_after_ns: ?u64 = null,
 };
 
 /// Parsed `wasm serve` flags. Returned by `parseWasmServeArgs`; `null`
@@ -297,7 +306,7 @@ fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?str
 /// subsequent token is collected verbatim into `parsed_args.extra_args`
 /// without flag interpretation, so callers can forward args to the game
 /// binary via `zig build run -- <extras>` (see run_cmd handler).
-fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_args: *ParsedArgs) ?struct { dir: []const u8, scene: ?[]const u8, timeout_ns: ?u64, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool } {
+fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_args: *ParsedArgs) ?struct { dir: []const u8, scene: ?[]const u8, timeout_ns: ?u64, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool, screenshot_path: ?[]const u8, screenshot_after_ns: ?u64 } {
     var dir: []const u8 = ".";
     var dir_set = !allow_dir;
     var scene: ?[]const u8 = null;
@@ -307,6 +316,8 @@ fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_arg
     var docker_build = false;
     var docker_target: ?[]const u8 = null;
     var bake = false;
+    var screenshot_path: ?[]const u8 = null;
+    var screenshot_after_ns: ?u64 = null;
     var passthrough = false;
 
     while (args.next()) |arg| {
@@ -366,6 +377,47 @@ fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_arg
                 std.debug.print("labelle: --timeout requires a value (e.g. --timeout 30s)\n", .{});
                 return null;
             }
+        } else if (std.mem.startsWith(u8, arg, "--screenshot=")) {
+            const val = arg["--screenshot=".len..];
+            if (val.len == 0) {
+                std.debug.print("labelle {s}: --screenshot requires a path (e.g. --screenshot=/tmp/shot.png)\n", .{cmd_name});
+                return null;
+            }
+            screenshot_path = val;
+            continue;
+        } else if (std.mem.eql(u8, arg, "--screenshot")) {
+            if (args.next()) |val| {
+                if (val.len == 0) {
+                    std.debug.print("labelle {s}: --screenshot requires a path (e.g. --screenshot /tmp/shot.png)\n", .{cmd_name});
+                    return null;
+                }
+                screenshot_path = val;
+            } else {
+                std.debug.print("labelle {s}: --screenshot requires a path (e.g. --screenshot /tmp/shot.png)\n", .{cmd_name});
+                return null;
+            }
+            continue;
+        } else if (std.mem.startsWith(u8, arg, "--after=")) {
+            screenshot_after_ns = util.parseDuration(arg["--after=".len..]);
+            if (screenshot_after_ns == null) {
+                std.debug.print("labelle {s}: invalid --after value '{s}'\n", .{ cmd_name, arg["--after=".len..] });
+                std.debug.print("  expected format: --after=2s, --after=500ms\n", .{});
+                return null;
+            }
+            continue;
+        } else if (std.mem.eql(u8, arg, "--after")) {
+            if (args.next()) |val| {
+                screenshot_after_ns = util.parseDuration(val);
+                if (screenshot_after_ns == null) {
+                    std.debug.print("labelle {s}: invalid --after value '{s}'\n", .{ cmd_name, val });
+                    std.debug.print("  expected format: --after 2s, --after 500ms\n", .{});
+                    return null;
+                }
+            } else {
+                std.debug.print("labelle {s}: --after requires a value (e.g. --after 2s)\n", .{cmd_name});
+                return null;
+            }
+            continue;
         } else if (std.mem.startsWith(u8, arg, "--")) {
             std.debug.print("labelle {s}: unknown flag '{s}'\n", .{ cmd_name, arg });
             return null;
@@ -378,7 +430,13 @@ fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_arg
             dir_set = true;
         }
     }
-    return .{ .dir = dir, .scene = scene, .timeout_ns = timeout_ns, .platform = platform, .optimize = optimize, .docker_build = docker_build, .docker_target = docker_target, .bake = bake };
+    // `--after` without `--screenshot` is a user mistake worth flagging
+    // — the delay has no observable effect by itself. Don't fail though;
+    // a warning preserves forward-compat if future flags reuse `--after`.
+    if (screenshot_after_ns != null and screenshot_path == null) {
+        std.debug.print("labelle {s}: warning: --after has no effect without --screenshot\n", .{cmd_name});
+    }
+    return .{ .dir = dir, .scene = scene, .timeout_ns = timeout_ns, .platform = platform, .optimize = optimize, .docker_build = docker_build, .docker_target = docker_target, .bake = bake, .screenshot_path = screenshot_path, .screenshot_after_ns = screenshot_after_ns };
 }
 
 /// Collect all remaining args into extra_args buffer.
@@ -461,6 +519,8 @@ pub fn main(proc_init: std.process.Init) !void {
             parsed_args.docker = result.docker_build;
             parsed_args.docker_target = result.docker_target;
             parsed_args.bake = result.bake;
+            parsed_args.screenshot_path = result.screenshot_path;
+            parsed_args.screenshot_after_ns = result.screenshot_after_ns;
         } else if (std.mem.eql(u8, first, "init")) {
             parsed_args.command = .init_cmd;
             try collectExtraArgs(&args, &parsed_args);
@@ -587,6 +647,8 @@ pub fn main(proc_init: std.process.Init) !void {
             parsed_args.docker = result.docker_build;
             parsed_args.docker_target = result.docker_target;
             parsed_args.bake = result.bake;
+            parsed_args.screenshot_path = result.screenshot_path;
+            parsed_args.screenshot_after_ns = result.screenshot_after_ns;
         }
     }
 
@@ -906,21 +968,39 @@ pub fn main(proc_init: std.process.Init) !void {
         } else {
             std.debug.print("labelle: running...\n\n", .{});
         }
-        // cli#229: when --scene=<name> was passed, also surface the
-        // requested scene to the child via the `LABELLE_SCENE` env var.
-        // Loading-controller scripts read this AFTER `assets.allReady`
-        // succeeds and call `setScene(requested)`, so asset streaming
-        // for large scenes (e.g. flying-platform-labelle's `colony`,
-        // 6 atlas packs) no longer races boot. The legacy
-        // `.initial_prefab` rewrite above is kept as a deprecation
+        // Build a combined env map for the child when --scene (cli#229)
+        // and/or --screenshot (cli#227) are set. Both flags need to be
+        // surfaced as env vars to the spawned game:
+        //  - LABELLE_SCENE          (cli#229 runtime scene-override)
+        //  - LABELLE_SCREENSHOT_PATH
+        //  - LABELLE_SCREENSHOT_AFTER_SEC
+        // Loading-controller scripts read LABELLE_SCENE *after*
+        // assets.allReady succeeds and call setScene(requested), so
+        // asset streaming for large scenes no longer races boot. The
+        // legacy .initial_prefab rewrite above stays as a deprecation
         // bridge for projects without a loading-scene gate.
         var env_map_storage: ?std.process.Environ.Map = null;
         defer if (env_map_storage) |*m| m.deinit();
         var env_map_ptr: ?*const std.process.Environ.Map = null;
-        if (parsed_args.scene_override) |scene| {
-            env_map_storage = try runner.buildEnvironWithExtra(allocator, &.{
-                .{ .key = "LABELLE_SCENE", .value = scene },
-            });
+        const has_scene_env = parsed_args.scene_override != null;
+        const has_screenshot_env = parsed_args.screenshot_path != null;
+        if (has_scene_env or has_screenshot_env) {
+            var extras: std.ArrayList(runner.EnvKV) = .empty;
+            defer extras.deinit(allocator);
+            if (parsed_args.scene_override) |scene| {
+                try extras.append(allocator, .{ .key = "LABELLE_SCENE", .value = scene });
+            }
+            var sec_buf: [32]u8 = undefined;
+            if (parsed_args.screenshot_path) |path| {
+                try extras.append(allocator, .{ .key = "LABELLE_SCREENSHOT_PATH", .value = path });
+                if (parsed_args.screenshot_after_ns) |ns| {
+                    const sec_f64 = @as(f64, @floatFromInt(ns)) / @as(f64, std.time.ns_per_s);
+                    const sec_str = try std.fmt.bufPrint(&sec_buf, "{d:.3}", .{sec_f64});
+                    try extras.append(allocator, .{ .key = "LABELLE_SCREENSHOT_AFTER_SEC", .value = sec_str });
+                }
+                std.debug.print("labelle: screenshot will be written to '{s}'\n", .{path});
+            }
+            env_map_storage = try runner.buildEnvironWithExtra(allocator, extras.items);
             env_map_ptr = &env_map_storage.?;
         }
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -11,7 +11,7 @@ pub fn printHelp() void {
         \\  init <name> [dir]    Create a new labelle project
         \\  generate [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>]  Generate .labelle/ assembler files
         \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build the project
-        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>] [-- <args>...]  Generate + build + run (default; `--` forwards trailing args to the game)
+        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>] [--screenshot=<path> [--after=<dur>]] [-- <args>...]  Generate + build + run (default; `--screenshot` captures one frame; `--` forwards trailing args to the game)
         \\  wasm serve [dir] [--port <n>] [--no-build] [--no-open]  Build the WASM target, serve it locally (default port 8080), open the browser
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
@@ -31,6 +31,7 @@ pub fn printHelp() void {
         \\  labelle run
         \\  labelle run --timeout=30s
         \\  labelle run --scene=settings_menu
+        \\  labelle run --screenshot=/tmp/shot.png --after=2s
         \\  labelle generate --platform=wasm
         \\  labelle build --platform=wasm
         \\  labelle wasm serve

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -26,7 +26,8 @@ pub fn runZig(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []con
 ///
 /// `environ_map`, when non-null, *replaces* the child's environment block.
 /// Callers that need to *augment* the parent env (e.g. to inject
-/// `LABELLE_SCENE` for the cli#229 runtime scene-override flow) should
+/// `LABELLE_SCENE` for the cli#229 runtime scene-override flow, or
+/// `LABELLE_SCREENSHOT_PATH` for the cli#227 screenshot flow) should
 /// build the map by snapshotting the current process environ and adding
 /// the extra entries on top — see `runZigInheritWithEnv` below.
 pub fn runZigInherit(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []const u8, timeout_ns: ?u64) !u8 {

--- a/src/cli/util.zig
+++ b/src/cli/util.zig
@@ -129,9 +129,20 @@ pub fn appendToProfile(allocator: std.mem.Allocator, path: []const u8, line: []c
     return true;
 }
 
-/// Parse a duration string like "30s", "2m", or bare "30" (seconds).
+/// Parse a duration string like "500ms", "30s", "2m", or bare "30" (seconds).
+///
+/// `ms` is matched before the single-char suffixes so that the help
+/// text in `--after=<dur>` (which advertises `500ms`) actually works;
+/// without this branch the trailing `s` would parse as seconds and the
+/// leading `500m` would fail integer parsing.
 pub fn parseDuration(input: []const u8) ?u64 {
     if (input.len == 0) return null;
+
+    if (std.mem.endsWith(u8, input, "ms")) {
+        const num_str = input[0 .. input.len - 2];
+        const ms = std.fmt.parseInt(u64, num_str, 10) catch return null;
+        return std.math.mul(u64, ms, std.time.ns_per_ms) catch return null;
+    }
 
     const last = input[input.len - 1];
     const multiplier: u64 = switch (last) {


### PR DESCRIPTION
## Summary

- Adds `labelle run --screenshot=<path> [--after=<dur>]`. Captures one frame to `<path>` and exits cleanly. Raylib picks PNG/BMP/TGA from the extension.
- Forwarded to the spawned game via `LABELLE_SCREENSHOT_PATH` + `LABELLE_SCREENSHOT_AFTER_SEC` env vars (so the assembler templates stay argv-agnostic).
- `runner.runZigInherit` now takes an optional `environ_map` parameter so the screenshot vars piggyback on the child process spawn.
- Bumps CLI to **1.42.0**.

Closes #227 (after engine + assembler PRs land).

## Behavior

- No `--screenshot` → `environ_map` is null, child inherits parent env unchanged — zero behavior change for existing flows.
- `--screenshot=/tmp/x.png --after=2s` → seeds env from parent + adds the two vars, child fires once after 2 s.
- `--after` without `--screenshot` → warning ("has no effect"); no fail.

## Test plan

- [x] `zig build` ok
- [x] `zig build test` — exit 0
- [x] `labelle --help` lists the new flag + example
- [ ] Smoke verify end-to-end with bouncing-ball / flying-platform once the engine + assembler PRs are released

## Depends on

- labelle-engine#588 (provides `engine.requestedScreenshot`)
- labelle-assembler#210 (template wiring that calls `window.takeScreenshot`)