### PR TITLE
Resolve docker run binary by sanitized project name (labelle-assembler#362)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1020,7 +1020,13 @@ pub fn main(proc_init: std.process.Init) !void {
                 std.debug.print("  binary is at: {s}/zig-out/bin/\n", .{target_dir});
                 return;
             }
-            const bin_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "bin", "game" });
+            // The assembler names the desktop binary after the project
+            // (sanitized) so concurrent games are distinguishable to
+            // `pgrep` (labelle-assembler#362). Derive the same name here so
+            // the docker run path execs the binary by its real on-disk name.
+            const exe_name = try util.sanitizeExeName(allocator, parsed.name);
+            defer allocator.free(exe_name);
+            const bin_path = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "bin", exe_name });
             defer allocator.free(bin_path);
             var run_args: std.ArrayList([]const u8) = .empty;
             defer run_args.deinit(allocator);
@@ -1339,6 +1345,10 @@ pub const ParseOptimizeFlagSpec = struct {
 // cli.zig and would skip the test_cmd_mod's nested spec structs.
 pub const TestCmdIsSkipDirSpec = test_cmd_mod.IsSkipDirSpec;
 pub const TestCmdFileHasTestBlockSpec = test_cmd_mod.FileHasTestBlockSpec;
+
+// Surface the exe-name sanitizer's spec namespace (labelle-assembler#362)
+// so `zspec.runAll(@This())` walks into it.
+pub const UtilSanitizeExeNameSpec = util.SanitizeExeName;
 
 // Surface audit-command spec namespaces so `zspec.runAll(@This())`
 // walks into them. Without these re-exports the audit tests would

--- a/src/cli/util.zig
+++ b/src/cli/util.zig
@@ -52,8 +52,12 @@ pub fn sanitizeExeName(allocator: std.mem.Allocator, name: []const u8) ![]const 
         if (ok) try buf.append(allocator, c);
     }
     if (buf.items.len == 0) {
+        // Allocate the fallback BEFORE freeing `buf`: if `dupe` OOMs, the
+        // `errdefer` frees `buf` (once). Freeing `buf` first would let the
+        // `errdefer` deinit it a second time on that OOM — a double free.
+        const fallback = try allocator.dupe(u8, "game");
         buf.deinit(allocator);
-        return allocator.dupe(u8, "game");
+        return fallback;
     }
     return buf.toOwnedSlice(allocator);
 }

--- a/src/cli/util.zig
+++ b/src/cli/util.zig
@@ -32,6 +32,32 @@ pub fn runCmd(allocator: std.mem.Allocator, argv: []const []const u8) !std.proce
     });
 }
 
+/// Sanitize a project name into the desktop-executable name the
+/// assembler bakes into `build.zig` (labelle-assembler#362). The
+/// assembler now names the desktop binary after the project so a running
+/// game is identifiable by `pgrep -f <name>` instead of every project
+/// building to an indistinguishable `zig-out/bin/game`. The `--docker`
+/// run path execs the built binary by absolute path, so it must derive
+/// the same name to locate it.
+///
+/// Keeps only `[A-Za-z0-9_-]` (byte-identical to the assembler's
+/// `sanitizeExeName`); every other byte is dropped, falling back to
+/// `"game"` when the result is empty. Caller owns the returned slice.
+pub fn sanitizeExeName(allocator: std.mem.Allocator, name: []const u8) ![]const u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    for (name) |c| {
+        const ok = (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or
+            (c >= '0' and c <= '9') or c == '_' or c == '-';
+        if (ok) try buf.append(allocator, c);
+    }
+    if (buf.items.len == 0) {
+        buf.deinit(allocator);
+        return allocator.dupe(u8, "game");
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
 /// Parse semantic version string into a comparable number.
 /// "1.2.3" -> 1*1000000 + 2*1000 + 3 = 1002003
 pub fn parseVersion(version: []const u8) u32 {
@@ -158,3 +184,34 @@ pub fn parseDuration(input: []const u8) ?u64 {
     const val = std.fmt.parseInt(u64, num_str, 10) catch return null;
     return std.math.mul(u64, val, multiplier) catch return null;
 }
+
+// --- Tests ---
+
+/// `sanitizeExeName` must stay byte-identical to the assembler's helper
+/// of the same name (labelle-assembler#362), so the docker run path
+/// resolves the same `zig-out/bin/<name>` the build.zig produced.
+pub const SanitizeExeName = struct {
+    test "passes through a clean name" {
+        const got = try sanitizeExeName(std.testing.allocator, "energy_flow");
+        defer std.testing.allocator.free(got);
+        try std.testing.expectEqualStrings("energy_flow", got);
+    }
+
+    test "keeps hyphens and digits" {
+        const got = try sanitizeExeName(std.testing.allocator, "my-game-2");
+        defer std.testing.allocator.free(got);
+        try std.testing.expectEqualStrings("my-game-2", got);
+    }
+
+    test "drops spaces and punctuation" {
+        const got = try sanitizeExeName(std.testing.allocator, "energy flow!");
+        defer std.testing.allocator.free(got);
+        try std.testing.expectEqualStrings("energyflow", got);
+    }
+
+    test "falls back to game when nothing survives" {
+        const got = try sanitizeExeName(std.testing.allocator, "!!!");
+        defer std.testing.allocator.free(got);
+        try std.testing.expectEqualStrings("game", got);
+    }
+};


### PR DESCRIPTION
Coordinated with labelle-toolkit/labelle-assembler#362 and its PR (branch `fix/issue-362-process-name`), which renames the desktop game executable from `game` to the sanitized project name.

## Change
- `src/cli/util.zig`: added `sanitizeExeName` (byte-identical to the assembler's) + a zspec test namespace.
- `src/cli.zig`: the `--docker` run path now execs `…/zig-out/bin/<sanitized project name>` instead of the hardcoded `bin/game`.

## Why only the docker path
The normal `labelle run` path uses `zig build run`, which resolves the artifact by build step (not by file path), so it keeps working regardless of the exe name. The only desktop path that execs the binary by absolute path is `--docker` — that's the one updated here. iOS/Android paths read the assembler's iOS/Android build.zig sections, which still emit `game`, so they're left unchanged.

## Verification
- `zig build` + `zig build test` pass.
- With the new assembler, `labelle run` launches `bin/<project>` and `pgrep -fl bin/<project>` matches.