### PR TITLE
fix(compat): independent minor versioning — warn on major mismatch only + refresh versions.zon

### DIFF
--- a/src/cli/compatibility.zig
+++ b/src/cli/compatibility.zig
@@ -15,38 +15,38 @@ pub fn validateCompatibility(cfg: project_config.ProjectConfig) void {
     const is_local = project_config.isLocalVersion;
     var warnings: u8 = 0;
 
-    const core_mm = if (!is_local(cfg.core_version)) parseMajorMinor(cfg.core_version) else null;
-    const engine_mm = if (!is_local(cfg.engine_version)) parseMajorMinor(cfg.engine_version) else null;
-    const gfx_mm = if (!is_local(cfg.gfx_version)) parseMajorMinor(cfg.gfx_version) else null;
-    const cli_mm = if (!is_local(cfg.labelle_version)) parseMajorMinor(cfg.labelle_version) else null;
+    // core / engine / gfx / cli version on INDEPENDENT minor trains (e.g. core
+    // 1.21, engine 1.65, gfx 1.19 are all current + mutually compatible). The
+    // assembler unifies every package onto the project's core at build time (the
+    // "core diamond"), so source-compatibility — not matching minors — is what
+    // matters. Only a MAJOR-version divergence is a real break (a 2.x package
+    // against a 1.x core), so that's all we warn on. The curated tested set lives
+    // in `versions.zon` (what `labelle upgrade all` targets); a per-package
+    // declared-core check (read each package's own core pin) is the planned
+    // stronger follow-up.
+    const core_major = if (!is_local(cfg.core_version)) parseVersion(cfg.core_version).major else null;
 
-    if (core_mm != null and engine_mm != null and core_mm.? != engine_mm.?) {
-        std.debug.print("labelle: warning: engine {s} may be incompatible with core {s}\n", .{ cfg.engine_version, cfg.core_version });
-        std.debug.print("  engine depends on core — their major.minor versions should match\n", .{});
-        std.debug.print("  hint: run `labelle upgrade all`\n\n", .{});
-        warnings += 1;
-    }
-
-    if (core_mm != null and gfx_mm != null and core_mm.? != gfx_mm.?) {
-        std.debug.print("labelle: warning: gfx {s} may be incompatible with core {s}\n", .{ cfg.gfx_version, cfg.core_version });
-        std.debug.print("  gfx depends on core — their major.minor versions should match\n", .{});
-        std.debug.print("  hint: run `labelle upgrade gfx` or `labelle upgrade all`\n\n", .{});
-        warnings += 1;
-    }
-
-    if (core_mm != null and cli_mm != null and core_mm.? != cli_mm.?) {
-        std.debug.print("labelle: warning: cli {s} backends may be incompatible with core {s}\n", .{ cfg.labelle_version, cfg.core_version });
-        std.debug.print("  backend adapters implement core interfaces — their major.minor versions should match\n", .{});
-        std.debug.print("  hint: run `labelle upgrade cli` or `labelle upgrade all`\n\n", .{});
-        warnings += 1;
-    }
-
-    for (cfg.plugins) |plugin| {
-        if (plugin.isLocal()) continue;
-        if (core_mm) |cmm| {
-            if (pluginCompatWarn(plugin.version, cmm)) {
+    const Dep = struct { name: []const u8, version: []const u8 };
+    const deps = [_]Dep{
+        .{ .name = "engine", .version = cfg.engine_version },
+        .{ .name = "gfx", .version = cfg.gfx_version },
+        .{ .name = "cli", .version = cfg.labelle_version },
+    };
+    if (core_major) |cmaj| {
+        for (deps) |d| {
+            if (is_local(d.version)) continue;
+            if (parseVersion(d.version).major != cmaj) {
+                std.debug.print("labelle: warning: {s} {s} may be incompatible with core {s}\n", .{ d.name, d.version, cfg.core_version });
+                std.debug.print("  major versions should match (minor versions are independent across packages)\n", .{});
+                std.debug.print("  hint: run `labelle upgrade all`\n\n", .{});
+                warnings += 1;
+            }
+        }
+        for (cfg.plugins) |plugin| {
+            if (plugin.isLocal()) continue;
+            if (pluginCompatWarn(plugin.version, cmaj)) {
                 std.debug.print("labelle: warning: plugin {s} {s} may be incompatible with core {s}\n", .{ plugin.name, plugin.version, cfg.core_version });
-                std.debug.print("  plugins depend on core — their major.minor versions should match\n", .{});
+                std.debug.print("  major versions should match (minor versions are independent across packages)\n", .{});
                 std.debug.print("  hint: update the plugin version in project.labelle\n\n", .{});
                 warnings += 1;
             }
@@ -97,22 +97,18 @@ fn validateStates(states: []const []const u8) void {
     }
 }
 
-/// Decide whether a plugin version should emit a compat warning against
-/// the given core major.minor value.
+/// Decide whether a plugin version should emit a compat warning against the
+/// given core MAJOR version.
 ///
-/// 0.x plugins are "pre-stable" by toolkit convention and live on a
-/// separate version train from a 1.x+ core, so the major.minor equality
-/// check does not apply to them — they are always skipped here. See
-/// https://github.com/labelle-toolkit/labelle-cli/issues/230. A declared
-/// compat range from `plugin.labelle` would supersede this skip and is
-/// tracked as the proper long-term fix.
-fn pluginCompatWarn(plugin_version: []const u8, core_mm: u32) bool {
+/// Independent-versioning model (the toolkit packages each version on their own
+/// minor train): only a MAJOR divergence is a real break. 0.x plugins are
+/// "pre-stable" by convention and live on a separate train from a 1.x+ core, so
+/// they're always skipped (see labelle-cli#230). A declared compat range from
+/// `plugin.labelle` would supersede this and is the planned stronger follow-up.
+fn pluginCompatWarn(plugin_version: []const u8, core_major: u32) bool {
     const plugin = parseVersion(plugin_version);
-    // Skip the check for 0.x plugins entirely (pre-stable train).
-    // Test the major directly — the major*100+minor encoding collides
-    // for e.g. 0.100 vs 1.0, so we can't recover major from the composite.
-    if (plugin.major == 0) return false;
-    return (plugin.major * 100 + plugin.minor) != core_mm;
+    if (plugin.major == 0) return false; // pre-stable train, skip
+    return plugin.major != core_major;
 }
 
 /// Parse a semver string into its major/minor components.
@@ -132,54 +128,26 @@ fn parseVersion(version: []const u8) struct { major: u32, minor: u32 } {
     return .{ .major = parts[0], .minor = parts[1] };
 }
 
-/// Parse a semver string into a major.minor comparable value.
-///
-/// Note: the major*100+minor encoding is ambiguous (0.100 collides with 1.0).
-/// Callers that need to distinguish 0.x from 1.x should use `parseVersion`.
-fn parseMajorMinor(version: []const u8) u32 {
-    const v = parseVersion(version);
-    return v.major * 100 + v.minor;
-}
-
 // ── Tests ────────────────────────────────────────────────────────────
 
 test "pluginCompatWarn: 0.x plugin vs 1.x core — no warning (issue #230)" {
-    const core_mm = parseMajorMinor("1.14.1");
-    try std.testing.expect(!pluginCompatWarn("0.5.0", core_mm));
-    try std.testing.expect(!pluginCompatWarn("0.6.1", core_mm));
+    try std.testing.expect(!pluginCompatWarn("0.5.0", 1));
+    try std.testing.expect(!pluginCompatWarn("0.6.1", 1));
 }
 
-test "pluginCompatWarn: 0.x plugin vs 0.x core with matching minor — no warning" {
-    const core_mm = parseMajorMinor("0.5.0");
-    try std.testing.expect(!pluginCompatWarn("0.5.2", core_mm));
+test "pluginCompatWarn: 1.x plugin vs 1.x core — no warning regardless of minor (independent minors)" {
+    // The key change: a minor mismatch is NOT a warning anymore. core 1.21 +
+    // plugin 1.13 are both major 1 → compatible under independent versioning.
+    try std.testing.expect(!pluginCompatWarn("1.14.0", 1));
+    try std.testing.expect(!pluginCompatWarn("1.13.0", 1));
+    try std.testing.expect(!pluginCompatWarn("1.65.0", 1));
 }
 
-test "pluginCompatWarn: 0.x plugin vs 0.x core with mismatched minor — no warning (0.x always skipped)" {
-    const core_mm = parseMajorMinor("0.5.0");
-    try std.testing.expect(!pluginCompatWarn("0.6.0", core_mm));
-    try std.testing.expect(!pluginCompatWarn("0.3.0", core_mm));
+test "pluginCompatWarn: major mismatch still warns" {
+    try std.testing.expect(pluginCompatWarn("2.0.0", 1));
+    try std.testing.expect(pluginCompatWarn("1.0.0", 2));
 }
 
-test "pluginCompatWarn: 1.x plugin matches 1.x core — no warning" {
-    const core_mm = parseMajorMinor("1.14.1");
-    try std.testing.expect(!pluginCompatWarn("1.14.0", core_mm));
-    try std.testing.expect(!pluginCompatWarn("1.14.5", core_mm));
-}
-
-test "pluginCompatWarn: 1.x plugin mismatched with 1.x core — warns" {
-    const core_mm = parseMajorMinor("1.14.1");
-    try std.testing.expect(pluginCompatWarn("1.13.0", core_mm));
-    try std.testing.expect(pluginCompatWarn("1.15.0", core_mm));
-    try std.testing.expect(pluginCompatWarn("2.0.0", core_mm));
-}
-
-test "pluginCompatWarn: 0.100.x plugin is still treated as 0.x (no warn vs 1.x core)" {
-    // Regression: parseMajorMinor("0.100.0") encodes as 100, which would
-    // collide with 1.0 under a naive `< 100` check. Major must be tested
-    // directly.
-    const core_mm = parseMajorMinor("1.14.1");
-    try std.testing.expect(!pluginCompatWarn("0.100.0", core_mm));
-    // Also confirm against a 1.0 core where the encoded values would match.
-    const core_10 = parseMajorMinor("1.0.0");
-    try std.testing.expect(!pluginCompatWarn("0.100.0", core_10));
+test "pluginCompatWarn: 0.100.x plugin is still treated as 0.x (no warn)" {
+    try std.testing.expect(!pluginCompatWarn("0.100.0", 1));
 }

--- a/versions.zon
+++ b/versions.zon
@@ -1,5 +1,9 @@
 .{
-    .core = "1.17.0",
-    .engine = "1.50.0",
-    .gfx = "1.10.0",
+    // The current tested-compatible set `labelle upgrade all` targets. The
+    // packages version on INDEPENDENT minor trains (the assembler unifies them
+    // onto the project's core at build time), so these minors differ by design.
+    // Bump to the latest releases as they're cut + CI-verified together.
+    .core = "1.21.0",
+    .engine = "1.65.0",
+    .gfx = "1.19.0",
 }


### PR DESCRIPTION
## The version-compatibility check assumed lockstep minors the repos abandoned

`compatibility.zig` required **core.minor == engine.minor == gfx.minor == cli.minor**. But the toolkit packages version on **independent minor trains** — the current releases are **core 1.21 / engine 1.65 / gfx 1.19 / cli 1.50**, all mutually compatible. The assembler unifies every package onto the project's core at build time (the "core diamond"), so *source*-compatibility, not matching minors, is what matters.

So the lockstep rule fired a `may be incompatible` warning on essentially **every** project — it even trips on the canonical `versions.zon` set — and that noise buries real signal. (It's also what made an external-bgfx black-screen look version-related when it wasn't.)

### Change
- **Warn only on a MAJOR-version divergence** (e.g. a 2.x package against a 1.x core — a genuine break). Minors are independent. Today, core/engine/gfx/cli are all 1.x → zero warnings (correct).
- **Refresh the stale `versions.zon`** (the `labelle upgrade all` target) from core 1.17 / engine 1.50 / gfx 1.10 → the current latest set (core 1.21 / engine 1.65 / gfx 1.19).
- Tests updated: a 1.x-plugin minor mismatch no longer warns; a major mismatch still does.

### Notes / follow-ups
- The `versions.zon` set is the latest releases. A maintainer/CI **matrix build should confirm they're tested together** (gfx 1.19 build-pins core 1.20, which the core-diamond overrides to the project's core) before relying on `upgrade all` to that set.
- A **per-package declared-core check** (read each package's own core pin from its `build.zig.zon`, compare against the project's core) is the stronger follow-up to this major-only heuristic — it's the "each package declares the core it targets" model. Deferred because it needs the CLI to fetch/parse each package manifest (and engine path-deps core, so it has nothing to declare yet).

`zig build test` green.