### PR TITLE
feat(cli): auto-run ASTC conversion in build/run when asset_compression selects it (#340)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -901,6 +901,18 @@ pub fn main(proc_init: std.process.Init) !void {
     defer asm_bin.deinit(allocator);
     std.debug.print("  using assembler: {s}\n", .{asm_bin.path});
 
+    // ASTC build-time conversion (#340): when this platform ships ASTC atlases
+    // (`asset_compression`), run `labelle astc` first so the `<name>.astc`
+    // siblings exist for the assembler's catalog `.png → .astc` swap. Runs
+    // before the assembler steps (it only needs project.labelle + the PNGs +
+    // astcenc). Non-fatal — on any failure the assembler finds no sibling and
+    // falls back to the source PNG, so the build still succeeds.
+    if (parsed.asset_compression.formatFor(parsed.platform) == .astc) {
+        astc_cmd.cmdAstc(allocator, &.{project_dir}) catch |err| {
+            std.debug.print("labelle: ASTC conversion failed ({any}); falling back to PNG atlases\n", .{err});
+        };
+    }
+
     // Ensure the package cache is populated. The assembler's `generate`
     // subcommand assumes a populated cache (it does not fetch packages
     // itself), so delegate `install --project-root` to the binary first.

--- a/src/cli/project_config.zig
+++ b/src/cli/project_config.zig
@@ -27,6 +27,29 @@ const std = @import("std");
 /// Graphics / windowing backend selection. `null` is a headless backend.
 pub const Backend = enum { raylib, sokol, sdl, bgfx, wgpu, null };
 pub const Platform = enum { desktop, ios, android, wasm };
+
+/// Texture container a platform ships atlases in — `.png` (CPU-decoded) or
+/// `.astc` (GPU-native, zero decode). Mirrors the assembler's `AssetFormat`
+/// (the assembler does the catalog swap; the CLI reads this to know whether to
+/// run `labelle astc` before generating). See labelle-gfx#269 / #340.
+pub const AssetFormat = enum { png, astc };
+
+/// Per-platform `AssetFormat` selection; default `.png` everywhere (opt-in).
+pub const AssetCompression = struct {
+    desktop: AssetFormat = .png,
+    android: AssetFormat = .png,
+    ios: AssetFormat = .png,
+    web: AssetFormat = .png,
+
+    pub fn formatFor(self: AssetCompression, platform: Platform) AssetFormat {
+        return switch (platform) {
+            .desktop => self.desktop,
+            .android => self.android,
+            .ios => self.ios,
+            .wasm => self.web,
+        };
+    }
+};
 pub const EcsChoice = enum { mock, zig_ecs, zflecs, mr_ecs };
 
 /// CLI version — injected from build.zig via build options.
@@ -265,6 +288,10 @@ pub const ProjectConfig = struct {
     initial_scene: ?[]const u8 = null,
     /// Sprite atlas / sound / font resources.
     resources: []const ResourceDef = &.{},
+    /// Per-platform texture-compression selection (read by `build`/`run` to
+    /// auto-run `labelle astc` before generating; the assembler does the
+    /// catalog `.png → .astc` swap). Default `.png` everywhere.
+    asset_compression: AssetCompression = .{},
     /// When true, the window is created hidden (headless CI).
     hidden: bool = false,
     /// Plugins — each declares its repo and version.
@@ -337,3 +364,12 @@ pub const ProjectConfig = struct {
         }
     }
 };
+
+test "AssetCompression.formatFor + default png" {
+    const def = AssetCompression{};
+    inline for (.{ Platform.desktop, .android, .ios, .wasm }) |p|
+        try @import("std").testing.expectEqual(AssetFormat.png, def.formatFor(p));
+    const m = AssetCompression{ .android = .astc, .desktop = .astc };
+    try @import("std").testing.expectEqual(AssetFormat.astc, m.formatFor(.android));
+    try @import("std").testing.expectEqual(AssetFormat.png, m.formatFor(.wasm));
+}


### PR DESCRIPTION
The last build-time piece of the ASTC epic (labelle-gfx#269). With this, a project just sets `asset_compression` and the rest is automatic.

## What
`labelle build`/`run`/`android`/`ios`/`wasm` now run `labelle astc` **automatically** (before the assembler steps) when the target platform's `asset_compression` is `.astc` — so the `<name>.astc` siblings exist for the assembler's catalog swap (labelle-assembler#347). No more manual `labelle astc`.

- `project_config.zig`: mirror the assembler's `AssetFormat`/`AssetCompression` (the CLI reads it to gate the hook; the assembler does the swap) + a `formatFor` test.
- `cli.zig`: after platform/backend + assembler-binary resolution, convert when `asset_compression.formatFor(platform) == .astc`. **Non-fatal** — on failure (e.g. astcenc unavailable) the assembler finds no sibling and falls back to the source PNG, so the build still succeeds.

## Bundle hygiene — no code needed
Assets load via `@embedFile` **by reference**, so source frames (`assets/raw/**`) are never embedded, and after the `.astc` swap only the `.astc` (not the `.png`) is compiled in. Confirmed the Android APK packages only `libgame.so` (no `assets/` dir). So the APK carries exactly the selected atlases and nothing else.

## Verified
`labelle build` on a project with `asset_compression.desktop = .astc` auto-converts `test.png → test.astc` (8×8) before generating. `zig build test` green.

Completes the pipeline: **convert (auto) → select (#347) → load (#341)**.