### PR TITLE
fix(run): --timeout now actually kills the game (no orphans)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.47.0",
+    .version = "1.49.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1203,9 +1203,36 @@ pub fn main(proc_init: std.process.Init) !void {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }
         } else {
-            try zig_args.append(allocator, "run");
-            try appendRunForwardedArgs(&zig_args, allocator, &parsed_args);
-            const run_result = try runner.runZigInheritWithEnv(allocator, target_dir, zig_args.items, timeout_ns, env_map_ptr);
+            // Build, then run the game BINARY DIRECTLY rather than via
+            // `zig build run`. `zig build run` launches the game in its own
+            // child process group, which ESCAPES the --timeout kill: the
+            // watchdog signals labelle's direct child (the `zig build`
+            // process), the game survives in its separate group, gets
+            // reparented to init, and orphans. Run as labelle's own child and
+            // the game stays in the process group the watchdog signals, so
+            // SIGTERM→SIGKILL actually reaches it. Mirrors the --docker path.
+            //
+            // Build with no timeout (only the run is time-limited); keep the
+            // game's cwd at `target_dir` (a target_dir-relative argv[0]) so
+            // saves land exactly where `zig build run` put them.
+            const build_result = try runner.runZigInheritWithEnv(allocator, target_dir, zig_args.items, null, env_map_ptr);
+            if (build_result != 0) {
+                std.debug.print("\nlabelle: build failed (exit {d})\n", .{build_result});
+                return;
+            }
+            // The generated build.zig names the desktop exe `game`. Run it by
+            // a target_dir-relative path so its cwd stays `target_dir` (saves
+            // land where `zig build run` put them). NOTE: when
+            // labelle-assembler#362 renames the exe after the sanitized
+            // project name, derive that name here (mirroring the --docker
+            // path) with a `game` fallback.
+            const rel_bin = try std.fs.path.join(allocator, &.{ "zig-out", "bin", "game" });
+            defer allocator.free(rel_bin);
+            var run_args: std.ArrayList([]const u8) = .empty;
+            defer run_args.deinit(allocator);
+            try run_args.append(allocator, rel_bin);
+            try appendRunForwardedArgs(&run_args, allocator, &parsed_args);
+            const run_result = try runner.runZigInheritWithEnv(allocator, target_dir, run_args.items, timeout_ns, env_map_ptr);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1220,13 +1220,19 @@ pub fn main(proc_init: std.process.Init) !void {
                 std.debug.print("\nlabelle: build failed (exit {d})\n", .{build_result});
                 return;
             }
-            // The generated build.zig names the desktop exe `game`. Run it by
-            // a target_dir-relative path so its cwd stays `target_dir` (saves
-            // land where `zig build run` put them). NOTE: when
-            // labelle-assembler#362 renames the exe after the sanitized
-            // project name, derive that name here (mirroring the --docker
-            // path) with a `game` fallback.
-            const rel_bin = try std.fs.path.join(allocator, &.{ "zig-out", "bin", "game" });
+            // Exe name: the assembler names the desktop exe after the
+            // sanitized project (labelle-assembler#362); older generated
+            // build.zig still emit `game`. Prefer the project name; fall back
+            // to `game` when that binary isn't on disk, so this works both
+            // before and after the rename ships. Run it by a target_dir-
+            // relative path so the game's cwd stays `target_dir` (saves land
+            // where `zig build run` put them). Mirrors the --docker path.
+            const sanitized = try util.sanitizeExeName(allocator, parsed.name);
+            defer allocator.free(sanitized);
+            const sanitized_full = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "bin", sanitized });
+            defer allocator.free(sanitized_full);
+            const exe_basename: []const u8 = if (util.fileExists(sanitized_full)) sanitized else "game";
+            const rel_bin = try std.fs.path.join(allocator, &.{ "zig-out", "bin", exe_basename });
             defer allocator.free(rel_bin);
             var run_args: std.ArrayList([]const u8) = .empty;
             defer run_args.deinit(allocator);

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -10,7 +10,22 @@ const windows = if (is_windows) struct {
 /// Shared state between the main thread and the timeout thread.
 /// Heap-allocated so it outlives the spawning stack frame.
 const TimeoutState = struct {
+    allocator: std.mem.Allocator,
     timed_out: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    // Both the main thread and the detached timeout thread hold a reference
+    // (init 2); whoever drops the last one frees it. Without this the main
+    // thread's `defer` frees `state` as soon as `child.wait` returns — and if
+    // the child exits BEFORE the timeout fires, the still-sleeping timeout
+    // thread then writes `timed_out` into freed memory (use-after-free).
+    ref_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(2),
+
+    fn release(self: *TimeoutState) void {
+        // `.acq_rel`: the decrement publishes our writes to other releasers
+        // and, on the last decrement, observes theirs before we destroy.
+        if (self.ref_count.fetchSub(1, .acq_rel) == 1) {
+            self.allocator.destroy(self);
+        }
+    }
 };
 
 /// Run a zig command capturing stdout/stderr.
@@ -58,11 +73,11 @@ pub fn runZigInheritWithEnv(
 
     // Heap-allocate so the detached thread can safely access it after this function returns
     var state: ?*TimeoutState = null;
-    defer if (state) |s| allocator.destroy(s);
+    defer if (state) |s| s.release();
 
     if (timeout_ns) |ns| {
         state = try allocator.create(TimeoutState);
-        state.?.* = .{};
+        state.?.* = .{ .allocator = allocator };
 
         if (is_windows) {
             const win_pid = windows.GetProcessId(child.id.?);
@@ -168,6 +183,7 @@ fn sleepNanos(ns: u64) void {
 const KILL_GRACE_NS: u64 = 2 * std.time.ns_per_s;
 
 fn timeoutKillPosix(pid: std.process.Child.Id, timeout_ns: u64, state: *TimeoutState) void {
+    defer state.release();
     sleepNanos(timeout_ns);
     state.timed_out.store(true, .release);
     // Negative pid = the child's whole process group. The child was spawned
@@ -201,6 +217,7 @@ fn timeoutKillPosix(pid: std.process.Child.Id, timeout_ns: u64, state: *TimeoutS
 
 fn timeoutKillWindows(allocator: std.mem.Allocator, pid: std.os.windows.DWORD, timeout_ns: u64, state: *TimeoutState) void {
     _ = allocator;
+    defer state.release();
     sleepNanos(timeout_ns);
     state.timed_out.store(true, .release);
     var pid_buf: [16]u8 = undefined;

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -164,13 +164,37 @@ fn sleepNanos(ns: u64) void {
     }
 }
 
+/// Grace period between the SIGTERM and the SIGKILL escalation below.
+const KILL_GRACE_NS: u64 = 2 * std.time.ns_per_s;
+
 fn timeoutKillPosix(pid: std.process.Child.Id, timeout_ns: u64, state: *TimeoutState) void {
     sleepNanos(timeout_ns);
     state.timed_out.store(true, .release);
+    // Negative pid = the child's whole process group. The child was spawned
+    // with `.pgid = 0`, so it leads its own group — this signals only THIS
+    // game's process tree (game + its `zig build run` parent), never any
+    // other game that happens to be running.
     const pgid: std.posix.pid_t = -@as(std.posix.pid_t, @intCast(pid));
+    // SIGTERM first, so a game that installs a handler can tear down its
+    // GPU/window cleanly.
     std.posix.kill(pgid, std.posix.SIG.TERM) catch |err| {
         if (err != error.ProcessNotFound) {
             std.debug.print("labelle: timeout kill failed: {any}\n", .{err});
+        }
+    };
+    // Escalate to SIGKILL. The bgfx/raylib game traps SIGTERM (it installs a
+    // handler for that clean teardown), so it can also just ignore it —
+    // leaving `child.wait()` to block forever and the game orphaned (the
+    // long-standing "labelle run --timeout doesn't terminate" symptom).
+    // SIGKILL can't be trapped. Still scoped to the same process group, so
+    // other running games are untouched. If the game DID exit on SIGTERM,
+    // `child.wait()` has already returned and `labelle` exits before this
+    // grace elapses — this detached thread dies with the process — so the
+    // SIGKILL only ever fires on a game that actually ignored SIGTERM.
+    sleepNanos(KILL_GRACE_NS);
+    std.posix.kill(pgid, std.posix.SIG.KILL) catch |err| {
+        if (err != error.ProcessNotFound) {
+            std.debug.print("labelle: timeout SIGKILL failed: {any}\n", .{err});
         }
     };
 }


### PR DESCRIPTION
## Bug
`labelle run --timeout` failed to terminate the game two ways:
1. It sent only **SIGTERM**, which the bgfx/raylib game **traps** (clean GPU teardown) and can ignore.
2. Even with a kill, `zig build run` launches the game in its **own child process group**, so the watchdog (which signals labelle's direct child, the `zig build` process) never reaches the game — it survives, reparents to init, and **orphans**.

Result: `--timeout` hung / left orphaned games piling up (the recurring 'timeout doesn't terminate the bgfx backend' symptom).

## Fix (two parts)
1. **`runner.zig`**: escalate the timeout kill **SIGTERM → SIGKILL** (2s grace). SIGKILL can't be trapped. Still scoped to the child's own process group (`-pid`), so a second running game is untouched.
2. **`cli.zig`**: the default desktop run now **builds then execs the game binary directly** (as `--docker` already did) instead of `zig build run`, so the game is labelle's own child *in* the signalled process group. Game cwd stays `target_dir` (target_dir-relative argv[0]) so saves don't move.

⚠️ **Blast radius**: changes how every desktop `labelle run` launches the game (build + direct exec vs `zig build run`). Behaviour preserved: same build, same cwd/saves, same forwarded args/env, same exit-code reporting.

Note: the exe is `game` today; when labelle-assembler#362 renames it per-project, derive the name here (a `game` fallback, mirroring `--docker`).

## Validation
flying-platform (bgfx): `labelle run --timeout=8s` now exits cleanly (rc=0) with **0 orphaned game processes** — previously **1 orphan survived every run**. `zig build test` green. version 1.47.0 → 1.49.0.