### PR TITLE
chore: release 1.51.0 — bgfx wasm backend

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.50.0",
+    .version = "1.51.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone


### PR DESCRIPTION
Bumps 1.50.0 → 1.51.0 to release the bgfx-wasm compatibility-guard fix (#274). Tag v1.51.0 fires release.yml.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw