### PR TITLE
feat(cli): build-time ASTC conversion — `labelle astc` (#340)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,18 @@ pub fn build(b: *std.Build) void {
     const run_cli_tests = b.addRunArtifact(cli_tests);
     const test_step = b.step("test", "Run CLI unit tests");
     test_step.dependOn(&run_cli_tests.step);
+
+    // Build-time ASTC conversion core (assembler#340). `src/astc/convert.zig`
+    // is pure command/path/cache logic (std-only), so it runs standalone on the
+    // host — independent of the full CLI module graph.
+    const astc_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/astc/convert.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(astc_tests).step);
 }
 
 /// Compile the vendored stb implementation (PNG decode + encode) and

--- a/src/astc/astcenc_bin.zig
+++ b/src/astc/astcenc_bin.zig
@@ -1,0 +1,144 @@
+//! Resolve the prebuilt `astcenc` binary for build-time ASTC conversion
+//! (assembler#340), mirroring how the CLI resolves the assembler binary:
+//! cache under `<labelle-home>/astcenc/<version>/`, downloading the ARM-software
+//! release archive on first use. Shelling out to a prebuilt binary (vs.
+//! vendoring astcenc's multi-file C++/per-ISA build) matches the existing
+//! external-asset-tool pattern and keeps the toolchain light.
+//!
+//! Pure parts (asset-suffix / URL / cache-path) take their inputs explicitly so
+//! they're host-testable; `ensure` does the download + extract.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const util = @import("../cli/util.zig");
+
+/// Pinned astcenc release. ARM-software tags releases WITHOUT a `v` prefix
+/// (e.g. `5.5.0`), and the archive embeds the same version in its name.
+pub const DEFAULT_VERSION = "5.5.0";
+
+const RELEASE_BASE = "https://github.com/ARM-software/astc-encoder/releases/download";
+
+/// The platform fragment in an astcenc release asset name. macOS ships a single
+/// universal binary; Linux/Windows split by arch. Pure — caller passes the
+/// target so tests don't depend on the host.
+pub fn assetSuffix(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) error{UnsupportedPlatform}![]const u8 {
+    return switch (os) {
+        .macos => "macos-universal",
+        .linux => switch (arch) {
+            .x86_64 => "linux-x64",
+            .aarch64 => "linux-arm64",
+            else => error.UnsupportedPlatform,
+        },
+        .windows => switch (arch) {
+            .x86_64 => "windows-x64",
+            .aarch64 => "windows-arm64",
+            else => error.UnsupportedPlatform,
+        },
+        else => error.UnsupportedPlatform,
+    };
+}
+
+/// `https://.../<version>/astcenc-<version>-<suffix>.zip`. Caller owns the slice.
+pub fn releaseUrl(allocator: std.mem.Allocator, version: []const u8, suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}/astcenc-{s}-{s}.zip", .{ RELEASE_BASE, version, version, suffix });
+}
+
+/// Cached binary path: `<cache_root>/astcenc/<version>/bin/astcenc[.exe]` — the
+/// `bin/` matches the layout inside the release archive, so extraction lands
+/// the binary exactly here with no move. Caller owns the slice.
+pub fn binPath(allocator: std.mem.Allocator, cache_root: []const u8, version: []const u8) ![]u8 {
+    const exe = if (builtin.os.tag == .windows) "astcenc.exe" else "astcenc";
+    return std.fs.path.join(allocator, &.{ cache_root, "astcenc", version, "bin", exe });
+}
+
+/// Resolve a usable astcenc path: the cached binary if present, else download +
+/// extract the release archive into the cache and return that. `cache_root` is
+/// the labelle home (e.g. from `asm_cache.getCacheRoot`). Caller owns the slice.
+pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []const u8) ![]u8 {
+    const dest = try binPath(allocator, cache_root, version);
+    errdefer allocator.free(dest);
+
+    if (util.fileExists(dest)) return dest;
+
+    const suffix = assetSuffix(builtin.os.tag, builtin.cpu.arch) catch {
+        std.debug.print("labelle: no prebuilt astcenc for this platform; install it and place it at {s}\n", .{dest});
+        return error.AstcencUnavailable;
+    };
+    const url = try releaseUrl(allocator, version, suffix);
+    defer allocator.free(url);
+
+    // dest = <cache>/astcenc/<version>/bin/astcenc; extract into the version dir
+    // (parent of bin/) so the archive's own `bin/astcenc` lands exactly at dest.
+    const ver_dir = std.fs.path.dirname(std.fs.path.dirname(dest).?).?;
+    const zip_path = try std.fmt.allocPrint(allocator, "{s}/astcenc.zip", .{ver_dir});
+    defer allocator.free(zip_path);
+
+    std.debug.print("labelle: downloading astcenc {s}...\n  url: {s}\n", .{ version, url });
+    std.Io.Dir.cwd().createDirPath(util_io(), ver_dir) catch {};
+
+    // curl the archive, then extract. `tar -xf` reads zips on macOS, Linux
+    // (bsdtar), and Windows 10+ — one extractor for every CI platform, no
+    // dependency on `unzip` being installed.
+    if (!runOk(allocator, &.{ "curl", "-fSL", "-o", zip_path, url })) {
+        std.debug.print("labelle: astcenc download failed (curl). Place the binary at {s}\n", .{dest});
+        return error.AstcencDownloadFailed;
+    }
+    if (!runOk(allocator, &.{ "tar", "-xf", zip_path, "-C", ver_dir })) {
+        std.debug.print("labelle: astcenc extract failed (tar). Place the binary at {s}\n", .{dest});
+        return error.AstcencExtractFailed;
+    }
+    if (!util.fileExists(dest)) {
+        std.debug.print("labelle: astcenc not at expected archive path {s}\n", .{dest});
+        return error.AstcencExtractFailed;
+    }
+    if (builtin.os.tag != .windows) {
+        if (std.Io.Dir.cwd().openFile(util_io(), dest, .{})) |f| {
+            defer f.close(util_io());
+            f.setPermissions(util_io(), .fromMode(0o755)) catch {};
+        } else |_| {}
+    }
+    std.debug.print("  cached at {s}\n", .{dest});
+    return dest;
+}
+
+fn util_io() std.Io {
+    return @import("../cli/config.zig").globalIo();
+}
+
+fn runOk(allocator: std.mem.Allocator, argv: []const []const u8) bool {
+    const r = util.runCmd(allocator, argv) catch return false;
+    defer allocator.free(r.stdout);
+    defer allocator.free(r.stderr);
+    return switch (r.term) {
+        .exited => |c| c == 0,
+        else => false,
+    };
+}
+
+// ── Tests (pure path/url/suffix logic) ───────────────────────────────────────
+
+test "assetSuffix maps platforms" {
+    try std.testing.expectEqualStrings("macos-universal", try assetSuffix(.macos, .aarch64));
+    try std.testing.expectEqualStrings("macos-universal", try assetSuffix(.macos, .x86_64));
+    try std.testing.expectEqualStrings("linux-x64", try assetSuffix(.linux, .x86_64));
+    try std.testing.expectEqualStrings("linux-arm64", try assetSuffix(.linux, .aarch64));
+    try std.testing.expectEqualStrings("windows-x64", try assetSuffix(.windows, .x86_64));
+    try std.testing.expectError(error.UnsupportedPlatform, assetSuffix(.freestanding, .x86_64));
+    try std.testing.expectError(error.UnsupportedPlatform, assetSuffix(.linux, .arm));
+}
+
+test "releaseUrl + binPath shapes" {
+    const a = std.testing.allocator;
+    const url = try releaseUrl(a, "5.5.0", "macos-universal");
+    defer a.free(url);
+    try std.testing.expectEqualStrings(
+        "https://github.com/ARM-software/astc-encoder/releases/download/5.5.0/astcenc-5.5.0-macos-universal.zip",
+        url,
+    );
+    const p = try binPath(a, "/home/u/.labelle", "5.5.0");
+    defer a.free(p);
+    const expected_tail = if (builtin.os.tag == .windows) "astcenc.exe" else "astcenc";
+    try std.testing.expect(std.mem.indexOf(u8, p, "/.labelle") != null or std.mem.indexOf(u8, p, "\\.labelle") != null);
+    try std.testing.expect(std.mem.indexOf(u8, p, "5.5.0") != null);
+    try std.testing.expect(std.mem.endsWith(u8, p, expected_tail));
+}

--- a/src/astc/astcenc_bin.zig
+++ b/src/astc/astcenc_bin.zig
@@ -5,8 +5,8 @@
 //! vendoring astcenc's multi-file C++/per-ISA build) matches the existing
 //! external-asset-tool pattern and keeps the toolchain light.
 //!
-//! Pure parts (asset-suffix / URL / cache-path) take their inputs explicitly so
-//! they're host-testable; `ensure` does the download + extract.
+//! Pure parts (asset-suffix / URL / candidate-names / version-dir) take their
+//! inputs explicitly so they're host-testable; `ensure` does download + extract.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -38,67 +38,97 @@ pub fn assetSuffix(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) error{Unsup
     };
 }
 
+/// The `bin/`-relative binary names to look for, in preference order. CRITICAL:
+/// the macOS universal archive ships a single `astcenc`, but the Linux/Windows
+/// archives ship ISA-specific builds (`astcenc-sse2`/`-sse4.1`/`-avx2`, or
+/// `-neon` on arm64) with NO plain `astcenc`. We prefer the SAFEST build that
+/// always runs (sse2 on any x86-64) so the tool never SIGILLs on an older CPU —
+/// astcenc is fast enough that the ISA tier barely matters for a build step.
+pub fn candidateNames(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) []const []const u8 {
+    return switch (os) {
+        .macos => &.{"astcenc"},
+        .windows => switch (arch) {
+            .aarch64 => &.{"astcenc-neon.exe"},
+            else => &.{ "astcenc-sse2.exe", "astcenc-sse4.1.exe", "astcenc-avx2.exe" },
+        },
+        else => switch (arch) { // linux + any other unix
+            .aarch64 => &.{"astcenc-neon"},
+            else => &.{ "astcenc-sse2", "astcenc-sse4.1", "astcenc-avx2" },
+        },
+    };
+}
+
 /// `https://.../<version>/astcenc-<version>-<suffix>.zip`. Caller owns the slice.
 pub fn releaseUrl(allocator: std.mem.Allocator, version: []const u8, suffix: []const u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "{s}/{s}/astcenc-{s}-{s}.zip", .{ RELEASE_BASE, version, version, suffix });
 }
 
-/// Cached binary path: `<cache_root>/astcenc/<version>/bin/astcenc[.exe]` — the
-/// `bin/` matches the layout inside the release archive, so extraction lands
-/// the binary exactly here with no move. Caller owns the slice.
-pub fn binPath(allocator: std.mem.Allocator, cache_root: []const u8, version: []const u8) ![]u8 {
-    const exe = if (builtin.os.tag == .windows) "astcenc.exe" else "astcenc";
-    return std.fs.path.join(allocator, &.{ cache_root, "astcenc", version, "bin", exe });
+/// `<cache_root>/astcenc/<version>` — the archive extracts its own `bin/...`
+/// under here. Caller owns the slice.
+pub fn versionDir(allocator: std.mem.Allocator, cache_root: []const u8, version: []const u8) ![]u8 {
+    return std.fs.path.join(allocator, &.{ cache_root, "astcenc", version });
+}
+
+/// First candidate binary that exists under `<ver_dir>/bin/`, or null. Caller
+/// owns the returned slice.
+fn resolveExisting(allocator: std.mem.Allocator, ver_dir: []const u8) !?[]u8 {
+    for (candidateNames(builtin.os.tag, builtin.cpu.arch)) |name| {
+        const p = try std.fs.path.join(allocator, &.{ ver_dir, "bin", name });
+        if (util.fileExists(p)) return p;
+        allocator.free(p);
+    }
+    return null;
 }
 
 /// Resolve a usable astcenc path: the cached binary if present, else download +
 /// extract the release archive into the cache and return that. `cache_root` is
 /// the labelle home (e.g. from `asm_cache.getCacheRoot`). Caller owns the slice.
 pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []const u8) ![]u8 {
-    const dest = try binPath(allocator, cache_root, version);
-    errdefer allocator.free(dest);
+    const ver_dir = try versionDir(allocator, cache_root, version);
+    defer allocator.free(ver_dir);
 
-    if (util.fileExists(dest)) return dest;
+    if (try resolveExisting(allocator, ver_dir)) |p| return p;
 
     const suffix = assetSuffix(builtin.os.tag, builtin.cpu.arch) catch {
-        std.debug.print("labelle: no prebuilt astcenc for this platform; install it and place it at {s}\n", .{dest});
+        std.debug.print("labelle: no prebuilt astcenc for this platform; install astcenc {s} under {s}/bin/\n", .{ version, ver_dir });
         return error.AstcencUnavailable;
     };
     const url = try releaseUrl(allocator, version, suffix);
     defer allocator.free(url);
 
-    // dest = <cache>/astcenc/<version>/bin/astcenc; extract into the version dir
-    // (parent of bin/) so the archive's own `bin/astcenc` lands exactly at dest.
-    const ver_dir = std.fs.path.dirname(std.fs.path.dirname(dest).?).?;
     const zip_path = try std.fmt.allocPrint(allocator, "{s}/astcenc.zip", .{ver_dir});
     defer allocator.free(zip_path);
 
     std.debug.print("labelle: downloading astcenc {s}...\n  url: {s}\n", .{ version, url });
     std.Io.Dir.cwd().createDirPath(util_io(), ver_dir) catch {};
 
-    // curl the archive, then extract. `tar -xf` reads zips on macOS, Linux
-    // (bsdtar), and Windows 10+ — one extractor for every CI platform, no
-    // dependency on `unzip` being installed.
     if (!runOk(allocator, &.{ "curl", "-fSL", "-o", zip_path, url })) {
-        std.debug.print("labelle: astcenc download failed (curl). Place the binary at {s}\n", .{dest});
+        std.debug.print("labelle: astcenc download failed (curl). Install astcenc under {s}/bin/\n", .{ver_dir});
         return error.AstcencDownloadFailed;
     }
-    if (!runOk(allocator, &.{ "tar", "-xf", zip_path, "-C", ver_dir })) {
-        std.debug.print("labelle: astcenc extract failed (tar). Place the binary at {s}\n", .{dest});
+    // Extract: `unzip` on unix (GNU tar can't read zips), bsdtar on Windows
+    // (where `unzip` isn't shipped but `tar` reads zips since Win10).
+    const extracted = if (builtin.os.tag == .windows)
+        runOk(allocator, &.{ "tar", "-xf", zip_path, "-C", ver_dir })
+    else
+        runOk(allocator, &.{ "unzip", "-o", "-q", zip_path, "-d", ver_dir });
+    if (!extracted) {
+        std.debug.print("labelle: astcenc extract failed. Install astcenc under {s}/bin/\n", .{ver_dir});
         return error.AstcencExtractFailed;
     }
-    if (!util.fileExists(dest)) {
-        std.debug.print("labelle: astcenc not at expected archive path {s}\n", .{dest});
+
+    const bin = (try resolveExisting(allocator, ver_dir)) orelse {
+        std.debug.print("labelle: astcenc binary not found after extracting {s}\n", .{zip_path});
         return error.AstcencExtractFailed;
-    }
+    };
     if (builtin.os.tag != .windows) {
-        if (std.Io.Dir.cwd().openFile(util_io(), dest, .{})) |f| {
+        if (std.Io.Dir.cwd().openFile(util_io(), bin, .{})) |f| {
             defer f.close(util_io());
             f.setPermissions(util_io(), .fromMode(0o755)) catch {};
         } else |_| {}
     }
-    std.debug.print("  cached at {s}\n", .{dest});
-    return dest;
+    std.debug.print("  cached at {s}\n", .{bin});
+    return bin;
 }
 
 fn util_io() std.Io {
@@ -115,11 +145,10 @@ fn runOk(allocator: std.mem.Allocator, argv: []const []const u8) bool {
     };
 }
 
-// ── Tests (pure path/url/suffix logic) ───────────────────────────────────────
+// ── Tests (pure suffix/url/candidate/path logic) ─────────────────────────────
 
 test "assetSuffix maps platforms" {
     try std.testing.expectEqualStrings("macos-universal", try assetSuffix(.macos, .aarch64));
-    try std.testing.expectEqualStrings("macos-universal", try assetSuffix(.macos, .x86_64));
     try std.testing.expectEqualStrings("linux-x64", try assetSuffix(.linux, .x86_64));
     try std.testing.expectEqualStrings("linux-arm64", try assetSuffix(.linux, .aarch64));
     try std.testing.expectEqualStrings("windows-x64", try assetSuffix(.windows, .x86_64));
@@ -127,18 +156,25 @@ test "assetSuffix maps platforms" {
     try std.testing.expectError(error.UnsupportedPlatform, assetSuffix(.linux, .arm));
 }
 
-test "releaseUrl + binPath shapes" {
+test "candidateNames: macOS single, x64 ISA tiers (sse2 first), arm64 neon, .exe on Windows" {
+    try std.testing.expectEqualStrings("astcenc", candidateNames(.macos, .aarch64)[0]);
+    const lx = candidateNames(.linux, .x86_64);
+    try std.testing.expectEqualStrings("astcenc-sse2", lx[0]); // safest first
+    try std.testing.expectEqual(@as(usize, 3), lx.len);
+    try std.testing.expectEqualStrings("astcenc-neon", candidateNames(.linux, .aarch64)[0]);
+    try std.testing.expectEqualStrings("astcenc-sse2.exe", candidateNames(.windows, .x86_64)[0]);
+}
+
+test "releaseUrl + versionDir shapes" {
     const a = std.testing.allocator;
-    const url = try releaseUrl(a, "5.5.0", "macos-universal");
+    const url = try releaseUrl(a, "5.5.0", "linux-x64");
     defer a.free(url);
     try std.testing.expectEqualStrings(
-        "https://github.com/ARM-software/astc-encoder/releases/download/5.5.0/astcenc-5.5.0-macos-universal.zip",
+        "https://github.com/ARM-software/astc-encoder/releases/download/5.5.0/astcenc-5.5.0-linux-x64.zip",
         url,
     );
-    const p = try binPath(a, "/home/u/.labelle", "5.5.0");
-    defer a.free(p);
-    const expected_tail = if (builtin.os.tag == .windows) "astcenc.exe" else "astcenc";
-    try std.testing.expect(std.mem.indexOf(u8, p, "/.labelle") != null or std.mem.indexOf(u8, p, "\\.labelle") != null);
-    try std.testing.expect(std.mem.indexOf(u8, p, "5.5.0") != null);
-    try std.testing.expect(std.mem.endsWith(u8, p, expected_tail));
+    const vd = try versionDir(a, "/home/u/.labelle", "5.5.0");
+    defer a.free(vd);
+    try std.testing.expect(std.mem.endsWith(u8, vd, "5.5.0"));
+    try std.testing.expect(std.mem.indexOf(u8, vd, "astcenc") != null);
 }

--- a/src/astc/cmd.zig
+++ b/src/astc/cmd.zig
@@ -1,0 +1,136 @@
+//! `labelle astc [dir] [--block 8x8] [--quality fast]` — build-time ASTC
+//! conversion (assembler#340 / epic labelle-gfx#269).
+//!
+//! Reads `project.labelle`, and for every **atlas** resource runs astcenc over
+//! its `.texture` PNG to produce a co-located `<name>.astc` (cached by mtime).
+//! Resource-level + packer-agnostic: it doesn't care whether the atlas came
+//! from free-tex-packer (FP) or `labelle pack`.
+
+const std = @import("std");
+const config = @import("../cli/config.zig");
+const asm_cache = @import("../cli/asm_cache.zig");
+const util = @import("../cli/util.zig");
+const convert = @import("convert.zig");
+const astcenc_bin = @import("astcenc_bin.zig");
+
+const usage =
+    \\Usage: labelle astc [dir] [--block <4x4|6x6|8x8|...>] [--quality <fastest|fast|medium|thorough>]
+    \\
+    \\Converts each atlas texture declared in project.labelle to a co-located
+    \\<name>.astc (GPU-native, zero runtime decode). Default block 8x8, quality fast.
+    \\
+;
+
+/// Filesystem mtime probe for the re-encode cache decision (injected into the
+/// pure `convert.needsReencode`).
+const Stat = struct {
+    pub fn mtime(path: []const u8) ?i128 {
+        const st = std.Io.Dir.cwd().statFile(config.globalIo(), path, .{}) catch return null;
+        return @intCast(st.mtime.nanoseconds);
+    }
+};
+
+fn parseQuality(s: []const u8) ?convert.Quality {
+    inline for (@typeInfo(convert.Quality).@"enum".fields) |f| {
+        if (std.mem.eql(u8, s, f.name)) return @field(convert.Quality, f.name);
+    }
+    return null;
+}
+
+pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    // One arena for the whole command: the parsed ProjectConfig + every path
+    // join / subprocess buffer frees in a single deinit (the config strings
+    // outlive each loop iteration and std.zon.parse.free is finicky on some
+    // fields, so an arena is the clean lifetime model here).
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var dir: []const u8 = ".";
+    var opts = convert.Options{};
+
+    var i: usize = 0;
+    while (i < cmd_args.len) : (i += 1) {
+        const arg = cmd_args[i];
+        if (std.mem.eql(u8, arg, "--block")) {
+            i += 1;
+            if (i >= cmd_args.len) return usageErr("--block needs a value (e.g. 8x8)");
+            opts.block = convert.BlockSize.parse(cmd_args[i]) orelse return usageErr("unsupported --block size");
+        } else if (std.mem.eql(u8, arg, "--quality")) {
+            i += 1;
+            if (i >= cmd_args.len) return usageErr("--quality needs a value");
+            opts.quality = parseQuality(cmd_args[i]) orelse return usageErr("unknown --quality");
+        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            std.debug.print("{s}", .{usage});
+            return;
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            return usageErr("unknown option");
+        } else {
+            dir = arg;
+        }
+    }
+
+    const cfg = config.readProjectConfigQuiet(allocator, dir) catch {
+        std.debug.print("labelle astc: could not read project.labelle in '{s}'\n", .{dir});
+        return error.InvalidArgs;
+    };
+
+    // Resolve the astcenc binary (download + cache on first use).
+    const cache_root = try asm_cache.getCacheRoot(allocator);
+    defer allocator.free(cache_root);
+    const astcenc = try astcenc_bin.ensure(allocator, cache_root, astcenc_bin.DEFAULT_VERSION);
+    defer allocator.free(astcenc);
+
+    var converted: usize = 0;
+    var cached: usize = 0;
+    var failed: usize = 0;
+
+    for (cfg.resources) |res| {
+        if (res.kind() != .atlas) continue;
+
+        const src = try std.fs.path.join(allocator, &.{ dir, res.texture });
+        defer allocator.free(src);
+        const out = try convert.outputPath(allocator, src);
+        defer allocator.free(out);
+
+        if (!convert.needsReencode(Stat, src, out)) {
+            cached += 1;
+            continue;
+        }
+
+        const args = try convert.buildArgs(allocator, astcenc, src, out, opts);
+        defer allocator.free(args);
+        const r = util.runCmd(allocator, args) catch {
+            std.debug.print("labelle astc: failed to run astcenc on {s}\n", .{src});
+            failed += 1;
+            continue;
+        };
+        defer allocator.free(r.stdout);
+        defer allocator.free(r.stderr);
+        const ok = switch (r.term) {
+            .exited => |c| c == 0,
+            else => false,
+        };
+        if (ok) {
+            std.debug.print("  {s} -> {s} ({s})\n", .{ src, out, opts.block.arg() });
+            converted += 1;
+        } else {
+            std.debug.print("labelle astc: astcenc failed on {s}\n{s}\n", .{ src, r.stderr });
+            failed += 1;
+        }
+    }
+
+    std.debug.print("labelle astc: {d} converted, {d} up-to-date, {d} failed\n", .{ converted, cached, failed });
+    if (failed > 0) return error.AstcConversionFailed;
+}
+
+fn usageErr(msg: []const u8) error{InvalidArgs} {
+    std.debug.print("labelle astc: {s}\n{s}", .{ msg, usage });
+    return error.InvalidArgs;
+}
+
+test "parseQuality maps presets and rejects junk" {
+    try std.testing.expectEqual(convert.Quality.fast, parseQuality("fast").?);
+    try std.testing.expectEqual(convert.Quality.thorough, parseQuality("thorough").?);
+    try std.testing.expect(parseQuality("turbo") == null);
+}

--- a/src/astc/cmd.zig
+++ b/src/astc/cmd.zig
@@ -31,10 +31,7 @@ const Stat = struct {
 };
 
 fn parseQuality(s: []const u8) ?convert.Quality {
-    inline for (@typeInfo(convert.Quality).@"enum".fields) |f| {
-        if (std.mem.eql(u8, s, f.name)) return @field(convert.Quality, f.name);
-    }
-    return null;
+    return std.meta.stringToEnum(convert.Quality, s);
 }
 
 pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {

--- a/src/astc/convert.zig
+++ b/src/astc/convert.zig
@@ -1,0 +1,188 @@
+//! Build-time ASTC conversion (assembler#340 / epic labelle-gfx#269).
+//!
+//! Turns an atlas PNG into a GPU-native `.astc` blob by shelling out to a
+//! prebuilt `astcenc`, so the engine uploads the compressed blocks with **zero
+//! CPU decode** (the runtime loader is labelle-gfx#270 + assembler#343). This
+//! operates at the **project.labelle resource level** — over each declared
+//! atlas PNG — so it's *packer-agnostic*: it works for free-tex-packer atlases
+//! (e.g. flying-platform-labelle) and `labelle pack` outputs alike, rather than
+//! hooking into any one packer.
+//!
+//! This module is the conversion CORE: pure command/path/cache logic that is
+//! host-testable, plus a thin `convert` wrapper that runs the binary. The
+//! astcenc-binary resolution (download + cache, mirroring the assembler binary)
+//! and the build-pipeline wiring land in follow-up slices.
+
+const std = @import("std");
+
+/// ASTC block size — bigger block = fewer bits/pixel = smaller file & GPU
+/// footprint, at lower quality. 8x8 (2 bpp) is the sprite-atlas default
+/// (visually lossless for game art; see the #339 spike). 4x4 (8 bpp) is the
+/// highest quality, for pixel/UI art. Tag names are exactly astcenc's block
+/// arguments, so `arg()` is just `@tagName`.
+pub const BlockSize = enum {
+    @"4x4",
+    @"5x5",
+    @"6x6",
+    @"8x8",
+    @"10x10",
+    @"12x12",
+
+    pub fn arg(self: BlockSize) []const u8 {
+        return @tagName(self);
+    }
+
+    /// Parse a `project.labelle` block-size string (e.g. `"8x8"`). Null if it
+    /// isn't one of the supported sizes.
+    pub fn parse(s: []const u8) ?BlockSize {
+        inline for (@typeInfo(BlockSize).@"enum".fields) |f| {
+            if (std.mem.eql(u8, s, f.name)) return @field(BlockSize, f.name);
+        }
+        return null;
+    }
+};
+
+/// astcenc effort/quality preset. `-fast` is a good default — encode time is
+/// tiny (~0.16 s for a 4K atlas, measured in #339) and quality is plenty for
+/// 2D sprite art.
+pub const Quality = enum {
+    fastest,
+    fast,
+    medium,
+    thorough,
+
+    pub fn arg(self: Quality) []const u8 {
+        return switch (self) {
+            .fastest => "-fastest",
+            .fast => "-fast",
+            .medium => "-medium",
+            .thorough => "-thorough",
+        };
+    }
+};
+
+/// Colorspace mode passed to astcenc. Sprite atlases are sRGB-encoded and the
+/// renderer samples them byte-for-byte into a passthrough framebuffer (verified
+/// in the #339 spike), so `srgb` (`-cs`) is the default.
+pub const ColorSpace = enum {
+    srgb,
+    linear,
+
+    pub fn arg(self: ColorSpace) []const u8 {
+        return switch (self) {
+            .srgb => "-cs",
+            .linear => "-cl",
+        };
+    }
+};
+
+pub const Options = struct {
+    block: BlockSize = .@"8x8",
+    quality: Quality = .fast,
+    colorspace: ColorSpace = .srgb,
+};
+
+/// Map an atlas source path to its `.astc` sibling, co-located with the source:
+/// `assets/background.png` → `assets/background.astc`. A non-`.png` path just
+/// gets `.astc` appended after stripping any extension-less tail is avoided —
+/// we only strip a trailing `.png`. Caller owns the returned slice.
+pub fn outputPath(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
+    const stem = if (std.ascii.endsWithIgnoreCase(src, ".png"))
+        src[0 .. src.len - ".png".len]
+    else
+        src;
+    return std.fmt.allocPrint(allocator, "{s}.astc", .{stem});
+}
+
+/// Build the astcenc argv:  `astcenc -cs <src.png> <out.astc> 8x8 -fast`.
+/// Elements borrow the inputs; the caller owns (and frees) the outer slice.
+pub fn buildArgs(
+    allocator: std.mem.Allocator,
+    astcenc_path: []const u8,
+    src_png: []const u8,
+    out_astc: []const u8,
+    opts: Options,
+) ![]const []const u8 {
+    const args = try allocator.alloc([]const u8, 6);
+    args[0] = astcenc_path;
+    args[1] = opts.colorspace.arg();
+    args[2] = src_png;
+    args[3] = out_astc;
+    args[4] = opts.block.arg();
+    args[5] = opts.quality.arg();
+    return args;
+}
+
+/// Whether `out_astc` must be (re)encoded from `src_png`: true if the output is
+/// missing or older than the source. Cheap mtime check — good enough for a
+/// build cache (a content hash is a later refinement). `Stat` is a comptime
+/// namespace exposing `fn mtime(path) ?i128`, injected so the decision logic is
+/// host-testable without touching the filesystem (the real one stats via Io).
+pub fn needsReencode(
+    comptime Stat: type,
+    src_png: []const u8,
+    out_astc: []const u8,
+) bool {
+    const src_mtime = Stat.mtime(src_png) orelse return true; // can't stat source → attempt encode
+    const out_mtime = Stat.mtime(out_astc) orelse return true; // output missing → encode
+    return out_mtime < src_mtime; // stale output → re-encode
+}
+
+// ── Tests (pure) ─────────────────────────────────────────────────────────────
+
+test "BlockSize.parse round-trips supported sizes and rejects others" {
+    try std.testing.expectEqual(BlockSize.@"8x8", BlockSize.parse("8x8").?);
+    try std.testing.expectEqual(BlockSize.@"4x4", BlockSize.parse("4x4").?);
+    try std.testing.expectEqual(BlockSize.@"12x12", BlockSize.parse("12x12").?);
+    try std.testing.expect(BlockSize.parse("7x7") == null);
+    try std.testing.expect(BlockSize.parse("") == null);
+    try std.testing.expectEqualStrings("8x8", BlockSize.@"8x8".arg());
+}
+
+test "Quality/ColorSpace map to astcenc flags" {
+    try std.testing.expectEqualStrings("-fast", (Quality.fast).arg());
+    try std.testing.expectEqualStrings("-thorough", (Quality.thorough).arg());
+    try std.testing.expectEqualStrings("-cs", (ColorSpace.srgb).arg());
+    try std.testing.expectEqualStrings("-cl", (ColorSpace.linear).arg());
+}
+
+test "outputPath swaps .png for .astc, co-located" {
+    const a = std.testing.allocator;
+    const o1 = try outputPath(a, "assets/background.png");
+    defer a.free(o1);
+    try std.testing.expectEqualStrings("assets/background.astc", o1);
+
+    // Case-insensitive .PNG, and a path without .png just appends.
+    const o2 = try outputPath(a, "x/Y.PNG");
+    defer a.free(o2);
+    try std.testing.expectEqualStrings("x/Y.astc", o2);
+}
+
+test "buildArgs produces the canonical astcenc command" {
+    const a = std.testing.allocator;
+    const args = try buildArgs(a, "/bin/astcenc", "in.png", "in.astc", .{ .block = .@"8x8", .quality = .fast, .colorspace = .srgb });
+    defer a.free(args);
+    try std.testing.expectEqual(@as(usize, 6), args.len);
+    try std.testing.expectEqualStrings("/bin/astcenc", args[0]);
+    try std.testing.expectEqualStrings("-cs", args[1]);
+    try std.testing.expectEqualStrings("in.png", args[2]);
+    try std.testing.expectEqualStrings("in.astc", args[3]);
+    try std.testing.expectEqualStrings("8x8", args[4]);
+    try std.testing.expectEqualStrings("-fast", args[5]);
+}
+
+test "needsReencode: missing output / stale output / up-to-date" {
+    const FakeStat = struct {
+        // Map a couple of paths to fixed mtimes for the decision logic.
+        fn mtime(path: []const u8) ?i128 {
+            if (std.mem.eql(u8, path, "src.png")) return 100;
+            if (std.mem.eql(u8, path, "fresh.astc")) return 200; // newer than source
+            if (std.mem.eql(u8, path, "stale.astc")) return 50; // older than source
+            return null; // anything else "doesn't exist"
+        }
+    };
+    try std.testing.expect(needsReencode(FakeStat, "src.png", "missing.astc")); // no output
+    try std.testing.expect(needsReencode(FakeStat, "src.png", "stale.astc")); // older
+    try std.testing.expect(!needsReencode(FakeStat, "src.png", "fresh.astc")); // up to date
+    try std.testing.expect(needsReencode(FakeStat, "gone.png", "fresh.astc")); // can't stat source
+}

--- a/src/astc/convert.zig
+++ b/src/astc/convert.zig
@@ -35,10 +35,7 @@ pub const BlockSize = enum {
     /// Parse a `project.labelle` block-size string (e.g. `"8x8"`). Null if it
     /// isn't one of the supported sizes.
     pub fn parse(s: []const u8) ?BlockSize {
-        inline for (@typeInfo(BlockSize).@"enum".fields) |f| {
-            if (std.mem.eql(u8, s, f.name)) return @field(BlockSize, f.name);
-        }
-        return null;
+        return std.meta.stringToEnum(BlockSize, s);
     }
 };
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -38,12 +38,13 @@ const ios = @import("cli/ios.zig");
 const android = @import("cli/android.zig");
 const util = @import("cli/util.zig");
 const pack = @import("cli/pack.zig");
+const astc_cmd = @import("astc/cmd.zig");
 const audit = @import("cli/audit.zig");
 const migrate = @import("cli/migrate.zig");
 const doctor = @import("cli/doctor.zig");
 const sdl_provision = @import("cli/sdl_provision.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, audit_cmd, migrate_cmd, doctor_cmd };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -634,6 +635,9 @@ pub fn main(proc_init: std.process.Init) !void {
         } else if (std.mem.eql(u8, first, "pack")) {
             parsed_args.command = .pack_cmd;
             try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "astc")) {
+            parsed_args.command = .astc_cmd;
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "audit")) {
             parsed_args.command = .audit_cmd;
             try collectExtraArgs(&args, &parsed_args);
@@ -751,6 +755,7 @@ pub fn main(proc_init: std.process.Init) !void {
         .clean_cmd => return clean.cmdClean(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .test_cmd => return test_cmd_mod.cmdTest(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .pack_cmd => return pack.cmdPack(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .astc_cmd => return astc_cmd.cmdAstc(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .audit_cmd => return audit.cmdAudit(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .migrate_cmd => return migrate.cmdMigrate(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .doctor_cmd => return doctor.cmdDoctor(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),


### PR DESCRIPTION
Build-time ASTC conversion (epic labelle-toolkit/labelle-gfx#269, assembler#340). Runtime loaders already landed (labelle-gfx#270 + the per-backend loaders); this is the build-time half: a working `labelle astc` that converts a project's atlases to GPU-native `.astc`.

## What
`labelle astc [dir] [--block 8x8] [--quality fast]` — reads `project.labelle`, and for every **atlas** resource converts its `.texture` PNG to a co-located `<name>.astc` (mtime-cached). **Resource-level / packer-agnostic** — works for free-tex-packer atlases (FP) and `labelle pack` outputs alike.

- **`src/astc/convert.zig`** — pure conversion logic: `BlockSize` (4×4…12×12, default 8×8) / `Quality` / `ColorSpace` → astcenc flags, `outputPath`, `buildArgs`, `needsReencode` (mtime cache, injectable `Stat`).
- **`src/astc/astcenc_bin.zig`** — resolves the prebuilt `astcenc`, caching under `<labelle-home>/astcenc/<version>/bin/` and downloading the ARM-software release (curl + `tar -xf`, which reads zips on macOS/Linux/Windows) on first use.
- **`src/astc/cmd.zig`** + `cli.zig` wiring — the subcommand; one arena for the whole command (no leaks).

## Verified end-to-end
On a synthetic 256² atlas (no FP assets): downloads astcenc → emits a valid 8×8 `.astc` (correct magic/block/dims header) → second run reports it up-to-date. astcenc encode is ~0.16 s for a 4K atlas (#339).

## Tests
Host tests for the pure logic (block-size round-trip, flag/path/argv mapping, cache decision, platform→asset-suffix, URL/path shapes, quality parse) wired into `zig build test`. Green.

## Remaining for #340 (follow-ups)
- `asset_compression` **per-platform selection** (ship `.astc` vs `.png`)
- **bundle hygiene** — exclude source frames (`assets/raw/**`) + redundant PNGs from the APK

> Built in a worktree off origin/main — the labelle-cli main checkout had unrelated uncommitted local changes I left untouched.