### PR TITLE
fix(scene): stop forwarding --scene to assembler (cli#229 follow-through #2)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -840,11 +840,16 @@ pub fn main(proc_init: std.process.Init) !void {
     // The CLI owns docker orchestration, the WASM serve loop, the
     // iOS/Android deploy paths and `--timeout` — generation is the only
     // step the assembler binary delegates.
+    // `parsed_args.scene_override` is intentionally NOT forwarded to the
+    // assembler. PR #243 removed the CLI's `cfg.initial_prefab` rewrite for
+    // exactly this reason; the assembler's own `--scene` handling does the
+    // same rewrite, which bypasses any loading-scene gate the project
+    // declares. The override is delivered at runtime via the
+    // `LABELLE_SCENE` env var injected at the spawn site (~line 990).
     try assembler_proc.generate(
         asm_bin,
         allocator,
         project_dir,
-        parsed_args.scene_override,
         @tagName(parsed.platform),
         @tagName(parsed.backend),
     );

--- a/src/cli/assembler_proc.zig
+++ b/src/cli/assembler_proc.zig
@@ -138,7 +138,15 @@ pub fn runSubcommand(
 /// `platform` / `backend` are forwarded as plain strings (`@tagName` of
 /// the CLI's enums) so this module needs no dependency on the assembler's
 /// type definitions. The assembler validates them against its own enums.
-/// `scene_override` mirrors the user-facing `--scene` flag.
+///
+/// The `--scene` flag is *not* forwarded to the assembler: PR #243 (cli#229
+/// follow-through) removed the CLI's `cfg.initial_prefab` rewrite, but the
+/// assembler still rewrites `cfg.initial_prefab = scene_override` when it
+/// receives `--scene`, which re-introduces the same loading-scene-gate
+/// bypass on the assembler side. The runtime `LABELLE_SCENE` env-var
+/// injection (see cli.zig:~990) is now the sole mechanism for the
+/// user-facing `--scene` flag; the assembler always compiles a stable
+/// artifact with `initial_prefab` taken straight from `project.labelle`.
 ///
 /// On a non-zero exit code, returns `error.AssemblerFailed`; the binary's
 /// inherited stderr already explains the failure.
@@ -146,23 +154,88 @@ pub fn generate(
     asm_bin: Assembler,
     allocator: std.mem.Allocator,
     project_dir: []const u8,
-    scene_override: ?[]const u8,
     platform: []const u8,
     backend: []const u8,
 ) !void {
     var args: std.ArrayList([]const u8) = .empty;
     defer args.deinit(allocator);
 
+    try buildGenerateArgs(allocator, &args, project_dir, platform, backend);
+
+    try asm_bin.run(allocator, "generate", args.items);
+}
+
+/// Build the argv slice for the assembler's `generate` subcommand.
+/// Extracted so a test can assert the CLI never injects `--scene` into
+/// the assembler invocation, even though the user-facing `--scene` flag
+/// is still accepted by the CLI (it routes through `LABELLE_SCENE` env
+/// injection at the spawn site instead — see cli.zig:~990).
+fn buildGenerateArgs(
+    allocator: std.mem.Allocator,
+    args: *std.ArrayList([]const u8),
+    project_dir: []const u8,
+    platform: []const u8,
+    backend: []const u8,
+) !void {
     try args.appendSlice(allocator, &.{ "--project-root", project_dir });
-    if (scene_override) |s| try args.appendSlice(allocator, &.{ "--scene", s });
     // Always forward platform/backend — the CLI may have mutated them
     // (e.g. `labelle ios` forces sokol+ios) and the binary must not
     // re-derive its own values from project.labelle.
     try args.appendSlice(allocator, &.{ "--platform", platform });
     try args.appendSlice(allocator, &.{ "--backend", backend });
-
-    try asm_bin.run(allocator, "generate", args.items);
 }
+
+const expect = @import("zspec").expect;
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+/// Regression guard for the cli#229 follow-through (#2). PR #243 removed
+/// the CLI's own `cfg.initial_prefab` rewrite when `--scene=X` was passed,
+/// but the assembler binary *also* rewrites `cfg.initial_prefab =
+/// scene_override` whenever it receives `--scene` — bypassing the
+/// loading-scene gate exactly the same way the CLI rewrite used to.
+///
+/// Contract: even when the user passes `--scene=X` to the CLI, the
+/// argv this module sends to `labelle-assembler generate` must NOT
+/// contain `--scene`. The override travels at runtime via the
+/// `LABELLE_SCENE` env var the CLI injects when it spawns the game.
+pub const BuildGenerateArgsSpec = struct {
+    pub const no_scene_forwarding = struct {
+        test "argv to assembler never contains --scene" {
+            const allocator = std.testing.allocator;
+            var args: std.ArrayList([]const u8) = .empty;
+            defer args.deinit(allocator);
+
+            try buildGenerateArgs(allocator, &args, "/proj", "desktop", "raylib");
+
+            for (args.items) |a| {
+                try std.testing.expect(!std.mem.eql(u8, a, "--scene"));
+            }
+        }
+    };
+
+    pub const forwards_project_platform_backend = struct {
+        test "argv carries --project-root, --platform, --backend" {
+            const allocator = std.testing.allocator;
+            var args: std.ArrayList([]const u8) = .empty;
+            defer args.deinit(allocator);
+
+            try buildGenerateArgs(allocator, &args, "/proj", "desktop", "raylib");
+
+            const expected: []const []const u8 = &.{
+                "--project-root", "/proj",
+                "--platform",     "desktop",
+                "--backend",      "raylib",
+            };
+            try std.testing.expectEqual(expected.len, args.items.len);
+            for (expected, args.items) |want, got| {
+                try std.testing.expectEqualStrings(want, got);
+            }
+        }
+    };
+};
 
 /// Spawn `exe_path <subcommand> [args...]`, inherit stdio, wait, and map
 /// the result onto a Zig error. Shared by `Assembler.run` and


### PR DESCRIPTION
## Summary

- PR #243 removed the CLI's own `cfg.initial_prefab = scene_override` rewrite, but the CLI was still passing `--scene=<name>` to the `labelle-assembler generate` subprocess. The assembler binary performs the same rewrite there (see `labelle-assembler/src/main.zig:197`), so `labelle run --scene=colony` still emitted `g.setScene("colony")` as the startup call and bypassed the loading-scene gate just like before #243.
- The runtime `LABELLE_SCENE` env-var injected at the spawn site (`cli.zig:~990`) is now the sole mechanism for the user-facing `--scene` flag. The assembler invocation compiles a stable artifact with `initial_prefab` taken straight from `project.labelle`.
- Drops the `scene_override` parameter from `assembler_proc.generate` (it had no other purpose), and extracts a small `buildGenerateArgs` helper so a regression test can pin the contract: the argv sent to the assembler must never contain `--scene`.

## Test plan

- [x] `zig build test` — 253/253 tests pass (up from 250 baseline; the 3 new tests are the `buildGenerateArgs` spec covering no-`--scene`-forwarding and the still-forwarded `--project-root`/`--platform`/`--backend` triple).
- [ ] Manual: `labelle run --scene=colony` against a loading-gated project — confirm the startup call is `g.setScene("loading")` (from project.labelle), and the loading controller transitions to `colony` after `assets.allReady` via `engine.requestedScene()`.

Follow-through to #243.