### PR TITLE
fix(cli): astc cache honors block size, not just mtime (#340)

### DIFF
--- a/src/astc/cmd.zig
+++ b/src/astc/cmd.zig
@@ -34,6 +34,18 @@ fn parseQuality(s: []const u8) ?convert.Quality {
     return std.meta.stringToEnum(convert.Quality, s);
 }
 
+/// Whether the existing `.astc` at `out` was encoded at `block` (bytes 4/5 of
+/// the ASTC header). Returns false if it's missing/short/unreadable so the
+/// caller re-encodes. (Quality isn't recoverable from the header — a `--quality`
+/// change still needs a clean rebuild; block is the format-determining param.)
+fn existingBlockMatches(allocator: std.mem.Allocator, out: []const u8, block: convert.BlockSize) bool {
+    // 64 MiB covers any 4K atlas even at 4x4 (8 bpp); we only need the header.
+    const data = std.Io.Dir.cwd().readFileAlloc(config.globalIo(), out, allocator, .limited(64 * 1024 * 1024)) catch return false;
+    if (data.len < 16) return false;
+    const d = block.dims();
+    return data[4] == d.x and data[5] == d.y;
+}
+
 pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
     // One arena for the whole command: the parsed ProjectConfig + every path
     // join / subprocess buffer frees in a single deinit (the config strings
@@ -90,7 +102,10 @@ pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
         const out = try convert.outputPath(allocator, src);
         defer allocator.free(out);
 
-        if (!convert.needsReencode(Stat, src, out)) {
+        // Up-to-date only if the output is newer than the source AND was
+        // encoded at the requested block size — otherwise a `--block` change
+        // would silently keep the stale format (the mtime alone can't see it).
+        if (!convert.needsReencode(Stat, src, out) and existingBlockMatches(allocator, out, opts.block)) {
             cached += 1;
             continue;
         }

--- a/src/astc/convert.zig
+++ b/src/astc/convert.zig
@@ -37,6 +37,18 @@ pub const BlockSize = enum {
     pub fn parse(s: []const u8) ?BlockSize {
         return std.meta.stringToEnum(BlockSize, s);
     }
+
+    /// The block's X/Y dimensions, parsed from the `"<x>x<y>"` tag name. These
+    /// match bytes 4/5 of an `.astc` header, so a converted file can be checked
+    /// against the requested block size (the cache must re-encode on a change).
+    pub fn dims(self: BlockSize) struct { x: u8, y: u8 } {
+        const name = @tagName(self);
+        const sep = std.mem.indexOfScalar(u8, name, 'x').?;
+        return .{
+            .x = std.fmt.parseInt(u8, name[0..sep], 10) catch unreachable,
+            .y = std.fmt.parseInt(u8, name[sep + 1 ..], 10) catch unreachable,
+        };
+    }
 };
 
 /// astcenc effort/quality preset. `-fast` is a good default — encode time is
@@ -134,6 +146,14 @@ test "BlockSize.parse round-trips supported sizes and rejects others" {
     try std.testing.expect(BlockSize.parse("7x7") == null);
     try std.testing.expect(BlockSize.parse("") == null);
     try std.testing.expectEqualStrings("8x8", BlockSize.@"8x8".arg());
+}
+
+test "BlockSize.dims parses the tag into x/y (matches .astc header bytes 4/5)" {
+    try std.testing.expectEqual(@as(u8, 8), BlockSize.@"8x8".dims().x);
+    try std.testing.expectEqual(@as(u8, 8), BlockSize.@"8x8".dims().y);
+    try std.testing.expectEqual(@as(u8, 4), BlockSize.@"4x4".dims().x);
+    try std.testing.expectEqual(@as(u8, 12), BlockSize.@"12x12".dims().y);
+    try std.testing.expectEqual(@as(u8, 10), BlockSize.@"10x10".dims().x);
 }
 
 test "Quality/ColorSpace map to astcenc flags" {


### PR DESCRIPTION
Follow-up to #257 — fixes a medium cache-correctness bug Cursor flagged on the merge commit.

## Problem
`labelle astc`'s cache only re-encoded when the `.astc` was older than its source PNG. So changing `--block` (e.g. 8×8 → 4×4) on an already-converted project left the **stale-format** `.astc` in place — the cache silently ignored the block change.

## Fix
"Up-to-date" now requires both a fresh mtime **and** a block match: `existingBlockMatches` reads the existing `.astc` header (bytes 4/5 = block x/y) and re-encodes on a mismatch.
- `convert.BlockSize.dims()` parses the `<x>x<y>` tag (+ test).
- Quality isn't recoverable from the header, so a `--quality`-only change still needs a clean rebuild (documented) — block is the format-determining param.

## Verified
`8x8 convert → rerun 'up-to-date' → '--block 4x4' re-converts` (header flips to `04 04`). `zig build test` green.