### PR TITLE
fix(astc): pick block size by backend capability (sokol→4×4)

### DIFF
--- a/src/astc/cmd.zig
+++ b/src/astc/cmd.zig
@@ -57,6 +57,11 @@ pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
 
     var dir: []const u8 = ".";
     var opts = convert.Options{};
+    // Whether the user pinned `--block` explicitly. When they didn't, we pick a
+    // backend-safe default below (sokol can only load 4×4); when they did, we
+    // validate it against the backend instead of silently emitting an
+    // unloadable file.
+    var block_explicit = false;
 
     var i: usize = 0;
     while (i < cmd_args.len) : (i += 1) {
@@ -65,6 +70,7 @@ pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
             i += 1;
             if (i >= cmd_args.len) return usageErr("--block needs a value (e.g. 8x8)");
             opts.block = convert.BlockSize.parse(cmd_args[i]) orelse return usageErr("unsupported --block size");
+            block_explicit = true;
         } else if (std.mem.eql(u8, arg, "--quality")) {
             i += 1;
             if (i >= cmd_args.len) return usageErr("--quality needs a value");
@@ -83,6 +89,31 @@ pub fn cmdAstc(gpa: std.mem.Allocator, cmd_args: []const []const u8) !void {
         std.debug.print("labelle astc: could not read project.labelle in '{s}'\n", .{dir});
         return error.InvalidArgs;
     };
+
+    // The target backend constrains which block sizes are loadable at runtime.
+    // sokol ships ASTC 4×4 only — an 8×8 atlas parses but fails to upload
+    // (error.LoadFailed), which on FP left the game stuck on the loading scene.
+    // Default to a backend-safe block when the user didn't pin one; reject an
+    // explicit block the backend can't load rather than baking a dud.
+    const caps: convert.BackendCaps = switch (cfg.backend) {
+        .sokol => .sokol_4x4_only,
+        .raylib => .raylib_4x4_8x8,
+        .bgfx, .wgpu => .full,
+        // sdl/null aren't ASTC upload targets; the gfx seam falls back to PNG
+        // decode if they ever see a compressed blob, so leave block unconstrained.
+        .sdl, .null => .full,
+    };
+    if (block_explicit) {
+        if (!caps.supports(opts.block)) {
+            std.debug.print(
+                "labelle astc: backend '{s}' cannot upload ASTC {s} (try {s})\n",
+                .{ @tagName(cfg.backend), opts.block.arg(), caps.defaultBlock().arg() },
+            );
+            return error.InvalidArgs;
+        }
+    } else {
+        opts.block = caps.defaultBlock();
+    }
 
     // Resolve the astcenc binary (download + cache on first use).
     const cache_root = try asm_cache.getCacheRoot(allocator);

--- a/src/astc/convert.zig
+++ b/src/astc/convert.zig
@@ -51,6 +51,37 @@ pub const BlockSize = enum {
     }
 };
 
+/// What ASTC block sizes a backend's *runtime* can actually upload. Emitting a
+/// block the target can't load produces `.astc` files that fail at load time
+/// with `error.LoadFailed` (surfaced live on the FP sokol trial: an 8×8 default
+/// left the game stuck on the loading scene). sokol ships ONLY 4×4; raylib
+/// ships 4×4 and 8×8; bgfx/wgpu accept the full astcenc range. This mirrors
+/// each backend's `astcFormat` mapping in its `gfx/texture.zig`.
+pub const BackendCaps = enum {
+    sokol_4x4_only,
+    raylib_4x4_8x8,
+    full,
+
+    /// Can this backend's runtime upload `block` as-is?
+    pub fn supports(self: BackendCaps, block: BlockSize) bool {
+        return switch (self) {
+            .sokol_4x4_only => block == .@"4x4",
+            .raylib_4x4_8x8 => block == .@"4x4" or block == .@"8x8",
+            .full => true,
+        };
+    }
+
+    /// Block to use when the caller didn't pass `--block`: the smallest GPU
+    /// footprint (largest block) the backend can still load. sokol can only do
+    /// 4×4; everyone else gets the 8×8 sprite-atlas default.
+    pub fn defaultBlock(self: BackendCaps) BlockSize {
+        return switch (self) {
+            .sokol_4x4_only => .@"4x4",
+            else => .@"8x8",
+        };
+    }
+};
+
 /// astcenc effort/quality preset. `-fast` is a good default — encode time is
 /// tiny (~0.16 s for a 4K atlas, measured in #339) and quality is plenty for
 /// 2D sprite art.
@@ -154,6 +185,33 @@ test "BlockSize.dims parses the tag into x/y (matches .astc header bytes 4/5)" {
     try std.testing.expectEqual(@as(u8, 4), BlockSize.@"4x4".dims().x);
     try std.testing.expectEqual(@as(u8, 12), BlockSize.@"12x12".dims().y);
     try std.testing.expectEqual(@as(u8, 10), BlockSize.@"10x10".dims().x);
+}
+
+test "BackendCaps.supports gates blocks by what the runtime can upload" {
+    // sokol's astcFormat only maps 4×4 — everything else fails sg.makeImage.
+    try std.testing.expect(BackendCaps.sokol_4x4_only.supports(.@"4x4"));
+    try std.testing.expect(!BackendCaps.sokol_4x4_only.supports(.@"8x8"));
+    try std.testing.expect(!BackendCaps.sokol_4x4_only.supports(.@"6x6"));
+    // raylib loads 4×4 and 8×8, but not the in-between/large sizes.
+    try std.testing.expect(BackendCaps.raylib_4x4_8x8.supports(.@"4x4"));
+    try std.testing.expect(BackendCaps.raylib_4x4_8x8.supports(.@"8x8"));
+    try std.testing.expect(!BackendCaps.raylib_4x4_8x8.supports(.@"6x6"));
+    try std.testing.expect(!BackendCaps.raylib_4x4_8x8.supports(.@"12x12"));
+    // bgfx/wgpu take the full astcenc range.
+    try std.testing.expect(BackendCaps.full.supports(.@"4x4"));
+    try std.testing.expect(BackendCaps.full.supports(.@"12x12"));
+}
+
+test "BackendCaps.defaultBlock picks the smallest footprint each backend can load" {
+    // sokol must fall back to 4×4 (the blocker this fix exists for).
+    try std.testing.expectEqual(BlockSize.@"4x4", BackendCaps.sokol_4x4_only.defaultBlock());
+    // others keep the 8×8 sprite-atlas default, and it must be loadable.
+    try std.testing.expectEqual(BlockSize.@"8x8", BackendCaps.raylib_4x4_8x8.defaultBlock());
+    try std.testing.expectEqual(BlockSize.@"8x8", BackendCaps.full.defaultBlock());
+    // a backend's own default is always one it supports.
+    inline for (std.enums.values(BackendCaps)) |caps| {
+        try std.testing.expect(caps.supports(caps.defaultBlock()));
+    }
 }
 
 test "Quality/ColorSpace map to astcenc flags" {


### PR DESCRIPTION
## The blocker

`labelle astc` defaulted to **8×8** blocks, but the **sokol** backend's `astcFormat` maps **only ASTC 4×4** (`0x0404`). An 8×8 atlas parses fine but fails `sg.makeImage` at runtime → `error.LoadFailed`. On the real **flying-platform-labelle** game (sokol/Android, Galaxy Tab A7) this left it stuck on the loading scene.

Making it worse: the build **auto-hook silently re-converted** any manual 4×4 fix back to 8×8, so there was no stable workaround.

## The fix

`cmdAstc` now reads `cfg.backend` and:

- **Picks a backend-safe default block** when the user didn't pass `--block` — sokol→4×4, raylib→4×4/8×8, bgfx/wgpu→full astcenc range.
- **Rejects an explicit `--block` the backend can't upload** with a clear message (and a suggested size) instead of silently baking an unloadable `.astc`.

Adds a `BackendCaps` enum (`sokol_4x4_only` / `raylib_4x4_8x8` / `full`) to `src/astc/convert.zig` with `supports()` + `defaultBlock()`, mirroring each backend's `astcFormat` mapping, wired into `src/astc/cmd.zig`. Includes inline tests for the caps logic.

## Validation

`zig build` clean; `zig build test` → **290/290 tests pass** (Zig 0.16.0).

Found while validating ASTC on the real FP game, where it proved a **~24s → ~1s cold-start win** once the block size matched the backend.

Part of the ASTC cold-start epic labelle-gfx#269.