### PR TITLE
release: labelle-cli v1.46.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.46.1",
+    .version = "1.46.2",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone


### PR DESCRIPTION
Version bump to 1.46.2 for release (captures the merged controller work). Temp core/dep commit-pins left as-is (functionally fine post core-unify #259); pin->tag hygiene tracked as a follow-up.