### PR TITLE
release: v1.47.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.46.2",
+    .version = "1.47.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone


### PR DESCRIPTION
Version bump for the work merged since v1.46.2: labelle run perf/CI flags --headless / --uncapped / --ticks / --profile (#245), labelle doctor desktop dependency preflight + SDL2 provisioning with build/run auto-wiring (#249), and the Versions Integration Test libsdl2-dev CI fix (#250). Tag v1.47.0 will be pushed after merge to trigger the R2 binary release.