### PR TITLE
feat(doctor): labelle doctor - desktop dependency preflight + SDL2 provisioning

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -793,10 +793,12 @@ pub fn main(proc_init: std.process.Init) !void {
     // build/run environment so desktop games that need it (raylib/sokol
     // gamepad, sdl backend) link + run without the user setting
     // LABELLE_SDL2_LIB by hand. No-op when SDL2 isn't in the cache or the
-    // user already set the var. (cli desktop SDL2 provisioning.)
-    if (parsed.platform == .desktop and
-        (parsed.backend == .raylib or parsed.backend == .sokol or parsed.backend == .sdl))
-    {
+    // user already set the var. Scoped like `labelle doctor`: the sdl
+    // backend always needs SDL2; raylib/sokol only for the gamepad
+    // source, so `.gamepad = .none` projects get nothing injected.
+    const wants_sdl2 = parsed.backend == .sdl or
+        ((parsed.backend == .raylib or parsed.backend == .sokol) and parsed.gamepad != .none);
+    if (parsed.platform == .desktop and wants_sdl2) {
         sdl_provision.autoWireEnv(allocator);
     }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -40,8 +40,10 @@ const util = @import("cli/util.zig");
 const pack = @import("cli/pack.zig");
 const audit = @import("cli/audit.zig");
 const migrate = @import("cli/migrate.zig");
+const doctor = @import("cli/doctor.zig");
+const sdl_provision = @import("cli/sdl_provision.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, audit_cmd, migrate_cmd };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, audit_cmd, migrate_cmd, doctor_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -563,6 +565,9 @@ pub fn main(proc_init: std.process.Init) !void {
         } else if (std.mem.eql(u8, first, "migrate")) {
             parsed_args.command = .migrate_cmd;
             try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "doctor")) {
+            parsed_args.command = .doctor_cmd;
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "ios")) {
             parsed_args.command = .ios_cmd;
             // First non-flag arg that isn't a subcommand is the project dir
@@ -673,6 +678,7 @@ pub fn main(proc_init: std.process.Init) !void {
         .pack_cmd => return pack.cmdPack(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .audit_cmd => return audit.cmdAudit(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .migrate_cmd => return migrate.cmdMigrate(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .doctor_cmd => return doctor.cmdDoctor(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
     }
@@ -782,6 +788,17 @@ pub fn main(proc_init: std.process.Init) !void {
 
     // Validate version compatibility
     compatibility.validateCompatibility(parsed);
+
+    // Auto-wire a cache-provisioned SDL2 (`labelle doctor --fix`) into the
+    // build/run environment so desktop games that need it (raylib/sokol
+    // gamepad, sdl backend) link + run without the user setting
+    // LABELLE_SDL2_LIB by hand. No-op when SDL2 isn't in the cache or the
+    // user already set the var. (cli desktop SDL2 provisioning.)
+    if (parsed.platform == .desktop and
+        (parsed.backend == .raylib or parsed.backend == .sokol or parsed.backend == .sdl))
+    {
+        sdl_provision.autoWireEnv(allocator);
+    }
 
     // Issue #217: the CLI is a thin driver over the standalone
     // labelle-assembler binary. Resolve it once here (LABELLE_ASSEMBLER

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -18,7 +18,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const config = @import("config.zig");
 const project_config = @import("project_config.zig");
-const asm_cache = @import("asm_cache.zig");
 const sdl_provision = @import("sdl_provision.zig");
 
 const Check = struct {
@@ -228,6 +227,13 @@ fn checkSdl2Headers(arena: std.mem.Allocator) Check {
                 const inc = std.fs.path.join(arena, &.{ dir, "..", "include", "SDL2", "SDL.h" }) catch dir;
                 if (fileExists(inc)) return ok(name, inc);
             }
+            // The --fix-provisioned MinGW package ships headers beside the
+            // lib — accept the cache here the same way checkSdl2Lib does,
+            // so a fixed setup passes the headers check too.
+            if (findCachedSdl2Lib(arena)) |libdir| {
+                const inc = std.fs.path.join(arena, &.{ libdir, "..", "include", "SDL2", "SDL.h" }) catch libdir;
+                if (fileExists(inc)) return ok(name, inc);
+            }
             return fail(name, "SDL2 headers not found. The `sdl` render backend needs the SDL2 dev headers (SDL2/SDL.h) from the MinGW dev package.");
         },
         .linux => {
@@ -308,20 +314,10 @@ fn onPath(arena: std.mem.Allocator, filename: []const u8) ?[]const u8 {
     return null;
 }
 
-/// Scan `~/.labelle/sdl2/*/x86_64-w64-mingw32/lib` for the import lib (the
-/// layout Phase 2 provisioning will populate).
+/// Cached SDL2 lib dir, any version. Delegates to the provisioner's scan
+/// so detection here and the build/run env wiring share one acceptance
+/// rule — doctor must never report a cache green that autoWireEnv then
+/// ignores.
 fn findCachedSdl2Lib(arena: std.mem.Allocator) ?[]const u8 {
-    const io = config.globalIo();
-    const root = asm_cache.getCacheRoot(arena) catch return null;
-    const sdl_root = std.fs.path.join(arena, &.{ root, "sdl2" }) catch return null;
-    var dir = std.Io.Dir.cwd().openDir(io, sdl_root, .{ .iterate = true }) catch return null;
-    defer dir.close(io);
-    var it = dir.iterate();
-    while (it.next(io) catch return null) |entry| {
-        if (entry.kind != .directory) continue;
-        const lib = std.fs.path.join(arena, &.{ sdl_root, entry.name, "x86_64-w64-mingw32", "lib" }) catch continue;
-        const probe = std.fs.path.join(arena, &.{ lib, "libSDL2.dll.a" }) catch continue;
-        if (fileExists(probe)) return lib;
-    }
-    return null;
+    return sdl_provision.findCachedLibDir(arena);
 }

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1,0 +1,327 @@
+//! `labelle doctor` — preflight the desktop build/run requirements and report
+//! missing system dependencies with actionable fixes.
+//!
+//! Desktop counterpart of `labelle android doctor`. Almost everything a
+//! labelle game needs is fetched + compiled by Zig automatically (raylib,
+//! sokol, cimgui, glfw, wgpu-native, the labelle packages). The one genuine
+//! manual system dependency is **SDL2** — used by the raylib/sokol backends
+//! for the desktop gamepad source, and by the `sdl` backend as the renderer
+//! (which additionally needs the headers + SDL2_mixer). When it is missing the
+//! build otherwise fails deep in a Zig linker dump ("unable to find dynamic
+//! system library 'SDL2'"); this command surfaces it up front instead.
+//!
+//! `--fix` auto-provisions SDL2 into `~/.labelle/sdl2/` on Windows (see
+//! `sdl_provision.zig`); `build`/`run` then auto-wire the cached install
+//! into the child environment so it works without manual env setup.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const config = @import("config.zig");
+const project_config = @import("project_config.zig");
+const asm_cache = @import("asm_cache.zig");
+const sdl_provision = @import("sdl_provision.zig");
+
+const Check = struct {
+    name: []const u8,
+    ok: bool,
+    /// Shown indented under an OK line (e.g. the resolved path or version).
+    detail: ?[]const u8 = null,
+    /// Shown under a FAIL/WARN line — the actionable fix.
+    hint: ?[]const u8 = null,
+    /// Required misses are FAIL (non-zero exit); optional misses are WARN.
+    required: bool = true,
+};
+
+pub fn cmdDoctor(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    var arena_inst = std.heap.ArenaAllocator.init(allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var project_dir: []const u8 = ".";
+    var do_fix = false;
+    for (cmd_args) |arg| {
+        if (std.mem.eql(u8, arg, "--fix")) {
+            do_fix = true;
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            std.debug.print("labelle doctor: unknown option '{s}'\n  usage: labelle doctor [dir] [--fix]\n", .{arg});
+            return error.InvalidArgument;
+        } else {
+            project_dir = arg;
+        }
+    }
+
+    // Best-effort read of project.labelle to scope what's actually required.
+    const cfg = readProjectConfig(arena, project_dir);
+    const effective_backend = cfg.backend orelse .raylib;
+
+    const needs_sdl_render = effective_backend == .sdl;
+    const needs_sdl_gamepad = switch (effective_backend) {
+        .raylib, .sokol, .sdl => !cfg.gamepad_off,
+        else => false,
+    };
+    const needs_sdl = needs_sdl_render or needs_sdl_gamepad;
+
+    var checks: std.ArrayList(Check) = .empty;
+
+    try checks.append(arena, checkZig(arena));
+
+    if (needs_sdl) {
+        var lib = checkSdl2Lib(arena);
+        if (!lib.ok and do_fix) {
+            std.debug.print("\nlabelle doctor: provisioning SDL2...\n", .{});
+            _ = sdl_provision.provisionSdl2(allocator);
+            lib = checkSdl2Lib(arena); // re-detect — the cache scan now finds it
+        }
+        try checks.append(arena, lib);
+        if (builtin.os.tag == .windows) try checks.append(arena, checkSdl2Dll(arena));
+        if (needs_sdl_render) {
+            try checks.append(arena, checkSdl2Headers(arena));
+            try checks.append(arena, checkSdl2Mixer(arena));
+        }
+    } else if (do_fix) {
+        std.debug.print("labelle doctor: nothing to fix — this backend needs no system libraries.\n", .{});
+    }
+
+    // ── Report ──────────────────────────────────────────────────────────
+    const backend_label = if (cfg.backend) |b| @tagName(b) else "unknown (no project.labelle)";
+    const gamepad_label = if (needs_sdl_gamepad) "on" else if (needs_sdl) "off" else "n/a";
+    std.debug.print(
+        \\
+        \\labelle doctor
+        \\==============
+        \\  project: {s}
+        \\  backend: {s}   gamepad: {s}
+        \\
+        \\
+    , .{ project_dir, backend_label, gamepad_label });
+
+    if (!needs_sdl) {
+        std.debug.print("  This backend needs no manual system libraries — everything is fetched + built by Zig.\n", .{});
+    }
+
+    var failures: u32 = 0;
+    var warnings: u32 = 0;
+    for (checks.items) |c| {
+        if (c.ok) {
+            std.debug.print("  [  OK  ] {s}\n", .{c.name});
+            if (c.detail) |d| std.debug.print("           {s}\n", .{d});
+        } else if (c.required) {
+            failures += 1;
+            std.debug.print("  [ FAIL ] {s}\n", .{c.name});
+            if (c.hint) |h| std.debug.print("           -> {s}\n", .{h});
+        } else {
+            warnings += 1;
+            std.debug.print("  [ WARN ] {s}\n", .{c.name});
+            if (c.hint) |h| std.debug.print("           -> {s}\n", .{h});
+        }
+    }
+
+    std.debug.print("\n", .{});
+    if (failures == 0) {
+        std.debug.print("  All required desktop build dependencies are present.\n\n", .{});
+    } else {
+        std.debug.print("  {d} required dependency(ies) missing — see FAIL lines above.\n\n", .{failures});
+        // Clean non-zero exit (scriptable) without a Zig error-return trace —
+        // this is a user-facing diagnostic, not an internal failure.
+        std.process.exit(1);
+    }
+}
+
+// ── Project config (textual, dependency-free) ───────────────────────────
+
+const Cfg = struct {
+    backend: ?project_config.Backend = null,
+    gamepad_off: bool = false,
+};
+
+/// Read backend + gamepad opt-out straight out of `project.labelle` text. A
+/// full ZON parse isn't worth a dependency here; the two fields we need are
+/// simple `.field = .value` forms.
+fn readProjectConfig(arena: std.mem.Allocator, project_dir: []const u8) Cfg {
+    const io = config.globalIo();
+    const path = std.fs.path.join(arena, &.{ project_dir, "project.labelle" }) catch return .{};
+    const content = std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(1 << 20)) catch return .{};
+
+    var cfg: Cfg = .{};
+    if (std.mem.indexOf(u8, content, ".backend = .")) |idx| {
+        const start = idx + ".backend = .".len;
+        var end = start;
+        while (end < content.len and (std.ascii.isAlphanumeric(content[end]) or content[end] == '_')) end += 1;
+        cfg.backend = std.meta.stringToEnum(project_config.Backend, content[start..end]);
+    }
+    cfg.gamepad_off = std.mem.indexOf(u8, content, ".gamepad = .none") != null or
+        std.mem.indexOf(u8, content, ".gamepad=.none") != null;
+    return cfg;
+}
+
+// ── Individual checks ───────────────────────────────────────────────────
+
+fn checkZig(arena: std.mem.Allocator) Check {
+    const res = std.process.run(arena, config.globalIo(), .{ .argv = &.{ "zig", "version" } }) catch {
+        return .{
+            .name = "Zig toolchain",
+            .ok = false,
+            .hint = "`zig` not found on PATH. Install Zig 0.15.2+ (https://ziglang.org/download), or use zvm.",
+        };
+    };
+    const passed = switch (res.term) {
+        .exited => |c| c == 0,
+        else => false,
+    };
+    if (!passed) return .{
+        .name = "Zig toolchain",
+        .ok = false,
+        .hint = "`zig` is on PATH but failed to run. Reinstall Zig 0.15.2+.",
+    };
+    const ver = std.mem.trim(u8, res.stdout, " \r\n\t");
+    return .{ .name = "Zig toolchain", .ok = true, .detail = std.fmt.allocPrint(arena, "zig {s}", .{ver}) catch "zig (version unknown)" };
+}
+
+fn checkSdl2Lib(arena: std.mem.Allocator) Check {
+    const name = "SDL2 library (gamepad + sdl backend)";
+    switch (builtin.os.tag) {
+        .windows => {
+            if (envOwned(arena, "LABELLE_SDL2_LIB")) |dir| {
+                const probe = std.fs.path.join(arena, &.{ dir, "libSDL2.dll.a" }) catch dir;
+                if (fileExists(probe)) return ok(name, dir);
+            }
+            if (findCachedSdl2Lib(arena)) |dir| return ok(name, dir);
+            return .{ .name = name, .ok = false, .hint = "SDL2 (MinGW dev libs) not found. Download SDL2-devel-<ver>-mingw, then set LABELLE_SDL2_LIB to its x86_64-w64-mingw32\\lib dir (and put SDL2.dll on PATH). Or set `.gamepad = .none` in project.labelle if you don't need gamepad input. (`labelle doctor --fix` will automate this soon.)" };
+        },
+        .linux => {
+            if (runOk(arena, &.{ "pkg-config", "--exists", "sdl2" })) return ok(name, "pkg-config: sdl2");
+            for ([_][]const u8{ "/usr/lib/x86_64-linux-gnu/libSDL2.so", "/usr/lib/libSDL2.so", "/usr/lib64/libSDL2.so", "/usr/local/lib/libSDL2.so" }) |p| {
+                if (fileExists(p)) return ok(name, p);
+            }
+            return .{ .name = name, .ok = false, .hint = "SDL2 not found. Install it: `sudo apt install libsdl2-dev` (Debian/Ubuntu) or `sudo dnf install SDL2-devel` (Fedora). Or set `.gamepad = .none`." };
+        },
+        .macos => {
+            for ([_][]const u8{ "/opt/homebrew/lib/libSDL2.dylib", "/usr/local/lib/libSDL2.dylib" }) |p| {
+                if (fileExists(p)) return ok(name, p);
+            }
+            return .{ .name = name, .ok = false, .hint = "SDL2 not found. Install it: `brew install sdl2`. Or set `.gamepad = .none`." };
+        },
+        else => return .{ .name = name, .ok = false, .hint = "Unsupported desktop OS for SDL2 detection." },
+    }
+}
+
+fn checkSdl2Dll(arena: std.mem.Allocator) Check {
+    const name = "SDL2.dll for runtime";
+    if (onPath(arena, "SDL2.dll")) |p| return ok(name, p);
+    // The provisioner places SDL2.dll in the cache lib dir; accept that so a
+    // freshly `--fix`ed setup reports green. (Auto-wiring PATH for `run` is a
+    // later phase; until then add this dir to PATH for standalone runs.)
+    if (findCachedSdl2Lib(arena)) |libdir| {
+        const dll = std.fs.path.join(arena, &.{ libdir, "SDL2.dll" }) catch libdir;
+        if (fileExists(dll)) {
+            return .{ .name = name, .ok = true, .detail = std.fmt.allocPrint(arena, "{s} (labelle SDL2 cache — add this dir to PATH for runtime)", .{libdir}) catch dll };
+        }
+    }
+    return .{ .name = name, .ok = false, .required = false, .hint = "SDL2.dll is needed at runtime. Add the SDL2 `bin` dir to PATH, or run `labelle doctor --fix`." };
+}
+
+fn checkSdl2Headers(arena: std.mem.Allocator) Check {
+    const name = "SDL2 headers (sdl backend)";
+    switch (builtin.os.tag) {
+        .windows => {
+            if (envOwned(arena, "LABELLE_SDL2_LIB")) |dir| {
+                const inc = std.fs.path.join(arena, &.{ dir, "..", "include", "SDL2", "SDL.h" }) catch dir;
+                if (fileExists(inc)) return ok(name, inc);
+            }
+            return fail(name, "SDL2 headers not found. The `sdl` render backend needs the SDL2 dev headers (SDL2/SDL.h) from the MinGW dev package.");
+        },
+        .linux => {
+            if (runOk(arena, &.{ "pkg-config", "--cflags", "sdl2" })) return ok(name, "pkg-config: sdl2 cflags");
+            if (fileExists("/usr/include/SDL2/SDL.h")) return ok(name, "/usr/include/SDL2/SDL.h");
+            return fail(name, "SDL2 headers not found. `sudo apt install libsdl2-dev` / `sudo dnf install SDL2-devel`.");
+        },
+        .macos => {
+            for ([_][]const u8{ "/opt/homebrew/include/SDL2/SDL.h", "/usr/local/include/SDL2/SDL.h" }) |p| {
+                if (fileExists(p)) return ok(name, p);
+            }
+            return fail(name, "SDL2 headers not found. `brew install sdl2`.");
+        },
+        else => return fail(name, "Unsupported OS."),
+    }
+}
+
+fn checkSdl2Mixer(arena: std.mem.Allocator) Check {
+    const name = "SDL2_mixer (sdl backend audio)";
+    switch (builtin.os.tag) {
+        .windows => {
+            if (envOwned(arena, "LABELLE_SDL2_LIB")) |dir| {
+                const probe = std.fs.path.join(arena, &.{ dir, "libSDL2_mixer.dll.a" }) catch dir;
+                if (fileExists(probe)) return ok(name, probe);
+            }
+            return fail(name, "SDL2_mixer not found. The `sdl` backend's audio needs SDL2_mixer-devel (MinGW). Download SDL2_mixer-devel-<ver>-mingw alongside SDL2.");
+        },
+        .linux => {
+            if (runOk(arena, &.{ "pkg-config", "--exists", "SDL2_mixer" })) return ok(name, "pkg-config: SDL2_mixer");
+            return fail(name, "SDL2_mixer not found. `sudo apt install libsdl2-mixer-dev` / `sudo dnf install SDL2_mixer-devel`.");
+        },
+        .macos => {
+            for ([_][]const u8{ "/opt/homebrew/lib/libSDL2_mixer.dylib", "/usr/local/lib/libSDL2_mixer.dylib" }) |p| {
+                if (fileExists(p)) return ok(name, p);
+            }
+            return fail(name, "SDL2_mixer not found. `brew install sdl2_mixer`.");
+        },
+        else => return fail(name, "Unsupported OS."),
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn ok(name: []const u8, detail: []const u8) Check {
+    return .{ .name = name, .ok = true, .detail = detail };
+}
+
+fn fail(name: []const u8, hint: []const u8) Check {
+    return .{ .name = name, .ok = false, .hint = hint };
+}
+
+fn fileExists(path: []const u8) bool {
+    std.Io.Dir.cwd().access(config.globalIo(), path, .{}) catch return false;
+    return true;
+}
+
+fn envOwned(arena: std.mem.Allocator, key: []const u8) ?[]u8 {
+    if (config.globalEnviron().getAlloc(arena, key)) |v| return v else |_| return null;
+}
+
+/// Run a command and report whether it exited 0. Used for `pkg-config` probes.
+fn runOk(arena: std.mem.Allocator, argv: []const []const u8) bool {
+    const res = std.process.run(arena, config.globalIo(), .{ .argv = argv }) catch return false;
+    return switch (res.term) {
+        .exited => |c| c == 0,
+        else => false,
+    };
+}
+
+/// First PATH entry containing `filename`, or null.
+fn onPath(arena: std.mem.Allocator, filename: []const u8) ?[]const u8 {
+    const path = envOwned(arena, "PATH") orelse return null;
+    var it = std.mem.tokenizeScalar(u8, path, std.fs.path.delimiter);
+    while (it.next()) |dir| {
+        const full = std.fs.path.join(arena, &.{ dir, filename }) catch continue;
+        if (fileExists(full)) return full;
+    }
+    return null;
+}
+
+/// Scan `~/.labelle/sdl2/*/x86_64-w64-mingw32/lib` for the import lib (the
+/// layout Phase 2 provisioning will populate).
+fn findCachedSdl2Lib(arena: std.mem.Allocator) ?[]const u8 {
+    const io = config.globalIo();
+    const root = asm_cache.getCacheRoot(arena) catch return null;
+    const sdl_root = std.fs.path.join(arena, &.{ root, "sdl2" }) catch return null;
+    var dir = std.Io.Dir.cwd().openDir(io, sdl_root, .{ .iterate = true }) catch return null;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch return null) |entry| {
+        if (entry.kind != .directory) continue;
+        const lib = std.fs.path.join(arena, &.{ sdl_root, entry.name, "x86_64-w64-mingw32", "lib" }) catch continue;
+        const probe = std.fs.path.join(arena, &.{ lib, "libSDL2.dll.a" }) catch continue;
+        if (fileExists(probe)) return lib;
+    }
+    return null;
+}

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -23,6 +23,7 @@ pub fn printHelp() void {
         \\  test [dir] [--verbose] [--no-libs]  Run inline `test` blocks across the project source tree
         \\  audit unification [dir]  Pre-flight check for the unified scene/prefab loader (RFC #560)
         \\  migrate unified [dir] [--dry-run]  Auto-fix legacy unified-format patterns (RFC #594 / engine#592)
+        \\  doctor [dir]         Check desktop build requirements (SDL2, Zig) and report fixes
         \\  help                 Show this help
         \\  version              Show CLI version
         \\

--- a/src/cli/project_config.zig
+++ b/src/cli/project_config.zig
@@ -220,6 +220,9 @@ pub const ResolvedGui = struct {
     bridge_artifact: []const u8 = "",
 };
 
+/// Gamepad opt-out, mirroring assembler `src/config.zig` (gamepad: .auto | .none).
+pub const GamepadMode = enum { auto, none };
+
 pub const ProjectConfig = struct {
     name: []const u8,
     description: []const u8 = "",
@@ -231,6 +234,10 @@ pub const ProjectConfig = struct {
     backend: Backend = .raylib,
     platform: Platform = .desktop,
     ecs: EcsChoice = .mock,
+    /// Gamepad input mode (assembler#274 opt-out flag): `.auto` (default)
+    /// pulls the shared SDL gamepad source into raylib/sokol desktop
+    /// builds; `.none` disables it (and drops the SDL2 link dependency).
+    gamepad: GamepadMode = .auto,
     /// GUI plugin reference — parsed from project.labelle.
     gui: ?GuiPlugin = null,
     layers: []const LayerDef = &.{

--- a/src/cli/sdl_provision.zig
+++ b/src/cli/sdl_provision.zig
@@ -1,0 +1,191 @@
+//! SDL2 auto-provisioning for `labelle doctor --fix`.
+//!
+//! SDL2 is the one manual system dependency a labelle desktop game needs (the
+//! raylib/sokol gamepad source + the sdl render backend). On Windows there is
+//! no system package manager, so this module downloads the official MinGW dev
+//! package into `~/.labelle/sdl2/` and arranges it exactly the way Zig's
+//! linker wants (import lib + the DLL placed in the lib search dir, static
+//! archives removed so the dynamic candidate wins). On Linux/macOS a system
+//! install needs privileges we won't assume, so we print the one-liner.
+//!
+//! The cache layout produced here is the one `doctor.zig:findCachedSdl2Lib`
+//! scans, and that a later phase wires into the build/run env automatically.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const config = @import("config.zig");
+const util = @import("util.zig");
+const asm_cache = @import("asm_cache.zig");
+
+/// SDL2 release to fetch. Matches the version verified against the toolkit's
+/// Windows backends.
+pub const SDL2_VERSION = "2.30.11";
+
+pub const Result = enum {
+    /// SDL2 is available in the cache (freshly provisioned or already there).
+    ready,
+    /// Printed package-manager guidance (Linux/macOS) — user action needed.
+    guided,
+    /// Download/extract failed.
+    failed,
+};
+
+/// Resolve the cache lib dir SDL2 is (or will be) provisioned into:
+/// `~/.labelle/sdl2/SDL2-<ver>/x86_64-w64-mingw32/lib`. Caller owns the slice.
+pub fn cachedLibDir(allocator: std.mem.Allocator) ![]u8 {
+    const cache_root = try asm_cache.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+    return std.fs.path.join(allocator, &.{ cache_root, "sdl2", "SDL2-" ++ SDL2_VERSION, "x86_64-w64-mingw32", "lib" });
+}
+
+/// Ensure SDL2 is available, downloading it on Windows if needed.
+pub fn provisionSdl2(gpa: std.mem.Allocator) Result {
+    switch (builtin.os.tag) {
+        .windows => return provisionWindows(gpa),
+        .linux => {
+            std.debug.print(
+                \\
+                \\  SDL2 must be installed via your system package manager:
+                \\    sudo apt install libsdl2-dev libsdl2-mixer-dev    # Debian/Ubuntu
+                \\    sudo dnf install SDL2-devel SDL2_mixer-devel      # Fedora
+                \\    sudo pacman -S sdl2 sdl2_mixer                    # Arch
+                \\
+            , .{});
+            return .guided;
+        },
+        .macos => {
+            std.debug.print(
+                \\
+                \\  Install SDL2 via Homebrew:
+                \\    brew install sdl2 sdl2_mixer
+                \\
+            , .{});
+            return .guided;
+        },
+        else => return .failed,
+    }
+}
+
+/// If SDL2 was provisioned into the cache (by `doctor --fix`) and the user
+/// hasn't set `LABELLE_SDL2_LIB` themselves, inject it — plus prepend the dir
+/// (which holds SDL2.dll) to PATH for runtime — into THIS process's
+/// environment, so the `zig build` / game children spawned afterwards inherit
+/// it. No-op off Windows, or when the cache is absent, or when the user
+/// already set `LABELLE_SDL2_LIB`. This is what makes a desktop build/run
+/// "just work" after a one-time `labelle doctor --fix`.
+pub fn autoWireEnv(gpa: std.mem.Allocator) void {
+    if (builtin.os.tag != .windows) return;
+    var arena_inst = std.heap.ArenaAllocator.init(gpa);
+    defer arena_inst.deinit();
+    const a = arena_inst.allocator();
+
+    const lib_dir = cachedLibDir(a) catch return;
+    const importlib = join(a, &.{ lib_dir, "libSDL2.dll.a" }) orelse return;
+    if (!util.fileExists(importlib)) return; // nothing provisioned
+
+    const env = config.globalEnviron();
+
+    // LABELLE_SDL2_LIB — respect a user-provided value; otherwise point at the cache.
+    const existing = env.getAlloc(a, "LABELLE_SDL2_LIB") catch null;
+    if (existing == null or existing.?.len == 0) {
+        setEnvW(a, "LABELLE_SDL2_LIB", lib_dir);
+        std.debug.print("labelle: using cached SDL2 ({s})\n", .{lib_dir});
+    }
+
+    // PATH — prepend the cache lib dir (contains SDL2.dll) for runtime, once.
+    const old_path = (env.getAlloc(a, "PATH") catch null) orelse "";
+    if (std.mem.indexOf(u8, old_path, lib_dir) == null) {
+        const new_path = std.fmt.allocPrint(a, "{s};{s}", .{ lib_dir, old_path }) catch return;
+        setEnvW(a, "PATH", new_path);
+    }
+}
+
+extern "kernel32" fn SetEnvironmentVariableW(name: [*:0]const u16, value: ?[*:0]const u16) callconv(.winapi) i32;
+
+/// Set an environment variable on the current process (Windows). Children
+/// spawned with an inherited environment block pick up the new value.
+fn setEnvW(a: std.mem.Allocator, name: []const u8, value: []const u8) void {
+    const name_w = std.unicode.utf8ToUtf16LeAllocZ(a, name) catch return;
+    const value_w = std.unicode.utf8ToUtf16LeAllocZ(a, value) catch return;
+    _ = SetEnvironmentVariableW(name_w.ptr, value_w.ptr);
+}
+
+fn provisionWindows(gpa: std.mem.Allocator) Result {
+    var arena_inst = std.heap.ArenaAllocator.init(gpa);
+    defer arena_inst.deinit();
+    const a = arena_inst.allocator();
+    const io = config.globalIo();
+
+    const cache_root = asm_cache.getCacheRoot(a) catch return .failed;
+    const sdl_base = join(a, &.{ cache_root, "sdl2" }) orelse return .failed;
+    const extracted = join(a, &.{ sdl_base, "SDL2-" ++ SDL2_VERSION }) orelse return .failed;
+    const mingw = join(a, &.{ extracted, "x86_64-w64-mingw32" }) orelse return .failed;
+    const lib_dir = join(a, &.{ mingw, "lib" }) orelse return .failed;
+    const importlib = join(a, &.{ lib_dir, "libSDL2.dll.a" }) orelse return .failed;
+    const dll_in_lib = join(a, &.{ lib_dir, "SDL2.dll" }) orelse return .failed;
+
+    if (util.fileExists(importlib) and util.fileExists(dll_in_lib)) {
+        std.debug.print("  SDL2 already provisioned: {s}\n", .{lib_dir});
+        return .ready;
+    }
+
+    std.Io.Dir.cwd().createDirPath(io, sdl_base) catch return .failed;
+
+    const tarball = join(a, &.{ sdl_base, "SDL2-devel-mingw.tar.gz" }) orelse return .failed;
+    const url = "https://github.com/libsdl-org/SDL/releases/download/release-" ++
+        SDL2_VERSION ++ "/SDL2-devel-" ++ SDL2_VERSION ++ "-mingw.tar.gz";
+
+    std.debug.print("  downloading SDL2 {s} (MinGW dev libs)...\n    {s}\n", .{ SDL2_VERSION, url });
+    if (!runOk(a, &.{ "curl", "-fSL", "-o", tarball, url })) {
+        std.debug.print("  download failed (is curl on PATH?).\n", .{});
+        return .failed;
+    }
+
+    std.debug.print("  extracting...\n", .{});
+    if (!runOk(a, &.{ "tar", "-xzf", tarball, "-C", sdl_base })) {
+        std.debug.print("  extract failed (is tar on PATH?).\n", .{});
+        return .failed;
+    }
+
+    // Arrange for Zig's dynamic linker: the resolver looks for SDL2.dll in the
+    // library search dir (not the MinGW `libSDL2.dll.a`), and would otherwise
+    // fall back to the static `libSDL2.a` (which drags in many Win32 libs).
+    // Copy the DLL into lib/ and drop the static archives.
+    const bin_dll = join(a, &.{ mingw, "bin", "SDL2.dll" }) orelse return .failed;
+    copyFileVia(a, io, bin_dll, dll_in_lib);
+    deleteIfPresent(io, join(a, &.{ lib_dir, "libSDL2.a" }));
+    deleteIfPresent(io, join(a, &.{ lib_dir, "libSDL2_test.a" }));
+    std.Io.Dir.cwd().deleteFile(io, tarball) catch {};
+
+    if (util.fileExists(importlib) and util.fileExists(dll_in_lib)) {
+        std.debug.print("  SDL2 ready: {s}\n", .{lib_dir});
+        return .ready;
+    }
+    std.debug.print("  provisioning incomplete (unexpected package layout).\n", .{});
+    return .failed;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn join(a: std.mem.Allocator, parts: []const []const u8) ?[]u8 {
+    return std.fs.path.join(a, parts) catch null;
+}
+
+fn runOk(a: std.mem.Allocator, argv: []const []const u8) bool {
+    const res = util.runCmd(a, argv) catch return false;
+    return switch (res.term) {
+        .exited => |c| c == 0,
+        else => false,
+    };
+}
+
+/// Copy a file by reading then writing (avoids depending on a copyFile API
+/// shape). SDL2.dll is a few MB; the 64 MiB limit is comfortable headroom.
+fn copyFileVia(a: std.mem.Allocator, io: std.Io, src: []const u8, dst: []const u8) void {
+    const data = std.Io.Dir.cwd().readFileAlloc(io, src, a, .limited(64 << 20)) catch return;
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = dst, .data = data }) catch {};
+}
+
+fn deleteIfPresent(io: std.Io, path: ?[]const u8) void {
+    if (path) |p| std.Io.Dir.cwd().deleteFile(io, p) catch {};
+}

--- a/src/cli/sdl_provision.zig
+++ b/src/cli/sdl_provision.zig
@@ -38,6 +38,28 @@ pub fn cachedLibDir(allocator: std.mem.Allocator) ![]u8 {
     return std.fs.path.join(allocator, &.{ cache_root, "sdl2", "SDL2-" ++ SDL2_VERSION, "x86_64-w64-mingw32", "lib" });
 }
 
+/// First cached SDL2 lib dir containing the import lib, ANY version —
+/// scans `~/.labelle/sdl2/*/x86_64-w64-mingw32/lib`. This is the single
+/// acceptance rule shared by `labelle doctor`'s detection and
+/// `autoWireEnv`, so doctor never reports a cache green that build/run
+/// then ignore. (`cachedLibDir` above stays pinned — it's the
+/// provisioning *target*, not the detection rule.) Arena-allocated.
+pub fn findCachedLibDir(a: std.mem.Allocator) ?[]const u8 {
+    const io = config.globalIo();
+    const root = asm_cache.getCacheRoot(a) catch return null;
+    const sdl_root = join(a, &.{ root, "sdl2" }) orelse return null;
+    var dir = std.Io.Dir.cwd().openDir(io, sdl_root, .{ .iterate = true }) catch return null;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch return null) |entry| {
+        if (entry.kind != .directory) continue;
+        const lib = join(a, &.{ sdl_root, entry.name, "x86_64-w64-mingw32", "lib" }) orelse continue;
+        const probe = join(a, &.{ lib, "libSDL2.dll.a" }) orelse continue;
+        if (util.fileExists(probe)) return lib;
+    }
+    return null;
+}
+
 /// Ensure SDL2 is available, downloading it on Windows if needed.
 pub fn provisionSdl2(gpa: std.mem.Allocator) Result {
     switch (builtin.os.tag) {
@@ -79,9 +101,8 @@ pub fn autoWireEnv(gpa: std.mem.Allocator) void {
     defer arena_inst.deinit();
     const a = arena_inst.allocator();
 
-    const lib_dir = cachedLibDir(a) catch return;
-    const importlib = join(a, &.{ lib_dir, "libSDL2.dll.a" }) orelse return;
-    if (!util.fileExists(importlib)) return; // nothing provisioned
+    // Accept any cached version — same rule as doctor's detection.
+    const lib_dir = findCachedLibDir(a) orelse return; // nothing provisioned
 
     const env = config.globalEnviron();
 
@@ -92,9 +113,19 @@ pub fn autoWireEnv(gpa: std.mem.Allocator) void {
         std.debug.print("labelle: using cached SDL2 ({s})\n", .{lib_dir});
     }
 
-    // PATH — prepend the cache lib dir (contains SDL2.dll) for runtime, once.
+    // PATH — prepend the cache lib dir (contains SDL2.dll) for runtime,
+    // once. Exact segment comparison (not substring) so an unrelated
+    // entry that merely contains this dir's text can't suppress it.
     const old_path = (env.getAlloc(a, "PATH") catch null) orelse "";
-    if (std.mem.indexOf(u8, old_path, lib_dir) == null) {
+    var on_path = false;
+    var seg_it = std.mem.splitScalar(u8, old_path, ';');
+    while (seg_it.next()) |seg| {
+        if (util.windowsPathEql(seg, lib_dir)) {
+            on_path = true;
+            break;
+        }
+    }
+    if (!on_path) {
         const new_path = std.fmt.allocPrint(a, "{s};{s}", .{ lib_dir, old_path }) catch return;
         setEnvW(a, "PATH", new_path);
     }


### PR DESCRIPTION
## What

`labelle doctor` — the desktop counterpart of `labelle android doctor` (#170). Preflights the build/run requirements for desktop games and reports missing system dependencies with actionable fixes, instead of letting the build die in a Zig linker dump (`unable to find dynamic system library 'SDL2'`).

Zig fetches and compiles nearly everything a labelle game needs (raylib, sokol, cimgui, glfw, wgpu-native, the labelle packages). The one genuine manual system dependency is **SDL2**: the raylib/sokol backends use it for the shared desktop gamepad source, and the `sdl` backend uses it as the renderer (plus SDL2_mixer for audio).

## How

- **`labelle doctor [dir]`** reads `project.labelle` (backend + `gamepad: .none` opt-out) and only checks what that configuration actually needs: Zig toolchain, SDL2 import lib, `SDL2.dll` at runtime (Windows, WARN-level), SDL2 headers + SDL2_mixer (`sdl` backend only). Backends that need no system libs say so explicitly. Required misses exit 1, so it's scriptable in CI.
- **`labelle doctor --fix`** (Windows) downloads the official `SDL2-devel-2.30.11-mingw` release into `~/.labelle/sdl2/` and arranges it the way Zig's linker resolves it: `SDL2.dll` copied beside the import lib, static archives dropped so the dynamic candidate wins. On Linux/macOS it prints the package-manager one-liner rather than assuming sudo.
- **Auto-wiring**: `build`/`run` now inject `LABELLE_SDL2_LIB` + PATH from the cache-provisioned SDL2 into the spawned child environment when the project needs SDL2 and the user hasn't set the var — a one-time `labelle doctor --fix` makes desktop builds just work.

Pairs with labelle-assembler#277, which adds the `LABELLE_SDL2_LIB` handling on the backend `build.zig` side.

## Testing

- `zig build test`: 263/263 pass.
- Verified live on Windows 11: detection of a `--fix`-provisioned SDL2 cache, `SDL2.dll` runtime resolution, and the no-`project.labelle` fallback path.
