### PR TITLE
fix(cli): use @errorName for the ASTC-fallback log (#340)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -909,7 +909,7 @@ pub fn main(proc_init: std.process.Init) !void {
     // falls back to the source PNG, so the build still succeeds.
     if (parsed.asset_compression.formatFor(parsed.platform) == .astc) {
         astc_cmd.cmdAstc(allocator, &.{project_dir}) catch |err| {
-            std.debug.print("labelle: ASTC conversion failed ({any}); falling back to PNG atlases\n", .{err});
+            std.debug.print("labelle: ASTC conversion failed ({s}); falling back to PNG atlases\n", .{@errorName(err)});
         };
     }
 


### PR DESCRIPTION
Trivial follow-up to #259 addressing Gemini's medium review note: format the non-fatal ASTC-conversion-fallback error with `@errorName(err)` + `{s}` instead of `{any}` (stable error name across Zig versions, consistent with the file's other error logging). One line.