### PR TITLE
fix(windows): preserve parent env for run flags + extract astcenc via System32 bsdtar

### DIFF
--- a/src/astc/astcenc_bin.zig
+++ b/src/astc/astcenc_bin.zig
@@ -117,10 +117,13 @@ pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []c
     // libarchive-backed system tar. Falls back to bare `tar` if SystemRoot is unset.
     const extracted = if (builtin.os.tag == .windows) blk: {
         const tar_exe = windowsTarPath(allocator) catch |err| switch (err) {
-            // OOM is fatal — don't mask it behind the bare-`tar` fallback,
-            // which only exists for a missing SystemRoot/windir.
-            error.OutOfMemory => return error.OutOfMemory,
-            else => try allocator.dupe(u8, "tar"),
+            // The bare-`tar` fallback exists ONLY for an unset/invalid
+            // SystemRoot+windir (the same cases `envVarOwnedOptional` collapses
+            // to null). Everything else — OOM first and foremost — propagates,
+            // so a real failure isn't silently masked by running whatever `tar`
+            // is on PATH (reintroducing the Git Bash GNU-tar shadowing bug).
+            error.EnvironmentVariableMissing, error.InvalidWtf8 => try allocator.dupe(u8, "tar"),
+            else => return err,
         };
         defer allocator.free(tar_exe);
         break :blk runOk(allocator, &.{ tar_exe, "-xf", zip_path, "-C", ver_dir });
@@ -156,10 +159,12 @@ fn windowsTarPath(allocator: std.mem.Allocator) ![]u8 {
     // `SystemRoot` is the canonical var (e.g. C:\Windows); `windir` is its
     // historical alias. Try both before giving up.
     const root = env.getAlloc(allocator, "SystemRoot") catch |err| switch (err) {
-        // OOM is fatal — only fall back to the `windir` alias when SystemRoot
-        // is genuinely absent, not when the allocation itself failed.
-        error.OutOfMemory => return error.OutOfMemory,
-        else => try env.getAlloc(allocator, "windir"),
+        // Only fall through to the `windir` alias when SystemRoot is unset or
+        // invalid UTF-8 (the cases `envVarOwnedOptional` treats as "not set").
+        // OOM and any other error propagate rather than masking a corrupt
+        // environment behind the alias lookup.
+        error.EnvironmentVariableMissing, error.InvalidWtf8 => try env.getAlloc(allocator, "windir"),
+        else => return err,
     };
     defer allocator.free(root);
     return std.fmt.allocPrint(allocator, "{s}\\System32\\tar.exe", .{root});

--- a/src/astc/astcenc_bin.zig
+++ b/src/astc/astcenc_bin.zig
@@ -116,7 +116,12 @@ pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []c
     // extract would fail only for those users. The absolute path always hits the
     // libarchive-backed system tar. Falls back to bare `tar` if SystemRoot is unset.
     const extracted = if (builtin.os.tag == .windows) blk: {
-        const tar_exe = windowsTarPath(allocator) catch try allocator.dupe(u8, "tar");
+        const tar_exe = windowsTarPath(allocator) catch |err| switch (err) {
+            // OOM is fatal — don't mask it behind the bare-`tar` fallback,
+            // which only exists for a missing SystemRoot/windir.
+            error.OutOfMemory => return error.OutOfMemory,
+            else => try allocator.dupe(u8, "tar"),
+        };
         defer allocator.free(tar_exe);
         break :blk runOk(allocator, &.{ tar_exe, "-xf", zip_path, "-C", ver_dir });
     } else runOk(allocator, &.{ "unzip", "-o", "-q", zip_path, "-d", ver_dir });
@@ -150,8 +155,12 @@ fn windowsTarPath(allocator: std.mem.Allocator) ![]u8 {
     const env = @import("../cli/config.zig").globalEnviron();
     // `SystemRoot` is the canonical var (e.g. C:\Windows); `windir` is its
     // historical alias. Try both before giving up.
-    const root = env.getAlloc(allocator, "SystemRoot") catch
-        try env.getAlloc(allocator, "windir");
+    const root = env.getAlloc(allocator, "SystemRoot") catch |err| switch (err) {
+        // OOM is fatal — only fall back to the `windir` alias when SystemRoot
+        // is genuinely absent, not when the allocation itself failed.
+        error.OutOfMemory => return error.OutOfMemory,
+        else => try env.getAlloc(allocator, "windir"),
+    };
     defer allocator.free(root);
     return std.fmt.allocPrint(allocator, "{s}\\System32\\tar.exe", .{root});
 }

--- a/src/astc/astcenc_bin.zig
+++ b/src/astc/astcenc_bin.zig
@@ -108,10 +108,18 @@ pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []c
     }
     // Extract: `unzip` on unix (GNU tar can't read zips), bsdtar on Windows
     // (where `unzip` isn't shipped but `tar` reads zips since Win10).
-    const extracted = if (builtin.os.tag == .windows)
-        runOk(allocator, &.{ "tar", "-xf", zip_path, "-C", ver_dir })
-    else
-        runOk(allocator, &.{ "unzip", "-o", "-q", zip_path, "-d", ver_dir });
+    //
+    // On Windows resolve bsdtar by ABSOLUTE path (<SystemRoot>\System32\tar.exe)
+    // rather than a bare `tar`: when labelle runs from a Git Bash / MSYS / Cygwin
+    // shell, that environment's GNU `tar` shadows the System32 bsdtar on PATH, and
+    // GNU tar can't read a zip ("This does not look like a tar archive") — so the
+    // extract would fail only for those users. The absolute path always hits the
+    // libarchive-backed system tar. Falls back to bare `tar` if SystemRoot is unset.
+    const extracted = if (builtin.os.tag == .windows) blk: {
+        const tar_exe = windowsTarPath(allocator) catch try allocator.dupe(u8, "tar");
+        defer allocator.free(tar_exe);
+        break :blk runOk(allocator, &.{ tar_exe, "-xf", zip_path, "-C", ver_dir });
+    } else runOk(allocator, &.{ "unzip", "-o", "-q", zip_path, "-d", ver_dir });
     if (!extracted) {
         std.debug.print("labelle: astcenc extract failed. Install astcenc under {s}/bin/\n", .{ver_dir});
         return error.AstcencExtractFailed;
@@ -133,6 +141,19 @@ pub fn ensure(allocator: std.mem.Allocator, cache_root: []const u8, version: []c
 
 fn util_io() std.Io {
     return @import("../cli/config.zig").globalIo();
+}
+
+/// `<SystemRoot>\System32\tar.exe` — the libarchive-backed bsdtar shipped with
+/// Windows 10+. Resolving it absolutely sidesteps a Git Bash / MSYS GNU `tar`
+/// that may shadow it on PATH (GNU tar can't read zips). Caller owns the slice.
+fn windowsTarPath(allocator: std.mem.Allocator) ![]u8 {
+    const env = @import("../cli/config.zig").globalEnviron();
+    // `SystemRoot` is the canonical var (e.g. C:\Windows); `windir` is its
+    // historical alias. Try both before giving up.
+    const root = env.getAlloc(allocator, "SystemRoot") catch
+        try env.getAlloc(allocator, "windir");
+    defer allocator.free(root);
+    return std.fmt.allocPrint(allocator, "{s}\\System32\\tar.exe", .{root});
 }
 
 fn runOk(allocator: std.mem.Allocator, argv: []const []const u8) bool {

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -135,19 +135,18 @@ pub fn buildEnvironWithExtra(
     allocator: std.mem.Allocator,
     extras: []const EnvKV,
 ) !std.process.Environ.Map {
-    var map = std.process.Environ.Map.init(allocator);
-    errdefer map.deinit();
-
+    // `Environ.createMap` is the platform-correct snapshot: on Windows the
+    // inherited environment is a *global* block (read live from the PEB),
+    // NOT a `WindowsBlock` slice, so the old `switch (@TypeOf(block))` hit
+    // the global branch and produced an extras-ONLY map — stripping PATH,
+    // LOCALAPPDATA, etc. That made every env-injecting `run` flag
+    // (--headless/--scene/--screenshot/--profile) fail with
+    // `AppDataDirUnavailable` because the child `zig build` lost its cache
+    // dir. createMap reads the PEB on Windows, `environ` on POSIX, and the
+    // WASI environ API on WASI, so the parent env is preserved everywhere.
     const environ = config.globalEnviron();
-    const block = environ.block;
-    switch (@TypeOf(block)) {
-        std.process.Environ.PosixBlock => try map.putPosixBlock(block.view()),
-        std.process.Environ.WindowsBlock => try map.putWindowsBlock(block.view()),
-        std.process.Environ.GlobalBlock => {
-            // Nothing to snapshot for global blocks — extras-only env.
-        },
-        else => @compileError("unsupported Environ.Block variant"),
-    }
+    var map = try environ.createMap(allocator);
+    errdefer map.deinit();
 
     for (extras) |kv| {
         try map.put(kv.key, kv.value);

--- a/test/gui-plugin-test/project.labelle
+++ b/test/gui-plugin-test/project.labelle
@@ -2,6 +2,7 @@
     .name = "gui_plugin_test",
     .title = "GUI Plugin Test",
     .backend = .raylib,
+    .y_axis = .up,
     .ecs = .mock,
     .gui = .{ .path = "../../../labelle-assembler/plugins/imgui" },
     .core_version = "local:../../../labelle-core",

--- a/test/imgui-anchor-test/project.labelle
+++ b/test/imgui-anchor-test/project.labelle
@@ -16,6 +16,7 @@
     .name = "imgui_anchor_test",
     .title = "ImGui Anchor Test",
     .backend = .sokol,
+    .y_axis = .up,
     .ecs = .zig_ecs,
     .gui = .{ .plugin = "imgui" },
     .core_version = "local:../../../labelle-core",

--- a/test/nuklear-plugin-test/project.labelle
+++ b/test/nuklear-plugin-test/project.labelle
@@ -2,6 +2,7 @@
     .name = "nuklear_plugin_test",
     .title = "Nuklear Plugin Test",
     .backend = .raylib,
+    .y_axis = .up,
     .ecs = .mock,
     .gui = .{ .path = "../../../labelle-assembler/plugins/nuklear" },
     .plugins = .{

--- a/test/plugin-manifest-test/project.labelle
+++ b/test/plugin-manifest-test/project.labelle
@@ -3,6 +3,7 @@
     .title = "Plugin Manifest Test",
     .backend = .raylib,
     .ecs = .mock,
+    .y_axis = .up,
     .core_version = "local:../../../labelle-core",
     .engine_version = "local:../../../labelle-engine",
     .gfx_version = "local:../../../labelle-gfx",


### PR DESCRIPTION
## Summary

Two Windows fixes found while validating the v1.50.0 changes on Windows 11 (Zig 0.16). Both are independent; each is its own commit.

### 1. `fix(run)`: parent environment stripped on Windows for env-injecting flags

The new direct-run path injects env vars for `--headless`, `--scene`, `--screenshot`, and `--profile` via `buildEnvironWithExtra`, which is meant to be "parent env + extras". On Windows it instead produced an **extras-only** environment, so the child `zig build` lost `LOCALAPPDATA`/`PATH` and failed with:

```
error: unable to resolve zig cache directory: AppDataDirUnavailable
labelle: build failed (exit 1)
```

Root cause: the helper switched on `@TypeOf(block)` and assumed the inherited env is a `WindowsBlock`, but Zig 0.16 represents it as a *global* (PEB-backed) block — hitting the "nothing to snapshot" branch. Fixed by using `std.process.Environ.createMap`, the platform-correct snapshot (PEB on Windows, `environ` on POSIX, WASI environ API on WASI).

### 2. `fix(astc)`: `labelle astc` extraction fails under Git Bash/MSYS

Extraction used a bare `tar -xf` to read the astcenc release zip. In PowerShell/cmd this is System32 bsdtar (reads zips, fine), but when labelle runs from a Git Bash / MSYS / Cygwin shell, that shell's GNU `tar` shadows it on `PATH` and cannot read a zip (`This does not look like a tar archive`). Pinned the Windows extract to absolute `<SystemRoot>\System32\tar.exe` (with a bare-`tar` fallback).

## Testing

- `zig build test` — **294/294 pass**.
- Verified on Windows 11 / Zig 0.16 against a freshly scaffolded raylib project:
  - `labelle run --screenshot=... --after=1s` writes a valid 800×600 PNG and self-exits (previously: `AppDataDirUnavailable`).
  - `labelle run --timeout` confirmed still kills cleanly with no orphan.
  - `labelle astc` full download → extract → convert from a Git Bash shell produces a valid `.astc` (correct `0x5CA1AB13` magic, 8×8 blocks).

## Note (not addressed here)

DebugAllocator reports a benign `TimeoutState` leak (`runner.zig` `runZigInheritWithEnv`) when a game self-exits before `--timeout` fires — the detached watchdog thread still holds its refcount and the process exits before it wakes. It's a deliberate trade-off of the UAF fix in #265 and harmless; flagging only for visibility.
