### PR TITLE
feat(run): pass --scene through LABELLE_SCENE env (#229)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.41.0",
+    .version = "1.42.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -654,6 +654,13 @@ pub fn main(proc_init: std.process.Init) !void {
 
     // Normalize the deprecated `.initial_scene` alias (RFC #560 / #565)
     // into `.initial_prefab`, then apply the --scene override on top.
+    //
+    // cli#229: `--scene` now ALSO sets `LABELLE_SCENE` in the spawned
+    // game's env so loading-scene controllers can pick up the requested
+    // scene AFTER `assets.allReady` (the safe, race-free path). The
+    // legacy `.initial_prefab` rewrite below stays as a deprecation
+    // bridge for projects without a loading-scene gate — once every
+    // game adopts the env-var path, the rewrite can be removed.
     parsed.normalizeInitialPrefab();
     if (parsed_args.scene_override) |scene| {
         parsed.initial_prefab = scene;
@@ -894,6 +901,24 @@ pub fn main(proc_init: std.process.Init) !void {
         } else {
             std.debug.print("labelle: running...\n\n", .{});
         }
+        // cli#229: when --scene=<name> was passed, also surface the
+        // requested scene to the child via the `LABELLE_SCENE` env var.
+        // Loading-controller scripts read this AFTER `assets.allReady`
+        // succeeds and call `setScene(requested)`, so asset streaming
+        // for large scenes (e.g. flying-platform-labelle's `colony`,
+        // 6 atlas packs) no longer races boot. The legacy
+        // `.initial_prefab` rewrite above is kept as a deprecation
+        // bridge for projects without a loading-scene gate.
+        var env_map_storage: ?std.process.Environ.Map = null;
+        defer if (env_map_storage) |*m| m.deinit();
+        var env_map_ptr: ?*const std.process.Environ.Map = null;
+        if (parsed_args.scene_override) |scene| {
+            env_map_storage = try runner.buildEnvironWithExtra(allocator, &.{
+                .{ .key = "LABELLE_SCENE", .value = scene },
+            });
+            env_map_ptr = &env_map_storage.?;
+        }
+
         // When --docker was used, run the built binary directly instead of
         // calling `zig build run` (local Zig may be broken).
         if (parsed_args.docker) {
@@ -909,14 +934,14 @@ pub fn main(proc_init: std.process.Init) !void {
             defer run_args.deinit(allocator);
             try run_args.append(allocator, bin_path);
             try appendRunForwardedArgs(&run_args, allocator, &parsed_args);
-            const run_result = try runner.runZigInherit(allocator, project_dir, run_args.items, timeout_ns);
+            const run_result = try runner.runZigInheritWithEnv(allocator, project_dir, run_args.items, timeout_ns, env_map_ptr);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }
         } else {
             try zig_args.append(allocator, "run");
             try appendRunForwardedArgs(&zig_args, allocator, &parsed_args);
-            const run_result = try runner.runZigInherit(allocator, target_dir, zig_args.items, timeout_ns);
+            const run_result = try runner.runZigInheritWithEnv(allocator, target_dir, zig_args.items, timeout_ns, env_map_ptr);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -23,7 +23,27 @@ pub fn runZig(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []con
 
 /// Run a zig command with inherited stdio (output goes straight to terminal).
 /// Optionally kills the process after `timeout_ns` nanoseconds.
+///
+/// `environ_map`, when non-null, *replaces* the child's environment block.
+/// Callers that need to *augment* the parent env (e.g. to inject
+/// `LABELLE_SCENE` for the cli#229 runtime scene-override flow) should
+/// build the map by snapshotting the current process environ and adding
+/// the extra entries on top — see `runZigInheritWithEnv` below.
 pub fn runZigInherit(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []const u8, timeout_ns: ?u64) !u8 {
+    return runZigInheritWithEnv(allocator, cwd, argv, timeout_ns, null);
+}
+
+/// Like `runZigInherit`, but accepts an optional environment map that
+/// replaces the child's environ when non-null. The map must already
+/// contain everything the child needs (parent env + extra keys); see
+/// `buildEnvironWithExtra` for the standard snapshot-and-add helper.
+pub fn runZigInheritWithEnv(
+    allocator: std.mem.Allocator,
+    cwd: []const u8,
+    argv: []const []const u8,
+    timeout_ns: ?u64,
+    environ_map: ?*const std.process.Environ.Map,
+) !u8 {
     const io = config.globalIo();
     var child = try std.process.spawn(io, .{
         .argv = argv,
@@ -32,6 +52,7 @@ pub fn runZigInherit(allocator: std.mem.Allocator, cwd: []const u8, argv: []cons
         .stdout = .inherit,
         .stderr = .inherit,
         .pgid = if (!is_windows and timeout_ns != null) 0 else null,
+        .environ_map = environ_map,
     });
 
     // Heap-allocate so the detached thread can safely access it after this function returns
@@ -81,6 +102,41 @@ pub fn runZigInherit(allocator: std.mem.Allocator, cwd: []const u8, argv: []cons
             return 1;
         },
     };
+}
+
+/// Build a fresh `Environ.Map` that mirrors the current process's
+/// environment block plus the entries in `extras`. The caller owns the
+/// returned map and must `deinit()` it after the spawned child has
+/// been waited on.
+///
+/// This exists because Zig's `process.spawn` treats `environ_map` as a
+/// *replacement* for the parent block — passing a one-entry map would
+/// strip PATH, HOME, etc. The cli#229 `LABELLE_SCENE` flow wants
+/// "parent env + one extra var," so we snapshot first.
+pub const EnvKV = struct { key: []const u8, value: []const u8 };
+
+pub fn buildEnvironWithExtra(
+    allocator: std.mem.Allocator,
+    extras: []const EnvKV,
+) !std.process.Environ.Map {
+    var map = std.process.Environ.Map.init(allocator);
+    errdefer map.deinit();
+
+    const environ = config.globalEnviron();
+    const block = environ.block;
+    switch (@TypeOf(block)) {
+        std.process.Environ.PosixBlock => try map.putPosixBlock(block.view()),
+        std.process.Environ.WindowsBlock => try map.putWindowsBlock(block.view()),
+        std.process.Environ.GlobalBlock => {
+            // Nothing to snapshot for global blocks — extras-only env.
+        },
+        else => @compileError("unsupported Environ.Block variant"),
+    }
+
+    for (extras) |kv| {
+        try map.put(kv.key, kv.value);
+    }
+    return map;
 }
 
 fn sleepNanos(ns: u64) void {


### PR DESCRIPTION
## Summary

- `labelle run --scene=<name>` now ALSO sets `LABELLE_SCENE=<name>` in the spawned game's env. Loading-scene controllers read it via `engine.requestedScene()` (labelle-engine#589, 1.45+) AFTER `assets.allReady` succeeds, swapping to the requested scene then.
- Fixes the frame-0 asset race that flying-platform-labelle's `colony` (6 atlas packs) was hitting under `labelle run --scene=colony`.
- The legacy `.initial_prefab` rewrite stays as a deprecation bridge for projects without a loading-scene gate. Both paths are active in 1.42.

## Implementation

- `runner.runZigInheritWithEnv(...)` — new variant that accepts `?*const Environ.Map`. `runZigInherit` delegates with `null` (unchanged behaviour for every existing caller).
- `runner.buildEnvironWithExtra(...)` — snapshots the parent environ block (PosixBlock / WindowsBlock / GlobalBlock) into a `Map` and overlays extras on top. Needed because `std.process.spawn`'s `environ_map` *replaces* the env wholesale; a one-entry map would strip PATH/HOME/etc.
- The run-command site in `src/cli.zig` builds the map iff `--scene` was passed, then routes the Docker-direct-bin and `zig build run` paths through `runZigInheritWithEnv`.

Channel choice — env var:
- argv was the alternative, but the cli already forwards trailing `-- <args>` for `--preview-mode`. A dedicated var keeps the runtime override out of argv parsing.
- Both ends agree on the key via `engine.runtime_env.SCENE_ENV_VAR` (single source of truth from the engine side).

## Migration notes for v1.42.0

- **Projects with a loading-scene controller** that adopts `engine.requestedScene()` get the safe path: loading boots first, atlas streaming finishes, controller swaps to the requested scene.
- **Projects without a loading-scene controller** keep the previous behaviour via the `.initial_prefab` rewrite (legacy bridge). No code changes required.
- Once every shipping game adopts the new pattern, the legacy bridge can be removed in a future major.

## Test plan

- [x] `zig build` — passes
- [x] `zig build test` — 140/140 pass (4 new added in #231 still pass)
- [x] flying-platform-labelle smoke: `labelle run --timeout=5s` and `labelle run --scene=colony --timeout=8s` both run to timeout without exiting at frame 0
- [ ] Land [labelle-engine#589](https://github.com/labelle-toolkit/labelle-engine/pull/589) first, then `Flying-Platform/flying-platform-labelle#TBD` (FP loading_controller adoption)

Closes #229