### PR TITLE
packs: `labelle check` — the §6 enforcement lint (Closes #270)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -14,6 +14,7 @@
 ///   labelle update [ver]                — self-update the CLI
 ///   labelle clean [--dry-run]           — prune unused package versions
 ///   labelle test [dir] [--verbose]      — run inline `test` blocks across the project source tree
+///   labelle check [dir]                 — lint packs for §6 convention violations (Packs RFC)
 const std = @import("std");
 const project_config = @import("cli/project_config.zig");
 
@@ -41,10 +42,11 @@ const pack = @import("cli/pack.zig");
 const astc_cmd = @import("astc/cmd.zig");
 const audit = @import("cli/audit.zig");
 const migrate = @import("cli/migrate.zig");
+const check = @import("cli/check.zig");
 const doctor = @import("cli/doctor.zig");
 const sdl_provision = @import("cli/sdl_provision.zig");
 
-const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd };
+const Command = enum { generate, build, run, init_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd, check_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -644,6 +646,9 @@ pub fn main(proc_init: std.process.Init) !void {
         } else if (std.mem.eql(u8, first, "migrate")) {
             parsed_args.command = .migrate_cmd;
             try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "check")) {
+            parsed_args.command = .check_cmd;
+            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "doctor")) {
             parsed_args.command = .doctor_cmd;
             try collectExtraArgs(&args, &parsed_args);
@@ -758,6 +763,7 @@ pub fn main(proc_init: std.process.Init) !void {
         .astc_cmd => return astc_cmd.cmdAstc(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .audit_cmd => return audit.cmdAudit(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .migrate_cmd => return migrate.cmdMigrate(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .check_cmd => return check.cmdCheck(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .doctor_cmd => return doctor.cmdDoctor(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},

--- a/src/cli/check.zig
+++ b/src/cli/check.zig
@@ -1,0 +1,49 @@
+//! `labelle check` — the Packs enforcement lint (labelle-cli#270).
+//!
+//! Thin CLI wrapper: parses the optional project directory and delegates
+//! to the standalone `labelle-assembler check` subcommand, which owns the
+//! AST/token scan (it already has the pack-scan + `pack.labelle` DAG
+//! machinery). Mirrors how `generate`/`install` delegate — the CLI stays a
+//! driver over the assembler binary.
+//!
+//! Part of the Packs initiative: RFC Flying-Platform/flying-platform-labelle#561
+//! §6 "Enforcement"; umbrella labelle-engine#651.
+//!
+//! Exit code is the assembler's own (`assembler_proc` re-exits with the
+//! child's code): 0 when clean, 1 when violations are found — so `labelle
+//! check` drops straight into a CI gate.
+
+const std = @import("std");
+const assembler_proc = @import("assembler_proc.zig");
+
+/// Handle `labelle check [dir]`. `cmd_args` is everything after the
+/// `check` token. The single optional positional is the project directory
+/// (default `.`); any flags are forwarded to the assembler untouched so
+/// future `check` flags need no CLI change.
+pub fn cmdCheck(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    var dir: []const u8 = ".";
+    var dir_set = false;
+
+    var forwarded: std.ArrayList([]const u8) = .empty;
+    defer forwarded.deinit(allocator);
+
+    for (cmd_args) |arg| {
+        if (std.mem.startsWith(u8, arg, "-")) {
+            try forwarded.append(allocator, arg);
+        } else if (!dir_set) {
+            dir = arg;
+            dir_set = true;
+        } else {
+            std.debug.print("labelle check: unexpected argument '{s}'\n", .{arg});
+            std.debug.print("  usage: labelle check [dir]\n", .{});
+            return error.TooManyArguments;
+        }
+    }
+
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.appendSlice(allocator, &.{ "--project-root", dir });
+    try argv.appendSlice(allocator, forwarded.items);
+
+    try assembler_proc.runSubcommand(allocator, dir, "check", argv.items);
+}

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -23,6 +23,7 @@ pub fn printHelp() void {
         \\  test [dir] [--verbose] [--no-libs]  Run inline `test` blocks across the project source tree
         \\  audit unification [dir]  Pre-flight check for the unified scene/prefab loader (RFC #560)
         \\  migrate unified [dir] [--dry-run]  Auto-fix legacy unified-format patterns (RFC #594 / engine#592)
+        \\  check [dir]          Lint packs for §6 convention violations (Packs RFC)
         \\  doctor [dir]         Check desktop build requirements (SDL2, Zig) and report fixes
         \\  help                 Show this help
         \\  version              Show CLI version


### PR DESCRIPTION
Adds `labelle check [dir]` — the Packs enforcement "net" (Phase 5): a static/AST scan over the game + its packs that reports the §6 convention rules the compiler can't (yet) enforce, and **exits non-zero on violations** so it drops straight into a CI gate.

**Closes #270.** **Part of** the Packs initiative — umbrella labelle-toolkit/labelle-engine#651; RFC `Flying-Platform/flying-platform-labelle` `docs/RFC-packs.md` §6.

## Architecture

The AST/token scan lives in the **assembler** (which already has the pack-scan + `pack.labelle` DAG machinery from #439/#440/#441) — companion PR **labelle-toolkit/labelle-assembler#486** adds the `check` subcommand. This CLI change is the thin driver: `labelle check [dir]` locates + delegates to `labelle-assembler check --project-root <dir>`, mirroring how `generate`/`install` delegate. The assembler's exit code propagates verbatim.

`src/cli/check.zig` is a **distinct file** (per the ticket note, to minimize overlap with the parallel `labelle add` #271 work — only the command enum + one dispatch line touch `cli.zig`).

## Checks (implemented in the assembler PR)

1. **cross-pack registry access** — `getType("<other>__X")` / `entityHasNamed(…, "<other>__X")` / `view(.{ForeignComponent})` on a foreign pack's name — **high confidence**.
2. **raw `.global`-facet writes** — `Locked{…}` bypassing `Locked.tryAcquire` — **high confidence**.
3. **event-direction inversions** — a lower pack reacting to a higher pack's event, per the `depends_on` DAG — **good, best-effort** (subscription detection is heuristic; the compile-time wall is future).

Framework, fixtures, and honest deferral details are in the assembler PR.

## Verification

- `zig build` ✓, `zig build test` ✓ — **6/6 steps, 292/292 tests passed**.
- `zig fmt --check` clean.
- Manual e2e (with `LABELLE_ASSEMBLER` pointed at the companion build) against a synthetic three-pack game: `labelle check` reports the violations and exits 1; the cleaned tree exits 0.

## Requires

An assembler with the `check` subcommand (protocol v4 — labelle-assembler#486). Against an older pinned assembler, `labelle check` surfaces the assembler's "unknown subcommand" message; `generate`/`build`/`run` are unaffected (the CLI still only requires protocol ≥3).