### PR TITLE
ci: install libsdl2-dev for the Versions Integration Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           sudo apt-get install -y \
             libgl1-mesa-dev libx11-dev libxcursor-dev libxrandr-dev \
             libxinerama-dev libxi-dev libxext-dev libxfixes-dev \
-            libwayland-dev libxkbcommon-dev libasound2-dev
+            libwayland-dev libxkbcommon-dev libasound2-dev libsdl2-dev
 
       - name: Build CLI
         run: cd labelle-cli && zig build


### PR DESCRIPTION
Since the desktop gamepad source landed across the toolkit (assembler gamepad .auto default), raylib desktop builds link SDL2. The Versions Integration Test builds a raylib test game on ubuntu-latest but its apt list lacked libsdl2-dev, so every fresh run dies at link time (unable to find dynamic system library SDL2) regardless of what the PR changes — this is what is currently failing on #245. One-line fix: add libsdl2-dev to the existing apt-get install.