### PR TITLE
Managed Zig toolchain: resolve/download/verify/cache from the project pin (#279)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -284,6 +284,10 @@ fn parseZigFlag(arg: []const u8, args: anytype) ?bool {
             std.debug.print("labelle: --zig requires a path (e.g. --zig /opt/zig/zig)\n", .{});
             return null;
         };
+        if (val.len == 0) {
+            std.debug.print("labelle: --zig requires a non-empty path (e.g. --zig /opt/zig/zig)\n", .{});
+            return null;
+        }
         zig_toolchain.setFlagOverride(val);
         return true;
     }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -33,6 +33,7 @@ const lockfile = @import("cli/lockfile.zig");
 const runner = @import("cli/runner.zig");
 const assembler = @import("cli/assembler.zig");
 const assembler_proc = @import("cli/assembler_proc.zig");
+const zig_toolchain = @import("cli/zig_toolchain.zig");
 const bake_mod = @import("cli/bake.zig");
 const docker = @import("cli/docker.zig");
 const serve = @import("cli/serve.zig");
@@ -47,7 +48,7 @@ const check = @import("cli/check.zig");
 const doctor = @import("cli/doctor.zig");
 const sdl_provision = @import("cli/sdl_provision.zig");
 
-const Command = enum { generate, build, run, init_cmd, add_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd, check_cmd };
+const Command = enum { generate, build, run, init_cmd, add_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd, check_cmd, toolchain_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -262,6 +263,33 @@ fn parsePlatformFlag(arg: []const u8, platform: *?Platform, cmd_name: []const u8
     return true;
 }
 
+/// Parse the `--zig <path>` / `--zig=<path>` escape hatch (cli#279, folding
+/// in the superseded cli#203 option 2). Records the override in
+/// `zig_toolchain` so `resolveZig` returns it directly. `LABELLE_ZIG` still
+/// wins (checked first in `resolveZig`). Returns true when consumed, false
+/// when `arg` is not `--zig`, and null on a missing value. The stored slice
+/// borrows argv, which lives for the whole `main()` call.
+fn parseZigFlag(arg: []const u8, args: anytype) ?bool {
+    if (std.mem.startsWith(u8, arg, "--zig=")) {
+        const val = arg["--zig=".len..];
+        if (val.len == 0) {
+            std.debug.print("labelle: --zig requires a path (e.g. --zig=/opt/zig/zig)\n", .{});
+            return null;
+        }
+        zig_toolchain.setFlagOverride(val);
+        return true;
+    }
+    if (std.mem.eql(u8, arg, "--zig")) {
+        const val = args.next() orelse {
+            std.debug.print("labelle: --zig requires a path (e.g. --zig /opt/zig/zig)\n", .{});
+            return null;
+        };
+        zig_toolchain.setFlagOverride(val);
+        return true;
+    }
+    return false;
+}
+
 const valid_optimize_modes = [_][]const u8{ "Debug", "ReleaseSafe", "ReleaseFast", "ReleaseSmall" };
 
 /// Try to parse --optimize=<value> from an argument. Returns true if consumed,
@@ -328,6 +356,9 @@ fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?str
             docker_target = val;
             continue;
         }
+        if (parseZigFlag(arg, args)) |consumed| {
+            if (consumed) continue;
+        } else return null;
         if (std.mem.startsWith(u8, arg, "--")) {
             std.debug.print("labelle {s}: unknown flag '{s}'\n", .{ cmd_name, arg });
             return null;
@@ -500,17 +531,20 @@ fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_arg
                 return null;
             }
             continue;
-        } else if (std.mem.startsWith(u8, arg, "--")) {
-            std.debug.print("labelle {s}: unknown flag '{s}'\n", .{ cmd_name, arg });
-            return null;
-        } else {
+        } else if (parseZigFlag(arg, args)) |consumed| {
+            if (consumed) continue;
+            // parseZigFlag returned false → fall through to unknown-flag/dir.
+            if (std.mem.startsWith(u8, arg, "--")) {
+                std.debug.print("labelle {s}: unknown flag '{s}'\n", .{ cmd_name, arg });
+                return null;
+            }
             if (dir_set) {
                 std.debug.print("labelle {s}: unexpected argument '{s}'\n", .{ cmd_name, arg });
                 return null;
             }
             dir = arg;
             dir_set = true;
-        }
+        } else return null;
     }
     // `--after` without `--screenshot` is a user mistake worth flagging
     // — the delay has no observable effect by itself. Don't fail though;
@@ -555,6 +589,22 @@ fn handleAssemblerCmd(allocator: std.mem.Allocator, cmd_args: []const []const u8
     }
     std.debug.print("labelle assembler: unknown subcommand '{s}'\n", .{cmd_args[0]});
     std.debug.print("  usage: labelle assembler list\n", .{});
+    return error.UnknownSubcommand;
+}
+
+/// Handle `labelle toolchain <subcommand>` — managed Zig introspection (cli#279).
+///   list         — cached versions under `~/.labelle/zig/`
+///   which [dir]  — the version + source + path the project would use
+fn handleToolchainCmd(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
+    if (cmd_args.len == 0 or std.mem.eql(u8, cmd_args[0], "list")) {
+        return zig_toolchain.cmdToolchainList(allocator);
+    }
+    if (std.mem.eql(u8, cmd_args[0], "which")) {
+        const dir = if (cmd_args.len >= 2) cmd_args[1] else ".";
+        return zig_toolchain.cmdToolchainWhich(allocator, dir);
+    }
+    std.debug.print("labelle toolchain: unknown subcommand '{s}'\n", .{cmd_args[0]});
+    std.debug.print("  usage: labelle toolchain list | labelle toolchain which [dir]\n", .{});
     return error.UnknownSubcommand;
 }
 
@@ -654,6 +704,10 @@ pub fn main(proc_init: std.process.Init) !void {
             try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "check")) {
             parsed_args.command = .check_cmd;
+            try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "toolchain")) {
+            // `labelle toolchain list|which` — managed Zig introspection (cli#279).
+            parsed_args.command = .toolchain_cmd;
             try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "doctor")) {
             parsed_args.command = .doctor_cmd;
@@ -773,6 +827,7 @@ pub fn main(proc_init: std.process.Init) !void {
         .check_cmd => return check.cmdCheck(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .doctor_cmd => return doctor.cmdDoctor(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .toolchain_cmd => return handleToolchainCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
     }
 
@@ -1014,14 +1069,14 @@ pub fn main(proc_init: std.process.Init) !void {
     // would leave `labelle test` broken on the host after `labelle build
     // --docker`. Patch `tests/` directly when present.
     if (!parsed_args.docker) {
-        try runner.fixFingerprints(allocator, output_dir);
+        try runner.fixFingerprints(allocator, project_dir, output_dir);
     } else {
         const tests_dir = try std.fs.path.join(allocator, &.{ output_dir, "tests" });
         defer allocator.free(tests_dir);
         const tests_build_zig = try std.fs.path.join(allocator, &.{ tests_dir, "build.zig" });
         defer allocator.free(tests_build_zig);
         if (std.Io.Dir.cwd().access(config.globalIo(), tests_build_zig, .{})) |_| {
-            try runner.fixFingerprint(allocator, tests_dir);
+            try runner.fixFingerprint(allocator, project_dir, tests_dir);
         } else |_| {}
     }
     try lockfile.writeLockFile(allocator, project_dir, parsed);
@@ -1051,9 +1106,22 @@ pub fn main(proc_init: std.process.Init) !void {
         null;
     defer if (optimize_flag) |f| allocator.free(f);
 
+    // Resolve the managed Zig toolchain (labelle-cli#279): every `zig` spawn
+    // uses this binary, never PATH. Downloads + verifies on a cache miss.
+    // Skipped for docker builds — the toolchain lives inside the container.
+    const managed_zig: ?[]u8 = if (parsed_args.docker) null else try runner.resolveZigExe(allocator, project_dir);
+    defer if (managed_zig) |z| allocator.free(z);
+
+    // Build a base env for child `zig` that pins ZIG_*_CACHE_DIR into the
+    // labelle cache tree (user-writable, never next to a read-only install).
+    var zig_env_storage: ?std.process.Environ.Map = if (parsed_args.docker) null else try runner.buildZigEnv(allocator, &.{});
+    defer if (zig_env_storage) |*m| m.deinit();
+    const zig_env_ptr: ?*const std.process.Environ.Map = if (zig_env_storage) |*m| m else null;
+
     var zig_args: std.ArrayList([]const u8) = .empty;
     defer zig_args.deinit(allocator);
-    try zig_args.appendSlice(allocator, &.{ "zig", "build" });
+    try zig_args.append(allocator, managed_zig orelse "zig");
+    try zig_args.append(allocator, "build");
     if (optimize_flag) |flag| try zig_args.append(allocator, flag);
 
     if (parsed_args.docker) {
@@ -1065,7 +1133,7 @@ pub fn main(proc_init: std.process.Init) !void {
         }
     } else {
         std.debug.print("labelle: building...\n", .{});
-        const build_result = try runner.runZig(allocator, target_dir, zig_args.items);
+        const build_result = try runner.runZigWithEnv(allocator, target_dir, zig_args.items, zig_env_ptr);
         defer allocator.free(build_result.stdout);
         defer allocator.free(build_result.stderr);
 
@@ -1138,9 +1206,11 @@ pub fn main(proc_init: std.process.Init) !void {
         // asset streaming for large scenes no longer races boot. This
         // is now the ONLY mechanism for `--scene=` — the legacy
         // `.initial_prefab` rewrite was removed (see above).
+        // Default the child env to the ZIG_*_CACHE_DIR map (cli#279) so the
+        // rebuilt-and-run step still lands the compiler cache in user space.
         var env_map_storage: ?std.process.Environ.Map = null;
         defer if (env_map_storage) |*m| m.deinit();
-        var env_map_ptr: ?*const std.process.Environ.Map = null;
+        var env_map_ptr: ?*const std.process.Environ.Map = zig_env_ptr;
         const has_scene_env = parsed_args.scene_override != null;
         const has_screenshot_env = parsed_args.screenshot_path != null;
         // --headless (and the flags that imply it) surface as
@@ -1182,7 +1252,13 @@ pub fn main(proc_init: std.process.Init) !void {
                 }
                 std.debug.print("labelle: screenshot will be written to '{s}'\n", .{path});
             }
-            env_map_storage = try runner.buildEnvironWithExtra(allocator, extras.items);
+            // For a non-docker run, fold the ZIG_*_CACHE_DIR vars in too so
+            // both the build and run children share the managed cache. For a
+            // docker run there is no managed toolchain, so just add extras.
+            env_map_storage = if (parsed_args.docker)
+                try runner.buildEnvironWithExtra(allocator, extras.items)
+            else
+                try runner.buildZigEnv(allocator, extras.items);
             env_map_ptr = &env_map_storage.?;
         }
 

--- a/src/cli/android/build.zig
+++ b/src/cli/android/build.zig
@@ -87,9 +87,11 @@ fn androidBuildArch(allocator: std.mem.Allocator, target_dir: []const u8, abi: A
     };
     std.debug.print("labelle: building for Android ({s}){s}...\n", .{ abi.libDir(), mode_label });
 
+    const zig_exe = try runner.resolveZigExe(allocator, target_dir);
+    defer allocator.free(zig_exe);
     var zig_args: std.ArrayList([]const u8) = .empty;
     defer zig_args.deinit(allocator);
-    try zig_args.appendSlice(allocator, &.{ "zig", "build" });
+    try zig_args.appendSlice(allocator, &.{ zig_exe, "build" });
 
     const arch_flag = try std.fmt.allocPrint(allocator, "-Dandroid_arch={s}", .{abi.optionValue()});
     defer allocator.free(arch_flag);
@@ -128,9 +130,11 @@ pub fn androidBuild(allocator: std.mem.Allocator, target_dir: []const u8, emulat
         mode_label,
     });
 
+    const zig_exe = try runner.resolveZigExe(allocator, target_dir);
+    defer allocator.free(zig_exe);
     var zig_args: std.ArrayList([]const u8) = .empty;
     defer zig_args.deinit(allocator);
-    try zig_args.appendSlice(allocator, &.{ "zig", "build" });
+    try zig_args.appendSlice(allocator, &.{ zig_exe, "build" });
 
     if (emulator) {
         try zig_args.append(allocator, "-Demulator=true");

--- a/src/cli/assembler.zig
+++ b/src/cli/assembler.zig
@@ -67,7 +67,14 @@ fn resolveLocalAssembler(allocator: std.mem.Allocator, rel_path: []const u8, pro
     defer allocator.free(real_source);
 
     std.debug.print("labelle: building local assembler at {s}...\n", .{real_source});
-    const build_result = runner.runZig(allocator, real_source, &.{ "zig", "build" }) catch |err| {
+    // Managed Zig (cli#279) — the local assembler checkout has no
+    // project.labelle, so this resolves to the CLI's default Zig.
+    const zig_exe = runner.resolveZigExe(allocator, real_source) catch |err| {
+        std.debug.print("labelle: could not resolve managed Zig: {any}\n", .{err});
+        return error.AssemblerNotCached;
+    };
+    defer allocator.free(zig_exe);
+    const build_result = runner.runZig(allocator, real_source, &.{ zig_exe, "build" }) catch |err| {
         std.debug.print("labelle: failed to run 'zig build' in {s}: {any}\n", .{ real_source, err });
         return error.AssemblerNotCached;
     };

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -64,7 +64,7 @@ pub fn cmdDoctor(allocator: std.mem.Allocator, cmd_args: []const []const u8) !vo
 
     var checks: std.ArrayList(Check) = .empty;
 
-    try checks.append(arena, checkZig(arena));
+    try checks.append(arena, checkZig(arena, project_dir));
 
     if (needs_sdl) {
         var lib = checkSdl2Lib(arena);
@@ -157,15 +157,16 @@ fn readProjectConfig(arena: std.mem.Allocator, project_dir: []const u8) Cfg {
 
 // ── Individual checks ───────────────────────────────────────────────────
 
-fn checkZig(arena: std.mem.Allocator) Check {
+fn checkZig(arena: std.mem.Allocator, project_dir: []const u8) Check {
     // Post-cli#279 the CLI owns Zig: it resolves + downloads + verifies a
     // managed toolchain on demand, so "zig on PATH" is no longer required.
     // Report the managed toolchain the next build would use, without
-    // triggering a download.
+    // triggering a download. Scoped to `project_dir` so `labelle doctor <dir>`
+    // reports the target project's Zig, not the CWD's (cli#279 review).
     if (zig_toolchain.lookupEnvOverride(arena) catch null) |path| {
         return .{ .name = "Zig toolchain", .ok = true, .detail = std.fmt.allocPrint(arena, "LABELLE_ZIG override: {s}", .{path}) catch "LABELLE_ZIG override" };
     }
-    const resolved = zig_toolchain.resolveRequiredVersion(arena, ".") catch {
+    const resolved = zig_toolchain.resolveRequiredVersion(arena, project_dir) catch {
         return .{ .name = "Zig toolchain", .ok = false, .hint = "could not resolve the required Zig version" };
     };
     const bin = zig_cache.binaryPath(arena, resolved.version) catch {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -19,6 +19,8 @@ const builtin = @import("builtin");
 const config = @import("config.zig");
 const project_config = @import("project_config.zig");
 const sdl_provision = @import("sdl_provision.zig");
+const zig_toolchain = @import("zig_toolchain.zig");
+const zig_cache = @import("zig_cache.zig");
 
 const Check = struct {
     name: []const u8,
@@ -156,24 +158,31 @@ fn readProjectConfig(arena: std.mem.Allocator, project_dir: []const u8) Cfg {
 // ── Individual checks ───────────────────────────────────────────────────
 
 fn checkZig(arena: std.mem.Allocator) Check {
-    const res = std.process.run(arena, config.globalIo(), .{ .argv = &.{ "zig", "version" } }) catch {
-        return .{
-            .name = "Zig toolchain",
-            .ok = false,
-            .hint = "`zig` not found on PATH. Install Zig 0.15.2+ (https://ziglang.org/download), or use zvm.",
-        };
+    // Post-cli#279 the CLI owns Zig: it resolves + downloads + verifies a
+    // managed toolchain on demand, so "zig on PATH" is no longer required.
+    // Report the managed toolchain the next build would use, without
+    // triggering a download.
+    if (zig_toolchain.lookupEnvOverride(arena) catch null) |path| {
+        return .{ .name = "Zig toolchain", .ok = true, .detail = std.fmt.allocPrint(arena, "LABELLE_ZIG override: {s}", .{path}) catch "LABELLE_ZIG override" };
+    }
+    const resolved = zig_toolchain.resolveRequiredVersion(arena, ".") catch {
+        return .{ .name = "Zig toolchain", .ok = false, .hint = "could not resolve the required Zig version" };
     };
-    const passed = switch (res.term) {
-        .exited => |c| c == 0,
-        else => false,
+    const bin = zig_cache.binaryPath(arena, resolved.version) catch {
+        return .{ .name = "Zig toolchain", .ok = false, .hint = "could not compute the managed Zig path" };
     };
-    if (!passed) return .{
+    const installed = blk: {
+        std.Io.Dir.cwd().access(config.globalIo(), bin, .{}) catch break :blk false;
+        break :blk true;
+    };
+    if (installed) {
+        return .{ .name = "Zig toolchain", .ok = true, .detail = std.fmt.allocPrint(arena, "managed zig {s} ({s})", .{ resolved.version, resolved.source.label() }) catch "managed zig" };
+    }
+    return .{
         .name = "Zig toolchain",
-        .ok = false,
-        .hint = "`zig` is on PATH but failed to run. Reinstall Zig 0.15.2+.",
+        .ok = true,
+        .detail = std.fmt.allocPrint(arena, "managed zig {s} — will download + verify on first build", .{resolved.version}) catch "managed zig (not yet installed)",
     };
-    const ver = std.mem.trim(u8, res.stdout, " \r\n\t");
-    return .{ .name = "Zig toolchain", .ok = true, .detail = std.fmt.allocPrint(arena, "zig {s}", .{ver}) catch "zig (version unknown)" };
 }
 
 fn checkSdl2Lib(arena: std.mem.Allocator) Check {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assembler = @import("assembler.zig");
 const assembler_proc = @import("assembler_proc.zig");
+const zig_toolchain = @import("zig_toolchain.zig");
 
 /// Fetch and cache packages without modifying any project.
 ///
@@ -19,6 +20,18 @@ pub fn cmdInstall(allocator: std.mem.Allocator, cmd_args: []const []const u8) !v
             return error.MissingArgument;
         }
         return assembler.cmdInstallAssembler(allocator, cmd_args[1]);
+    }
+
+    // `labelle install zig <version>` — CLI bootstrap (cli#279). Download +
+    // verify + extract a managed Zig into `~/.labelle/zig/<version>/`.
+    if (cmd_args.len >= 1 and std.mem.eql(u8, cmd_args[0], "zig")) {
+        if (cmd_args.len < 2) {
+            std.debug.print("labelle install zig: missing version argument\n", .{});
+            std.debug.print("  usage: labelle install zig <version>\n", .{});
+            std.debug.print("  example: labelle install zig {s}\n", .{zig_toolchain.DEFAULT_ZIG_VERSION});
+            return error.MissingArgument;
+        }
+        return zig_toolchain.cmdInstallZig(allocator, cmd_args[1]);
     }
 
     // Every other form delegates to the assembler binary.

--- a/src/cli/ios.zig
+++ b/src/cli/ios.zig
@@ -347,9 +347,14 @@ fn iosBuild(allocator: std.mem.Allocator, target_dir: []const u8, device: bool, 
     const config_label: []const u8 = if (release) "Release" else "Debug";
     std.debug.print("labelle: building for {s} ({s})...\n", .{ target_label, config_label });
 
+    // Managed Zig (cli#279) — resolve against the generated target dir; it
+    // has no project.labelle, so this falls back to the CLI's default Zig.
+    const zig_exe = try runner.resolveZigExe(allocator, target_dir);
+    defer allocator.free(zig_exe);
+
     var argv_buf: [8][]const u8 = undefined;
     var argc: usize = 0;
-    argv_buf[argc] = "zig";
+    argv_buf[argc] = zig_exe;
     argc += 1;
     argv_buf[argc] = "build";
     argc += 1;

--- a/src/cli/launcher_manifest.zig
+++ b/src/cli/launcher_manifest.zig
@@ -9,7 +9,13 @@ const config = @import("config.zig");
 
 pub const LauncherManifest = struct {
     assembler_version: ?[]const u8 = null,
-    // Future: zig_version, etc.
+    /// Explicit managed-Zig pin (labelle-cli#279). When set, it is the
+    /// highest-precedence *version* source (below only the LABELLE_ZIG /
+    /// `--zig` path overrides). See `zig_toolchain.resolveRequiredVersion`.
+    zig_version: ?[]const u8 = null,
+    /// Pinned engine version — the CLI derives the required Zig from it when
+    /// no explicit `zig_version` is set (`zig_toolchain.zigVersionForEngine`).
+    engine_version: ?[]const u8 = null,
 };
 
 /// Read and parse project.labelle into a LauncherManifest.

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -1,7 +1,38 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const config = @import("config.zig");
+const zig_toolchain = @import("zig_toolchain.zig");
+const zig_cache = @import("zig_cache.zig");
 const is_windows = builtin.os.tag == .windows;
+
+/// Resolve the managed `zig` binary for `project_dir` (labelle-cli#279).
+/// This is the ONE place spawns get a `zig` path — never PATH. Downloads +
+/// verifies the required toolchain on a cache miss. Caller owns the slice.
+pub fn resolveZigExe(allocator: std.mem.Allocator, project_dir: []const u8) ![]u8 {
+    return zig_toolchain.resolveZig(allocator, project_dir);
+}
+
+/// Build an env map for a child `zig` that inherits the parent environment
+/// and adds `ZIG_GLOBAL_CACHE_DIR` / `ZIG_LOCAL_CACHE_DIR` pointing into the
+/// labelle cache tree, plus any `extras`. Keeps the compiler's own cache in
+/// user-writable space (never next to a read-only install). Caller owns the
+/// map and must `deinit()` it after the child is waited on.
+pub fn buildZigEnv(allocator: std.mem.Allocator, extras: []const EnvKV) !std.process.Environ.Map {
+    const global = try zig_cache.globalCacheDir(allocator);
+    defer allocator.free(global);
+    const local = try zig_cache.localCacheDir(allocator);
+    defer allocator.free(local);
+    // Ensure the dirs exist so zig doesn't choke on a missing cache root.
+    std.Io.Dir.cwd().createDirPath(config.globalIo(), global) catch {};
+    std.Io.Dir.cwd().createDirPath(config.globalIo(), local) catch {};
+
+    var all: std.ArrayList(EnvKV) = .empty;
+    defer all.deinit(allocator);
+    try all.append(allocator, .{ .key = "ZIG_GLOBAL_CACHE_DIR", .value = global });
+    try all.append(allocator, .{ .key = "ZIG_LOCAL_CACHE_DIR", .value = local });
+    try all.appendSlice(allocator, extras);
+    return buildEnvironWithExtra(allocator, all.items);
+}
 
 const windows = if (is_windows) struct {
     extern "kernel32" fn GetProcessId(Process: std.os.windows.HANDLE) callconv(.c) std.os.windows.DWORD;
@@ -33,6 +64,21 @@ pub fn runZig(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []con
     return std.process.run(allocator, config.globalIo(), .{
         .argv = argv,
         .cwd = .{ .path = cwd },
+    });
+}
+
+/// Like `runZig`, but with an optional environment map (used to inject
+/// `ZIG_*_CACHE_DIR` — see `buildZigEnv`). When null, inherits the parent env.
+pub fn runZigWithEnv(
+    allocator: std.mem.Allocator,
+    cwd: []const u8,
+    argv: []const []const u8,
+    environ_map: ?*const std.process.Environ.Map,
+) !std.process.RunResult {
+    return std.process.run(allocator, config.globalIo(), .{
+        .argv = argv,
+        .cwd = .{ .path = cwd },
+        .environ_map = environ_map,
     });
 }
 
@@ -237,7 +283,7 @@ fn timeoutKillWindows(allocator: std.mem.Allocator, pid: std.os.windows.DWORD, t
 /// dir per target (e.g. `raylib_desktop/`, plus `tests/` from 0.14.0),
 /// and each generated zon ships a placeholder fingerprint that needs
 /// replacing with the value Zig computes from the dir's actual path.
-pub fn fixFingerprints(allocator: std.mem.Allocator, output_dir: []const u8) !void {
+pub fn fixFingerprints(allocator: std.mem.Allocator, project_dir: []const u8, output_dir: []const u8) !void {
     const io = config.globalIo();
     var dir = std.Io.Dir.cwd().openDir(io, output_dir, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => return,
@@ -253,17 +299,19 @@ pub fn fixFingerprints(allocator: std.mem.Allocator, output_dir: []const u8) !vo
         const zon_path = try std.fs.path.join(allocator, &.{ sub_path, "build.zig.zon" });
         defer allocator.free(zon_path);
         std.Io.Dir.cwd().access(io, zon_path, .{}) catch continue;
-        try fixFingerprint(allocator, sub_path);
+        try fixFingerprint(allocator, project_dir, sub_path);
     }
 }
 
 /// Run `zig build` in output_dir, parse the fingerprint error, and patch build.zig.zon.
-pub fn fixFingerprint(allocator: std.mem.Allocator, output_dir: []const u8) !void {
+pub fn fixFingerprint(allocator: std.mem.Allocator, project_dir: []const u8, output_dir: []const u8) !void {
     const io = config.globalIo();
     const zon_path = try std.fs.path.join(allocator, &.{ output_dir, "build.zig.zon" });
     defer allocator.free(zon_path);
 
-    const result = try runZig(allocator, output_dir, &.{ "zig", "build" });
+    const zig_exe = try resolveZigExe(allocator, project_dir);
+    defer allocator.free(zig_exe);
+    const result = try runZig(allocator, output_dir, &.{ zig_exe, "build" });
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -311,7 +311,11 @@ pub fn fixFingerprint(allocator: std.mem.Allocator, project_dir: []const u8, out
 
     const zig_exe = try resolveZigExe(allocator, project_dir);
     defer allocator.free(zig_exe);
-    const result = try runZig(allocator, output_dir, &.{ zig_exe, "build" });
+    // Give the fingerprint build the same ZIG_*_CACHE_DIR wiring as every
+    // other managed spawn, so its compiler cache lands in user-writable space.
+    var zig_env = try buildZigEnv(allocator, &.{});
+    defer zig_env.deinit();
+    const result = try runZigWithEnv(allocator, output_dir, &.{ zig_exe, "build" }, &zig_env);
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 

--- a/src/cli/test.zig
+++ b/src/cli/test.zig
@@ -275,7 +275,9 @@ fn isIdentifierBoundary(c: u8) bool {
 /// the spawn/wait dance to `runner.runZigInherit` so all CLI-driven
 /// zig invocations share one process-management code path.
 fn runZigTest(allocator: std.mem.Allocator, cwd: []const u8, rel_path: []const u8) !bool {
-    const code = try runner.runZigInherit(allocator, cwd, &.{ "zig", "test", rel_path }, null);
+    const zig_exe = try runner.resolveZigExe(allocator, cwd);
+    defer allocator.free(zig_exe);
+    const code = try runner.runZigInherit(allocator, cwd, &.{ zig_exe, "test", rel_path }, null);
     return code == 0;
 }
 
@@ -292,7 +294,9 @@ fn hasBuildZig(dir: *std.Io.Dir) bool {
 fn runZigBuildTest(allocator: std.mem.Allocator, project_dir: []const u8, rel_path: []const u8) !bool {
     const sub_cwd = try std.fs.path.join(allocator, &.{ project_dir, rel_path });
     defer allocator.free(sub_cwd);
-    const code = try runner.runZigInherit(allocator, sub_cwd, &.{ "zig", "build", "test" }, null);
+    const zig_exe = try runner.resolveZigExe(allocator, project_dir);
+    defer allocator.free(zig_exe);
+    const code = try runner.runZigInherit(allocator, sub_cwd, &.{ zig_exe, "build", "test" }, null);
     return code == 0;
 }
 

--- a/src/cli/zig_cache.zig
+++ b/src/cli/zig_cache.zig
@@ -1,0 +1,159 @@
+//! Zig-toolchain cache-path resolution — the sibling of `asm_cache.zig`.
+//!
+//! Part of labelle-studio#25 (SUB1, labelle-cli#279): the CLI owns the Zig
+//! toolchain the same way it owns `labelle-assembler`. This module owns the
+//! *paths* under the shared `~/.labelle/` tree; the download/verify/extract
+//! flow lives in `zig_toolchain.zig` (mirroring the assembler split, where
+//! `asm_cache.zig` owns paths and `assembler.zig` owns the flow).
+//!
+//! Cache layout (the SUB2 / #280 seed contract):
+//!
+//!   <cache-root>/<ZIG_SUBDIR>/<version>/zig[.exe]   ← the managed binary
+//!   <cache-root>/<ZIG_SUBDIR>/<version>/lib/...      ← Zig's std/ tree
+//!   <cache-root>/<ZIG_SUBDIR>/<version>/doc/, ...    ← the rest of the release
+//!
+//! The version directory holds the *flattened* release: `zig`, `lib/`, `doc/`
+//! sit directly under `<version>/`, NOT under a nested `zig-<arch>-<os>-<ver>/`
+//! dir. `zig_toolchain.extractArchive` strips the leading component to produce
+//! this; a #280 seed archive MUST extract to the identical flat layout so a
+//! seeded and a downloaded toolchain are byte-for-byte indistinguishable.
+//!
+//! Windows MAX_PATH: Zig's `lib/std/...` tree plus the compiler's own nested
+//! build cache can blow past 260 chars. We keep the subdir SHORT on Windows
+//! (`tc` instead of `zig`) so the version root is as shallow as possible. For
+//! very deep user profiles, `LABELLE_HOME=C:\labelle` (honored by
+//! `asm_cache.getCacheRoot`) moves the whole tree to a short root.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const asm_cache = @import("asm_cache.zig");
+
+const is_windows = builtin.os.tag == .windows;
+
+/// Subdirectory of the cache root that holds managed Zig toolchains.
+///
+/// SHORT on Windows (`tc`) to dodge MAX_PATH — a deeply-nested `lib/std/...`
+/// path under `zig\<full-version>\` can exceed 260 chars once the compiler
+/// adds its own `.zig-cache/` nesting on top. Unix has no such limit, so it
+/// keeps the readable `zig` name.
+pub const ZIG_SUBDIR = if (is_windows) "tc" else "zig";
+
+/// Global-compiler-cache subdir under the cache root. Passed to child `zig`
+/// processes as `ZIG_GLOBAL_CACHE_DIR` so the compiler cache lands in
+/// user-writable space, never next to a read-only install (epic gotcha).
+pub const GLOBAL_CACHE_SUBDIR = "zig-global-cache";
+
+/// Local-compiler-cache subdir under the cache root. Passed as
+/// `ZIG_LOCAL_CACHE_DIR`. Kept under the labelle tree (rather than the
+/// project's `.zig-cache/`) so studio-launched builds against a read-only
+/// bundle still have somewhere writable.
+pub const LOCAL_CACHE_SUBDIR = "zig-local-cache";
+
+const exe_suffix = if (is_windows) ".exe" else "";
+
+/// The managed `zig` binary name for the host (`zig` / `zig.exe`).
+pub const zig_exe_name = "zig" ++ exe_suffix;
+
+/// Re-export the shared cache root so callers and tests resolve Zig paths
+/// against the SAME `~/.labelle/` tree the assembler and package cache use.
+/// Tests pin it with `asm_cache.setCacheRootOverride`. Caller owns the slice.
+pub fn getCacheRoot(allocator: std.mem.Allocator) ![]const u8 {
+    return asm_cache.getCacheRoot(allocator);
+}
+
+/// `<cache-root>/<ZIG_SUBDIR>` — the directory that holds one subdir per
+/// installed Zig version. Caller owns the returned slice.
+pub fn zigRoot(allocator: std.mem.Allocator) ![]u8 {
+    const root = try getCacheRoot(allocator);
+    defer allocator.free(root);
+    return std.fs.path.join(allocator, &.{ root, ZIG_SUBDIR });
+}
+
+/// `<cache-root>/<ZIG_SUBDIR>/<version>` — the flat install dir for `version`.
+/// Caller owns the returned slice.
+pub fn versionDir(allocator: std.mem.Allocator, version: []const u8) ![]u8 {
+    const root = try getCacheRoot(allocator);
+    defer allocator.free(root);
+    return std.fs.path.join(allocator, &.{ root, ZIG_SUBDIR, version });
+}
+
+/// `<version-dir>/zig[.exe]` — the managed binary a spawn points at.
+/// Caller owns the returned slice.
+pub fn binaryPath(allocator: std.mem.Allocator, version: []const u8) ![]u8 {
+    const root = try getCacheRoot(allocator);
+    defer allocator.free(root);
+    return std.fs.path.join(allocator, &.{ root, ZIG_SUBDIR, version, zig_exe_name });
+}
+
+/// `<cache-root>/zig-global-cache`. Caller owns the returned slice.
+pub fn globalCacheDir(allocator: std.mem.Allocator) ![]u8 {
+    const root = try getCacheRoot(allocator);
+    defer allocator.free(root);
+    return std.fs.path.join(allocator, &.{ root, GLOBAL_CACHE_SUBDIR });
+}
+
+/// `<cache-root>/zig-local-cache`. Caller owns the returned slice.
+pub fn localCacheDir(allocator: std.mem.Allocator) ![]u8 {
+    const root = try getCacheRoot(allocator);
+    defer allocator.free(root);
+    return std.fs.path.join(allocator, &.{ root, LOCAL_CACHE_SUBDIR });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "binaryPath places zig under <root>/<subdir>/<version>/" {
+    const alloc = testing.allocator;
+    asm_cache.setCacheRootOverride("/tmp/labelle-test-home");
+    defer asm_cache.clearCacheRootOverride();
+
+    const path = try binaryPath(alloc, "0.16.0");
+    defer alloc.free(path);
+
+    const expected = try std.fs.path.join(alloc, &.{
+        "/tmp/labelle-test-home", ZIG_SUBDIR, "0.16.0", zig_exe_name,
+    });
+    defer alloc.free(expected);
+    try testing.expectEqualStrings(expected, path);
+}
+
+test "Windows uses the short 'tc' subdir; Unix uses 'zig'" {
+    if (is_windows) {
+        try testing.expectEqualStrings("tc", ZIG_SUBDIR);
+    } else {
+        try testing.expectEqualStrings("zig", ZIG_SUBDIR);
+    }
+}
+
+test "versionDir is the flat install root (no nested release dir)" {
+    const alloc = testing.allocator;
+    asm_cache.setCacheRootOverride("/x");
+    defer asm_cache.clearCacheRootOverride();
+
+    const dir = try versionDir(alloc, "0.16.0");
+    defer alloc.free(dir);
+    const bin = try binaryPath(alloc, "0.16.0");
+    defer alloc.free(bin);
+
+    // binaryPath must be exactly `<versionDir>/zig[.exe]` — the contract the
+    // #280 seed relies on (binary sits directly in the version dir).
+    const expected_bin = try std.fs.path.join(alloc, &.{ dir, zig_exe_name });
+    defer alloc.free(expected_bin);
+    try testing.expectEqualStrings(expected_bin, bin);
+}
+
+test "compiler cache dirs live under the cache root, not the project" {
+    const alloc = testing.allocator;
+    asm_cache.setCacheRootOverride("/home/u/.labelle");
+    defer asm_cache.clearCacheRootOverride();
+
+    const g = try globalCacheDir(alloc);
+    defer alloc.free(g);
+    const l = try localCacheDir(alloc);
+    defer alloc.free(l);
+
+    try testing.expect(std.mem.startsWith(u8, g, "/home/u/.labelle"));
+    try testing.expect(std.mem.endsWith(u8, g, GLOBAL_CACHE_SUBDIR));
+    try testing.expect(std.mem.endsWith(u8, l, LOCAL_CACHE_SUBDIR));
+}

--- a/src/cli/zig_toolchain.zig
+++ b/src/cli/zig_toolchain.zig
@@ -273,10 +273,33 @@ pub fn ensureInstalled(allocator: std.mem.Allocator, version: []const u8) !void 
 
     const bin_path = try zig_cache.binaryPath(allocator, version);
     defer allocator.free(bin_path);
+    // Fast path: already installed, no lock contention.
     if (cwd.access(io, bin_path, .{})) |_| return else |_| {}
 
     const dest_dir = try zig_cache.versionDir(allocator, version);
     defer allocator.free(dest_dir);
+
+    // Serialize installs of the SAME version across processes with a
+    // per-version advisory lock. Without it, two concurrent `labelle`
+    // processes could each stage + publish, and the loser's
+    // `deleteTree(dest_dir)` would nuke the winner's already-published
+    // toolchain out from under a running build. The lock releases when the
+    // holding process exits (even on crash). See labelle-cli#279 review.
+    const zroot = try zig_cache.zigRoot(allocator);
+    defer allocator.free(zroot);
+    cwd.createDirPath(io, zroot) catch {};
+    const lock_path = try std.fmt.allocPrint(allocator, "{s}{c}{s}.lock", .{ zroot, std.fs.path.sep, version });
+    defer allocator.free(lock_path);
+    const lock_file = cwd.createFile(io, lock_path, .{ .truncate = false, .lock = .exclusive }) catch |err| {
+        std.debug.print("labelle: could not acquire install lock {s}: {any}\n", .{ lock_path, err });
+        return error.ZigInstallLockFailed;
+    };
+    defer lock_file.close(io); // releases the advisory lock
+
+    // Double-checked: another process may have finished installing while we
+    // were blocked on the lock. If so, we're done — never re-download or
+    // touch the published dir.
+    if (cwd.access(io, bin_path, .{})) |_| return else |_| {}
 
     // Stage everything under a temp sibling of the version dir. The suffix
     // only needs to avoid collisions with a concurrent/stale staging dir, not
@@ -336,7 +359,11 @@ pub fn ensureInstalled(allocator: std.mem.Allocator, version: []const u8) !void 
         } else |_| {}
     }
 
-    // Publish atomically. Remove any stale/partial dest first.
+    // Publish atomically. We hold the install lock and re-checked above that
+    // `bin_path` is absent, so any `dest_dir` here is an INCOMPLETE leftover
+    // from a crashed prior install (no working `zig` inside it → no build can
+    // be using it). Removing it is safe; a fully-published toolchain is never
+    // reached here because the lock + double-check returned early.
     cwd.deleteTree(io, dest_dir) catch {};
     if (std.fs.path.dirname(dest_dir)) |parent| cwd.createDirPath(io, parent) catch {};
     try cwd.rename(staging, cwd, dest_dir, io);
@@ -348,7 +375,12 @@ pub fn ensureInstalled(allocator: std.mem.Allocator, version: []const u8) !void 
 /// cleanup on failure). Fails with `error.ZigDownloadFailed`.
 fn curlDownload(allocator: std.mem.Allocator, url: []const u8, dest: []const u8) !void {
     const io = config.globalIo();
-    const result = util.runCmd(allocator, &.{ "curl", "-fSL", "-o", dest, url }) catch {
+    // `--connect-timeout` bounds the TCP handshake; `--max-time` bounds the
+    // whole transfer so a stalled mirror can't hang `labelle build` forever.
+    // 600s is a generous ceiling for the ~50MB archive on a slow link (cli#279 review).
+    const result = util.runCmd(allocator, &.{
+        "curl", "-fSL", "--connect-timeout", "30", "--max-time", "600", "-o", dest, url,
+    }) catch {
         std.debug.print("labelle: download failed (is curl installed?)\n  url: {s}\n", .{url});
         return error.ZigDownloadFailed;
     };
@@ -504,9 +536,16 @@ fn extractZipWindows(allocator: std.mem.Allocator, archive_path: []const u8, des
     defer allocator.free(scratch);
     cwd.createDirPath(io, scratch) catch {};
 
+    // Escape embedded single quotes (`'` → `''`) so a path like
+    // `C:\Users\O'Neil\...` (or a LABELLE_HOME with a quote) can't break out
+    // of the single-quoted PowerShell string arg (cli#279 review).
+    const archive_q = try util.escapePowerShellString(allocator, archive_path);
+    defer allocator.free(archive_q);
+    const scratch_q = try util.escapePowerShellString(allocator, scratch);
+    defer allocator.free(scratch_q);
     const ps = try std.fmt.allocPrint(allocator,
         \\Expand-Archive -LiteralPath '{s}' -DestinationPath '{s}' -Force
-    , .{ archive_path, scratch });
+    , .{ archive_q, scratch_q });
     defer allocator.free(ps);
     const result = util.runCmd(allocator, &.{ "powershell", "-NoProfile", "-Command", ps }) catch {
         return error.ZigExtractFailed;
@@ -518,22 +557,33 @@ fn extractZipWindows(allocator: std.mem.Allocator, archive_path: []const u8, des
         else => return error.ZigExtractFailed,
     }
 
-    // Move the single `zig-*/` child's contents up into dest_dir.
-    var sd = try cwd.openDir(io, scratch, .{ .iterate = true });
-    defer sd.close(io);
-    var it = sd.iterate();
-    const top = (try it.next(io)) orelse return error.ZigArchiveLayoutUnexpected;
-    const inner = try std.fs.path.join(allocator, &.{ scratch, top.name });
+    // Find the single `zig-*/` release dir by kind+prefix (not by assuming the
+    // first iterated entry — a stray desktop.ini/Thumbs.db would mis-select).
+    // Scope the dir handles so they close BEFORE deleteTree(scratch) below;
+    // an open iterate handle on Windows would block the tree removal.
+    const inner = blk: {
+        var sd = try cwd.openDir(io, scratch, .{ .iterate = true });
+        defer sd.close(io);
+        var it = sd.iterate();
+        while (try it.next(io)) |e| {
+            if (e.kind == .directory and std.mem.startsWith(u8, e.name, "zig-"))
+                break :blk try std.fs.path.join(allocator, &.{ scratch, e.name });
+        }
+        return error.ZigArchiveLayoutUnexpected;
+    };
     defer allocator.free(inner);
-    var id = try cwd.openDir(io, inner, .{ .iterate = true });
-    defer id.close(io);
-    var iit = id.iterate();
-    while (try iit.next(io)) |entry| {
-        const from = try std.fs.path.join(allocator, &.{ inner, entry.name });
-        defer allocator.free(from);
-        const to = try std.fs.path.join(allocator, &.{ dest_dir, entry.name });
-        defer allocator.free(to);
-        try cwd.rename(from, cwd, to, io);
+
+    {
+        var id = try cwd.openDir(io, inner, .{ .iterate = true });
+        defer id.close(io);
+        var iit = id.iterate();
+        while (try iit.next(io)) |entry| {
+            const from = try std.fs.path.join(allocator, &.{ inner, entry.name });
+            defer allocator.free(from);
+            const to = try std.fs.path.join(allocator, &.{ dest_dir, entry.name });
+            defer allocator.free(to);
+            try cwd.rename(from, cwd, to, io);
+        }
     }
     cwd.deleteTree(io, scratch) catch {};
 }

--- a/src/cli/zig_toolchain.zig
+++ b/src/cli/zig_toolchain.zig
@@ -1,0 +1,818 @@
+//! Managed Zig-toolchain resolver — the sibling of `assembler.zig`.
+//!
+//! Part of labelle-studio#25 (SUB1, labelle-cli#279). The CLI owns the Zig
+//! toolchain the way it already owns `labelle-assembler`: read the required
+//! version from the project, resolve it to a per-version cache under
+//! `~/.labelle/`, download + **verify** + extract it if absent, and point
+//! every `zig` spawn at the managed binary instead of PATH.
+//!
+//! This mirrors `assembler.zig` (`resolveAssembler`/`downloadAssembler`) with
+//! `zig_cache.zig` playing the `asm_cache.zig` role. The one thing this
+//! resolver adds that the assembler path lacks is **signature verification**:
+//! downloads are checked against Zig's published minisign signature with the
+//! well-known public key, in pure Zig (Ed25519 + Blake2b-512), before a
+//! toolchain is considered installed. Verification is mandatory — a bad
+//! signature deletes the download and fails closed.
+//!
+//! ## Version-resolution precedence (see `resolveRequiredVersion`)
+//!
+//!   1. `LABELLE_ZIG` env var — absolute path to a `zig`. Total override:
+//!      skips version resolution *and* the cache entirely (folds in the
+//!      superseded cli#203 option 1). Handled in `resolveZig`.
+//!   2. `--zig <path>` flag — same, via `setFlagOverride` (cli#203 option 2).
+//!      `LABELLE_ZIG` wins over the flag, matching the assembler env-override.
+//!   3. `zig_version` pin in `project.labelle` (`launcher_manifest`).
+//!   4. Engine-derived: map the pinned engine version (`project.labelle`
+//!      `engine_version`, else `labelle.lock`) to its required Zig via
+//!      `zigVersionForEngine`. Today the whole toolkit rides ONE Zig train
+//!      (0.16.x), so the map returns `DEFAULT_ZIG_VERSION` for the current
+//!      engine major — but the *source* is attributed to the engine so
+//!      `toolchain which` reports it honestly, and the map is the seam where
+//!      future engine-train divergence lands. NOTE: there is no first-class
+//!      engine→Zig table in the toolkit yet (the engine's
+//!      `minimum_zig_version` is not surfaced to the CLI at runtime); this
+//!      map is the most-defensible stand-in. See PR notes.
+//!   5. `DEFAULT_ZIG_VERSION` constant — kept in lockstep with the CLI's own
+//!      build Zig and the SUB2/#280 bundled seed.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const zig_cache = @import("zig_cache.zig");
+const config = @import("config.zig");
+const launcher_manifest = @import("launcher_manifest.zig");
+const util = @import("util.zig");
+
+const is_windows = builtin.os.tag == .windows;
+
+/// Default Zig version resolved/downloaded when a project pins none and no
+/// engine mapping applies. Keep in lockstep with the CLI's own build Zig
+/// (the toolkit rides one Zig train) and with the SUB2/#280 bundled seed.
+pub const DEFAULT_ZIG_VERSION = "0.16.0";
+
+/// Zig's published minisign public key (from ziglang.org/download). Pinned so
+/// verification does not trust anything fetched at runtime. Base64 of
+/// `signature_algorithm[2] || key_id[8] || ed25519_public_key[32]` (42 bytes).
+pub const MINISIGN_PUBLIC_KEY = "RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U";
+
+/// Official Zig release download root. NOT GitHub — Zig hosts releases on
+/// ziglang.org (with community mirrors). The `.minisig` sits next to the
+/// tarball at `<url>.minisig`.
+pub const ZIG_DOWNLOAD_BASE = "https://ziglang.org/download";
+
+/// Where the requested version came from — reported by `toolchain which`.
+pub const VersionSource = enum {
+    env_override, // LABELLE_ZIG (a path, not a version)
+    flag_override, // --zig <path>
+    project_pin, // zig_version in project.labelle
+    engine_derived, // mapped from the pinned engine version
+    default, // DEFAULT_ZIG_VERSION fallback
+
+    pub fn label(self: VersionSource) []const u8 {
+        return switch (self) {
+            .env_override => "LABELLE_ZIG env override",
+            .flag_override => "--zig flag override",
+            .project_pin => "zig_version in project.labelle",
+            .engine_derived => "derived from pinned engine version",
+            .default => "CLI default",
+        };
+    }
+};
+
+pub const ResolvedVersion = struct {
+    /// Heap-owned version string (e.g. "0.16.0"). Caller frees.
+    version: []u8,
+    source: VersionSource,
+};
+
+// ── Escape hatches (cli#203 options 1–2) ──────────────────────────────
+
+/// `--zig <path>` override, set by the arg parser. Borrowed slice owned by
+/// the caller (the argv lives for the whole process). `LABELLE_ZIG` wins.
+var _flag_override: ?[]const u8 = null;
+
+/// Record the `--zig <path>` flag. `path` must outlive all `resolveZig`
+/// calls (argv-lifetime is fine). Pass null to clear (tests).
+pub fn setFlagOverride(path: ?[]const u8) void {
+    _flag_override = path;
+}
+
+/// Look up the `LABELLE_ZIG` path override. Heap-owned on success (caller
+/// frees), null when unset. Mirrors `assembler.lookupOverride`.
+pub fn lookupEnvOverride(allocator: std.mem.Allocator) !?[]u8 {
+    return config.globalEnviron().getAlloc(allocator, "LABELLE_ZIG") catch |err| switch (err) {
+        error.EnvironmentVariableMissing => null,
+        else => return err,
+    };
+}
+
+// ── Host triple ────────────────────────────────────────────────────────
+
+/// Zig's os name in the release triple. Zig switched the archive naming from
+/// `zig-<os>-<arch>-<ver>` (≤0.14.0) to `zig-<arch>-<os>-<ver>` (0.14.1+); the
+/// toolkit rides 0.16.x, so we build the modern arch-first form.
+fn osName() error{UnsupportedPlatform}![]const u8 {
+    return switch (builtin.os.tag) {
+        .macos => "macos",
+        .linux => "linux",
+        .windows => "windows",
+        else => {
+            std.debug.print("labelle: unsupported OS for Zig download: {s}\n", .{@tagName(builtin.os.tag)});
+            return error.UnsupportedPlatform;
+        },
+    };
+}
+
+fn archName() error{UnsupportedPlatform}![]const u8 {
+    return switch (builtin.cpu.arch) {
+        .aarch64 => "aarch64",
+        .x86_64 => "x86_64",
+        else => {
+            std.debug.print("labelle: unsupported architecture for Zig download: {s}\n", .{@tagName(builtin.cpu.arch)});
+            return error.UnsupportedPlatform;
+        },
+    };
+}
+
+/// Archive extension for the host: `.zip` on Windows, `.tar.xz` elsewhere.
+const archive_ext = if (is_windows) "zip" else "tar.xz";
+
+/// Build the release archive URL for `version`, e.g.
+/// `https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz`.
+/// Caller owns the returned slice.
+pub fn archiveUrl(allocator: std.mem.Allocator, version: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}/zig-{s}-{s}-{s}.{s}", .{
+        ZIG_DOWNLOAD_BASE, version, try archName(), try osName(), version, archive_ext,
+    });
+}
+
+// ── Version resolution ───────────────────────────────────────────────
+
+/// Map a pinned engine version to its required Zig version. The toolkit
+/// currently ships every package (engine included) on a single Zig train, so
+/// any engine on the 1.x major maps to `DEFAULT_ZIG_VERSION`. Returns null for
+/// an unrecognized engine so the caller falls through to the default.
+///
+/// This is the seam where future divergence lands: when an engine 2.x train
+/// requires a different Zig, add an arm here. Kept intentionally small rather
+/// than fabricating a speculative table.
+pub fn zigVersionForEngine(engine_version: []const u8) ?[]const u8 {
+    const major = util.parseVersion(engine_version) / 1_000_000;
+    return switch (major) {
+        1 => DEFAULT_ZIG_VERSION,
+        else => null,
+    };
+}
+
+/// Resolve the Zig VERSION the project requires and where it came from.
+/// Does not consult the path overrides (those short-circuit in `resolveZig`);
+/// this is the version-only chain: project pin → engine-derived → default.
+/// Caller owns `result.version`.
+pub fn resolveRequiredVersion(allocator: std.mem.Allocator, project_dir: []const u8) !ResolvedVersion {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const manifest = try launcher_manifest.readLauncherManifest(a, project_dir);
+
+    // 3. Explicit zig_version pin.
+    if (manifest) |m| {
+        if (m.zig_version) |v| {
+            if (v.len > 0) return .{ .version = try allocator.dupe(u8, v), .source = .project_pin };
+        }
+    }
+
+    // 4. Engine-derived. Prefer project.labelle's engine_version, else the
+    //    resolved engine in labelle.lock.
+    const engine_version: ?[]const u8 = blk: {
+        if (manifest) |m| if (m.engine_version) |ev| if (ev.len > 0) break :blk ev;
+        break :blk readLockEngineVersion(a, project_dir);
+    };
+    if (engine_version) |ev| {
+        if (zigVersionForEngine(ev)) |zv| {
+            return .{ .version = try allocator.dupe(u8, zv), .source = .engine_derived };
+        }
+    }
+
+    // 5. Default.
+    return .{ .version = try allocator.dupe(u8, DEFAULT_ZIG_VERSION), .source = .default };
+}
+
+/// Minimal `labelle.lock` shape: only `.resolved.engine.version`. Returns an
+/// arena-owned slice (borrowed from `allocator`), or null if absent/unparsable.
+fn readLockEngineVersion(allocator: std.mem.Allocator, project_dir: []const u8) ?[]const u8 {
+    @setEvalBranchQuota(10000);
+    const lock_path = std.fs.path.join(allocator, &.{ project_dir, "labelle.lock" }) catch return null;
+    const raw = std.Io.Dir.cwd().readFileAlloc(config.globalIo(), lock_path, allocator, .limited(1024 * 1024)) catch return null;
+    const raw_z = allocator.dupeZ(u8, raw) catch return null;
+
+    const LockShape = struct {
+        resolved: ?struct {
+            engine: ?struct { version: []const u8 = "" } = null,
+        } = null,
+    };
+    const parsed = std.zon.parse.fromSliceAlloc(LockShape, allocator, raw_z, null, .{
+        .ignore_unknown_fields = true,
+    }) catch return null;
+    const resolved = parsed.resolved orelse return null;
+    const engine = resolved.engine orelse return null;
+    if (engine.version.len == 0) return null;
+    return engine.version;
+}
+
+// ── Resolve to a managed binary path ───────────────────────────────────
+
+/// Resolve the `zig` binary every spawn should use, downloading + verifying +
+/// extracting the required version on a cache miss. Precedence:
+///   1. `LABELLE_ZIG` env path (wins over everything).
+///   2. `--zig <path>` flag.
+///   3. managed cache for `resolveRequiredVersion(project_dir)`.
+/// Caller owns the returned slice.
+pub fn resolveZig(allocator: std.mem.Allocator, project_dir: []const u8) ![]u8 {
+    if (try lookupEnvOverride(allocator)) |path| return path;
+    if (_flag_override) |path| return allocator.dupe(u8, path);
+
+    const resolved = try resolveRequiredVersion(allocator, project_dir);
+    defer allocator.free(resolved.version);
+
+    const bin_path = try zig_cache.binaryPath(allocator, resolved.version);
+    errdefer allocator.free(bin_path);
+
+    std.Io.Dir.cwd().access(config.globalIo(), bin_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            ensureInstalled(allocator, resolved.version) catch |dl_err| {
+                std.debug.print(
+                    \\
+                    \\labelle: could not provision Zig {s}.
+                    \\  A working Zig toolchain is required to build. Options:
+                    \\    - set LABELLE_ZIG=/path/to/zig (or pass --zig /path/to/zig)
+                    \\    - run: labelle install zig {s}
+                    \\    - pin a different zig_version in project.labelle
+                    \\
+                , .{ resolved.version, resolved.version });
+                allocator.free(bin_path);
+                return dl_err;
+            };
+        },
+        else => {
+            allocator.free(bin_path);
+            return err;
+        },
+    };
+    return bin_path;
+}
+
+// ── Install (download + verify + extract, atomic) ──────────────────────
+
+/// Ensure Zig `version` is installed in the managed cache. No-op if already
+/// present. On a miss: download the archive + `.minisig`, verify the
+/// signature, extract into a temp dir, then atomically rename into place so a
+/// half-extracted toolchain is never observed as installed.
+pub fn ensureInstalled(allocator: std.mem.Allocator, version: []const u8) !void {
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+
+    const bin_path = try zig_cache.binaryPath(allocator, version);
+    defer allocator.free(bin_path);
+    if (cwd.access(io, bin_path, .{})) |_| return else |_| {}
+
+    const dest_dir = try zig_cache.versionDir(allocator, version);
+    defer allocator.free(dest_dir);
+
+    // Stage everything under a temp sibling of the version dir. The suffix
+    // only needs to avoid collisions with a concurrent/stale staging dir, not
+    // be cryptographic — 0.16 has no std.crypto.random, so seed a PRNG from a
+    // stack address mixed with the dest path.
+    var prng = std.Random.DefaultPrng.init(@intFromPtr(&dest_dir) ^ std.hash.Wyhash.hash(0, dest_dir));
+    const staging = try std.fmt.allocPrint(allocator, "{s}.tmp-{d}", .{ dest_dir, prng.random().int(u32) });
+    defer allocator.free(staging);
+    cwd.deleteTree(io, staging) catch {};
+    try cwd.createDirPath(io, staging);
+    defer cwd.deleteTree(io, staging) catch {};
+
+    const url = try archiveUrl(allocator, version);
+    defer allocator.free(url);
+    const archive_name = try std.fmt.allocPrint(allocator, "zig-{s}.{s}", .{ version, archive_ext });
+    defer allocator.free(archive_name);
+    const archive_path = try std.fs.path.join(allocator, &.{ staging, archive_name });
+    defer allocator.free(archive_path);
+    const sig_path = try std.fmt.allocPrint(allocator, "{s}.minisig", .{archive_path});
+    defer allocator.free(sig_path);
+    const sig_url = try std.fmt.allocPrint(allocator, "{s}.minisig", .{url});
+    defer allocator.free(sig_url);
+
+    std.debug.print("labelle: downloading Zig {s}...\n", .{version});
+    std.debug.print("  url: {s}\n", .{url});
+    try curlDownload(allocator, url, archive_path);
+    try curlDownload(allocator, sig_url, sig_path);
+
+    std.debug.print("  verifying signature...\n", .{});
+    verifyArchive(allocator, archive_path, sig_path) catch |err| {
+        std.debug.print("labelle: Zig {s} signature verification FAILED — refusing to install\n", .{version});
+        return err;
+    };
+    std.debug.print("  signature ok\n", .{});
+
+    std.debug.print("  extracting...\n", .{});
+    try extractArchive(allocator, archive_path, staging);
+
+    // The archive unpacks a single `zig-<arch>-<os>-<ver>/` dir. Promote its
+    // contents so the version dir is flat (the #280 seed contract). We extract
+    // with strip-of-leading-component below, so `staging` already holds `zig`,
+    // `lib/`, etc. directly — drop the downloaded archive + sig first.
+    cwd.deleteFile(io, archive_path) catch {};
+    cwd.deleteFile(io, sig_path) catch {};
+
+    // Sanity: the binary must exist in staging before we publish.
+    const staged_bin = try std.fs.path.join(allocator, &.{ staging, zig_cache.zig_exe_name });
+    defer allocator.free(staged_bin);
+    cwd.access(io, staged_bin, .{}) catch {
+        std.debug.print("labelle: extracted archive has no '{s}' at its root\n", .{zig_cache.zig_exe_name});
+        return error.ZigArchiveLayoutUnexpected;
+    };
+    if (!is_windows) {
+        if (cwd.openFile(io, staged_bin, .{})) |file| {
+            defer file.close(io);
+            file.setPermissions(io, .fromMode(0o755)) catch {};
+        } else |_| {}
+    }
+
+    // Publish atomically. Remove any stale/partial dest first.
+    cwd.deleteTree(io, dest_dir) catch {};
+    if (std.fs.path.dirname(dest_dir)) |parent| cwd.createDirPath(io, parent) catch {};
+    try cwd.rename(staging, cwd, dest_dir, io);
+
+    std.debug.print("  installed at {s}\n", .{dest_dir});
+}
+
+/// `curl -fSL -o dest url`, mirroring `assembler.downloadAssembler` (partial
+/// cleanup on failure). Fails with `error.ZigDownloadFailed`.
+fn curlDownload(allocator: std.mem.Allocator, url: []const u8, dest: []const u8) !void {
+    const io = config.globalIo();
+    const result = util.runCmd(allocator, &.{ "curl", "-fSL", "-o", dest, url }) catch {
+        std.debug.print("labelle: download failed (is curl installed?)\n  url: {s}\n", .{url});
+        return error.ZigDownloadFailed;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            std.debug.print("labelle: download failed (HTTP error, exit {d})\n  url: {s}\n", .{ code, url });
+            std.Io.Dir.cwd().deleteFile(io, dest) catch {};
+            return error.ZigDownloadFailed;
+        },
+        else => {
+            std.debug.print("labelle: download process terminated abnormally\n  url: {s}\n", .{url});
+            std.Io.Dir.cwd().deleteFile(io, dest) catch {};
+            return error.ZigDownloadFailed;
+        },
+    }
+}
+
+/// Read the archive + its `.minisig` and verify against `MINISIGN_PUBLIC_KEY`.
+fn verifyArchive(allocator: std.mem.Allocator, archive_path: []const u8, sig_path: []const u8) !void {
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+    const archive = try cwd.readFileAlloc(io, archive_path, allocator, .limited(512 * 1024 * 1024));
+    defer allocator.free(archive);
+    const sig_text = try cwd.readFileAlloc(io, sig_path, allocator, .limited(64 * 1024));
+    defer allocator.free(sig_text);
+    try verifyMinisign(MINISIGN_PUBLIC_KEY, archive, sig_text);
+}
+
+// ── Minisign verification (pure Zig: Ed25519 + Blake2b-512) ────────────
+
+pub const MinisignError = error{
+    MinisignMalformedPublicKey,
+    MinisignMalformedSignature,
+    MinisignKeyIdMismatch,
+    MinisignUnsupportedAlgorithm,
+    ZigSignatureInvalid,
+};
+
+/// Verify `file_data` against a minisign signature `sig_text`, using the
+/// base64 minisign public key `pub_key_b64`.
+///
+/// Minisign layout:
+///   - public key b64 → algo[2] "Ed" || key_id[8] || ed25519_pub[32]  (42 B)
+///   - .minisig line 2 b64 → algo[2] || key_id[8] || ed25519_sig[64]  (74 B)
+///       algo "ED" = prehashed: the signed message is Blake2b-512(file).
+///       algo "Ed" = legacy: the signed message is the file bytes.
+///   - .minisig line 4 b64 → global sig[64] over (sig[64] || trusted_comment)
+/// Zig signs with the prehashed "ED" variant. We verify BOTH the file
+/// signature and the trusted-comment global signature (the latter binds the
+/// human-readable comment to the key). Fails closed on any mismatch.
+pub fn verifyMinisign(pub_key_b64: []const u8, file_data: []const u8, sig_text: []const u8) !void {
+    const b64 = std.base64.standard.Decoder;
+
+    // Decode public key (42 bytes).
+    var pk_buf: [42]u8 = undefined;
+    {
+        const n = b64.calcSizeForSlice(pub_key_b64) catch return MinisignError.MinisignMalformedPublicKey;
+        if (n != pk_buf.len) return MinisignError.MinisignMalformedPublicKey;
+        b64.decode(&pk_buf, pub_key_b64) catch return MinisignError.MinisignMalformedPublicKey;
+    }
+    const pk_key_id = pk_buf[2..10];
+    const ed_pub_bytes: [32]u8 = pk_buf[10..42].*;
+
+    // Parse the signature file lines. Line 2 = signature, line 4 = global sig,
+    // line 3 = trusted comment (prefix "trusted comment: ").
+    var lines = std.mem.splitScalar(u8, sig_text, '\n');
+    _ = lines.next(); // line 1: untrusted comment
+    const sig_line = std.mem.trim(u8, lines.next() orelse return MinisignError.MinisignMalformedSignature, " \t\r");
+    const tc_line = std.mem.trim(u8, lines.next() orelse return MinisignError.MinisignMalformedSignature, " \t\r");
+    const gsig_line = std.mem.trim(u8, lines.next() orelse return MinisignError.MinisignMalformedSignature, " \t\r");
+
+    const tc_prefix = "trusted comment: ";
+    if (!std.mem.startsWith(u8, tc_line, tc_prefix)) return MinisignError.MinisignMalformedSignature;
+    const trusted_comment = tc_line[tc_prefix.len..];
+
+    // Decode signature blob (74 bytes: algo[2] || key_id[8] || sig[64]).
+    var sig_buf: [74]u8 = undefined;
+    {
+        const n = b64.calcSizeForSlice(sig_line) catch return MinisignError.MinisignMalformedSignature;
+        if (n != sig_buf.len) return MinisignError.MinisignMalformedSignature;
+        b64.decode(&sig_buf, sig_line) catch return MinisignError.MinisignMalformedSignature;
+    }
+    const algo = sig_buf[0..2];
+    const sig_key_id = sig_buf[2..10];
+    const ed_sig_bytes: [64]u8 = sig_buf[10..74].*;
+
+    if (!std.mem.eql(u8, pk_key_id, sig_key_id)) return MinisignError.MinisignKeyIdMismatch;
+
+    const Ed25519 = std.crypto.sign.Ed25519;
+    const public_key = Ed25519.PublicKey.fromBytes(ed_pub_bytes) catch return MinisignError.MinisignMalformedPublicKey;
+    const signature = Ed25519.Signature.fromBytes(ed_sig_bytes);
+
+    // Build the signed message per algorithm.
+    if (std.mem.eql(u8, algo, "ED")) {
+        var hash: [64]u8 = undefined;
+        std.crypto.hash.blake2.Blake2b512.hash(file_data, &hash, .{});
+        signature.verify(&hash, public_key) catch return MinisignError.ZigSignatureInvalid;
+    } else if (std.mem.eql(u8, algo, "Ed")) {
+        signature.verify(file_data, public_key) catch return MinisignError.ZigSignatureInvalid;
+    } else {
+        return MinisignError.MinisignUnsupportedAlgorithm;
+    }
+
+    // Verify the global signature over (sig[64] || trusted_comment). This
+    // binds the trusted comment (which names the file + timestamp) to the key.
+    var gsig_bytes: [64]u8 = undefined;
+    {
+        const n = b64.calcSizeForSlice(gsig_line) catch return MinisignError.MinisignMalformedSignature;
+        if (n != gsig_bytes.len) return MinisignError.MinisignMalformedSignature;
+        b64.decode(&gsig_bytes, gsig_line) catch return MinisignError.MinisignMalformedSignature;
+    }
+    var global_msg: std.ArrayList(u8) = .empty;
+    defer global_msg.deinit(std.heap.page_allocator);
+    global_msg.appendSlice(std.heap.page_allocator, &ed_sig_bytes) catch return error.OutOfMemory;
+    global_msg.appendSlice(std.heap.page_allocator, trusted_comment) catch return error.OutOfMemory;
+    const global_sig = Ed25519.Signature.fromBytes(gsig_bytes);
+    global_sig.verify(global_msg.items, public_key) catch return MinisignError.ZigSignatureInvalid;
+}
+
+// ── Extraction ─────────────────────────────────────────────────────────
+
+/// Extract `archive_path` into `dest_dir`, stripping the single leading
+/// `zig-<arch>-<os>-<ver>/` component so `dest_dir` is flat. Unix uses
+/// `tar -xJf --strip-components=1`; Windows uses PowerShell `Expand-Archive`
+/// then flattens the one top-level dir.
+fn extractArchive(allocator: std.mem.Allocator, archive_path: []const u8, dest_dir: []const u8) !void {
+    if (is_windows) return extractZipWindows(allocator, archive_path, dest_dir);
+    const result = util.runCmd(allocator, &.{
+        "tar", "-xJf", archive_path, "-C", dest_dir, "--strip-components=1",
+    }) catch {
+        std.debug.print("labelle: extraction failed (is tar installed?)\n", .{});
+        return error.ZigExtractFailed;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            std.debug.print("labelle: tar extraction failed (exit {d})\n{s}\n", .{ code, result.stderr });
+            return error.ZigExtractFailed;
+        },
+        else => return error.ZigExtractFailed,
+    }
+}
+
+/// Windows: `Expand-Archive` cannot strip a leading dir, so unzip into a
+/// scratch subdir then move the single top-level entry's children up.
+fn extractZipWindows(allocator: std.mem.Allocator, archive_path: []const u8, dest_dir: []const u8) !void {
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+    const scratch = try std.fs.path.join(allocator, &.{ dest_dir, "__unzip" });
+    defer allocator.free(scratch);
+    cwd.createDirPath(io, scratch) catch {};
+
+    const ps = try std.fmt.allocPrint(allocator,
+        \\Expand-Archive -LiteralPath '{s}' -DestinationPath '{s}' -Force
+    , .{ archive_path, scratch });
+    defer allocator.free(ps);
+    const result = util.runCmd(allocator, &.{ "powershell", "-NoProfile", "-Command", ps }) catch {
+        return error.ZigExtractFailed;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) return error.ZigExtractFailed,
+        else => return error.ZigExtractFailed,
+    }
+
+    // Move the single `zig-*/` child's contents up into dest_dir.
+    var sd = try cwd.openDir(io, scratch, .{ .iterate = true });
+    defer sd.close(io);
+    var it = sd.iterate();
+    const top = (try it.next(io)) orelse return error.ZigArchiveLayoutUnexpected;
+    const inner = try std.fs.path.join(allocator, &.{ scratch, top.name });
+    defer allocator.free(inner);
+    var id = try cwd.openDir(io, inner, .{ .iterate = true });
+    defer id.close(io);
+    var iit = id.iterate();
+    while (try iit.next(io)) |entry| {
+        const from = try std.fs.path.join(allocator, &.{ inner, entry.name });
+        defer allocator.free(from);
+        const to = try std.fs.path.join(allocator, &.{ dest_dir, entry.name });
+        defer allocator.free(to);
+        try cwd.rename(from, cwd, to, io);
+    }
+    cwd.deleteTree(io, scratch) catch {};
+}
+
+// ── Subcommands ─────────────────────────────────────────────────────────
+
+/// `labelle install zig <version>` — force download+verify+install.
+pub fn cmdInstallZig(allocator: std.mem.Allocator, version: []const u8) !void {
+    const bin_path = try zig_cache.binaryPath(allocator, version);
+    defer allocator.free(bin_path);
+    if (std.Io.Dir.cwd().access(config.globalIo(), bin_path, .{})) |_| {
+        std.debug.print("labelle: Zig {s} already installed at {s}\n", .{ version, bin_path });
+        return;
+    } else |_| {}
+    try ensureInstalled(allocator, version);
+    std.debug.print("labelle: Zig {s} installed\n", .{version});
+}
+
+/// `labelle toolchain list` — cached versions under `<root>/<subdir>/`.
+pub fn cmdToolchainList(allocator: std.mem.Allocator) !void {
+    const io = config.globalIo();
+    const root = try zig_cache.zigRoot(allocator);
+    defer allocator.free(root);
+    var dir = std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true }) catch {
+        std.debug.print("labelle: no cached Zig toolchains\n  cache directory: {s}\n", .{root});
+        return;
+    };
+    defer dir.close(io);
+    var count: usize = 0;
+    var it = dir.iterate();
+    while (try it.next(io)) |entry| {
+        if (entry.kind != .directory) continue;
+        if (count == 0) std.debug.print("Cached Zig toolchains:\n", .{});
+        const bin = try std.fs.path.join(allocator, &.{ root, entry.name, zig_cache.zig_exe_name });
+        defer allocator.free(bin);
+        const ok = blk: {
+            std.Io.Dir.cwd().access(io, bin, .{}) catch break :blk false;
+            break :blk true;
+        };
+        if (ok) std.debug.print("  {s}\n", .{entry.name}) else std.debug.print("  {s} (incomplete)\n", .{entry.name});
+        count += 1;
+    }
+    if (count == 0) std.debug.print("labelle: no cached Zig toolchains\n  cache directory: {s}\n", .{root});
+}
+
+/// `labelle toolchain which` — report the version, its source, and resolved
+/// path for the project in `project_dir` (no download).
+pub fn cmdToolchainWhich(allocator: std.mem.Allocator, project_dir: []const u8) !void {
+    const io = config.globalIo();
+    // Path overrides short-circuit — report them explicitly.
+    if (try lookupEnvOverride(allocator)) |path| {
+        defer allocator.free(path);
+        std.debug.print("zig: {s}\n  source: {s}\n", .{ path, VersionSource.env_override.label() });
+        return;
+    }
+    if (_flag_override) |path| {
+        std.debug.print("zig: {s}\n  source: {s}\n", .{ path, VersionSource.flag_override.label() });
+        return;
+    }
+    const resolved = try resolveRequiredVersion(allocator, project_dir);
+    defer allocator.free(resolved.version);
+    const bin = try zig_cache.binaryPath(allocator, resolved.version);
+    defer allocator.free(bin);
+    const installed = blk: {
+        std.Io.Dir.cwd().access(io, bin, .{}) catch break :blk false;
+        break :blk true;
+    };
+    std.debug.print("zig: {s}\n  version: {s}\n  source: {s}\n  installed: {s}\n", .{
+        bin, resolved.version, resolved.source.label(), if (installed) "yes" else "no (will download on next build)",
+    });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const asm_cache = @import("asm_cache.zig");
+
+test "archiveUrl builds the modern arch-os triple on ziglang.org" {
+    const alloc = testing.allocator;
+    const url = try archiveUrl(alloc, "0.16.0");
+    defer alloc.free(url);
+    // Host-specific, so assert the invariant pieces.
+    try testing.expect(std.mem.startsWith(u8, url, "https://ziglang.org/download/0.16.0/zig-"));
+    try testing.expect(std.mem.indexOf(u8, url, "-0.16.0.") != null);
+    try testing.expect(std.mem.endsWith(u8, url, if (is_windows) ".zip" else ".tar.xz"));
+    // arch precedes os (0.14.1+ scheme): the arch token appears before the os token.
+    const arch = try archName();
+    const os = try osName();
+    const arch_idx = std.mem.indexOf(u8, url, arch).?;
+    const os_idx = std.mem.indexOf(u8, url, os).?;
+    try testing.expect(arch_idx < os_idx);
+}
+
+test "zigVersionForEngine maps the 1.x train to the default; unknown -> null" {
+    try testing.expectEqualStrings(DEFAULT_ZIG_VERSION, zigVersionForEngine("1.65.0").?);
+    try testing.expect(zigVersionForEngine("2.0.0") == null);
+}
+
+test "resolveRequiredVersion: no project -> default" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+
+    const r = try resolveRequiredVersion(alloc, buf[0..n]);
+    defer alloc.free(r.version);
+    try testing.expectEqualStrings(DEFAULT_ZIG_VERSION, r.version);
+    try testing.expectEqual(VersionSource.default, r.source);
+}
+
+test "resolveRequiredVersion: explicit zig_version pin wins" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(config.globalIo(), .{
+        .sub_path = "project.labelle",
+        .data = ".{ .name = \"t\", .zig_version = \"0.15.2\", .engine_version = \"1.65.0\" }",
+    });
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+
+    const r = try resolveRequiredVersion(alloc, buf[0..n]);
+    defer alloc.free(r.version);
+    try testing.expectEqualStrings("0.15.2", r.version);
+    try testing.expectEqual(VersionSource.project_pin, r.source);
+}
+
+test "resolveRequiredVersion: engine_version derives when no explicit pin" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(config.globalIo(), .{
+        .sub_path = "project.labelle",
+        .data = ".{ .name = \"t\", .engine_version = \"1.65.0\" }",
+    });
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+
+    const r = try resolveRequiredVersion(alloc, buf[0..n]);
+    defer alloc.free(r.version);
+    try testing.expectEqualStrings(DEFAULT_ZIG_VERSION, r.version);
+    try testing.expectEqual(VersionSource.engine_derived, r.source);
+}
+
+test "resolveRequiredVersion: falls back to labelle.lock engine version" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(config.globalIo(), .{
+        .sub_path = "project.labelle",
+        .data = ".{ .name = \"t\" }",
+    });
+    try tmp.dir.writeFile(config.globalIo(), .{
+        .sub_path = "labelle.lock",
+        .data = ".{ .resolved = .{ .engine = .{ .version = \"1.65.0\" } } }",
+    });
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+
+    const r = try resolveRequiredVersion(alloc, buf[0..n]);
+    defer alloc.free(r.version);
+    try testing.expectEqual(VersionSource.engine_derived, r.source);
+    try testing.expectEqualStrings(DEFAULT_ZIG_VERSION, r.version);
+}
+
+test "resolveZig: --zig flag override returns the path verbatim; env wins over flag" {
+    const alloc = testing.allocator;
+    setFlagOverride("/opt/custom/zig");
+    defer setFlagOverride(null);
+    const p = try resolveZig(alloc, ".");
+    defer alloc.free(p);
+    // No LABELLE_ZIG in the test environ, so the flag wins.
+    try testing.expectEqualStrings("/opt/custom/zig", p);
+}
+
+test "the pinned minisign public key parses to 42 bytes with algo 'Ed'" {
+    const b64 = std.base64.standard.Decoder;
+    var pk: [42]u8 = undefined;
+    const n = try b64.calcSizeForSlice(MINISIGN_PUBLIC_KEY);
+    try testing.expectEqual(@as(usize, 42), n);
+    try b64.decode(&pk, MINISIGN_PUBLIC_KEY);
+    try testing.expectEqualStrings("Ed", pk[0..2]);
+}
+
+// Sign a test file with our OWN Ed25519 key and hand-assemble a minisign
+// signature (prehashed "ED"), then verify accept/reject. This exercises the
+// parser + Ed25519 + Blake2b path without needing Zig's private key.
+const MiniFixture = struct {
+    pub_b64: []u8,
+    sig_text: []u8,
+
+    fn make(alloc: std.mem.Allocator, file_data: []const u8, kp: std.crypto.sign.Ed25519.KeyPair) !MiniFixture {
+        const Enc = std.base64.standard.Encoder;
+        const key_id = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
+
+        // public key blob: "Ed" || key_id || pub[32]
+        var pk_blob: [42]u8 = undefined;
+        @memcpy(pk_blob[0..2], "Ed");
+        @memcpy(pk_blob[2..10], &key_id);
+        @memcpy(pk_blob[10..42], &kp.public_key.bytes);
+        const pub_b64 = try alloc.alloc(u8, Enc.calcSize(pk_blob.len));
+        _ = Enc.encode(pub_b64, &pk_blob);
+
+        // prehashed signature over Blake2b512(file)
+        var hash: [64]u8 = undefined;
+        std.crypto.hash.blake2.Blake2b512.hash(file_data, &hash, .{});
+        const sig = try kp.sign(&hash, null);
+        var sig_blob: [74]u8 = undefined;
+        @memcpy(sig_blob[0..2], "ED");
+        @memcpy(sig_blob[2..10], &key_id);
+        @memcpy(sig_blob[10..74], &sig.toBytes());
+        var sig_b64: [100]u8 = undefined;
+        const sig_b64_s = Enc.encode(&sig_b64, &sig_blob);
+
+        const trusted_comment = "timestamp:1 file:test hashed";
+        // global signature over sig[64] || trusted_comment
+        var gmsg: [64 + trusted_comment.len]u8 = undefined;
+        @memcpy(gmsg[0..64], &sig.toBytes());
+        @memcpy(gmsg[64..], trusted_comment);
+        const gsig = try kp.sign(&gmsg, null);
+        var gsig_b64: [100]u8 = undefined;
+        const gsig_b64_s = Enc.encode(&gsig_b64, &gsig.toBytes());
+
+        const sig_text = try std.fmt.allocPrint(alloc,
+            "untrusted comment: x\n{s}\ntrusted comment: {s}\n{s}\n",
+            .{ sig_b64_s, trusted_comment, gsig_b64_s },
+        );
+        return .{ .pub_b64 = pub_b64, .sig_text = sig_text };
+    }
+
+    fn deinit(self: *MiniFixture, alloc: std.mem.Allocator) void {
+        alloc.free(self.pub_b64);
+        alloc.free(self.sig_text);
+    }
+};
+
+test "verifyMinisign: accepts a valid signature, rejects a tampered file" {
+    const alloc = testing.allocator;
+    const kp = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic([_]u8{7} ** 32);
+    const file_data = "the labelle managed zig archive bytes";
+
+    var fx = try MiniFixture.make(alloc, file_data, kp);
+    defer fx.deinit(alloc);
+
+    // Known-good: verifies.
+    try verifyMinisign(fx.pub_b64, file_data, fx.sig_text);
+
+    // Tampered payload: same signature, different bytes → reject.
+    try testing.expectError(MinisignError.ZigSignatureInvalid, verifyMinisign(fx.pub_b64, "tampered!!!", fx.sig_text));
+}
+
+test "verifyMinisign: rejects a signature from the wrong key" {
+    const alloc = testing.allocator;
+    const kp = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic([_]u8{11} ** 32);
+    const other = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic([_]u8{22} ** 32);
+    const file_data = "payload";
+
+    var fx = try MiniFixture.make(alloc, file_data, kp);
+    defer fx.deinit(alloc);
+
+    // Re-encode a DIFFERENT public key with the same key_id → algo/key_id
+    // parse fine but the ed25519 verify fails.
+    const Enc = std.base64.standard.Encoder;
+    var pk_blob: [42]u8 = undefined;
+    @memcpy(pk_blob[0..2], "Ed");
+    @memcpy(pk_blob[2..10], &[_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    @memcpy(pk_blob[10..42], &other.public_key.bytes);
+    var wrong_pub: [56]u8 = undefined;
+    const wrong_pub_s = Enc.encode(&wrong_pub, &pk_blob);
+
+    try testing.expectError(MinisignError.ZigSignatureInvalid, verifyMinisign(wrong_pub_s, file_data, fx.sig_text));
+}
+
+test "verifyMinisign: key_id mismatch is caught before crypto" {
+    const alloc = testing.allocator;
+    const kp = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic([_]u8{33} ** 32);
+    var fx = try MiniFixture.make(alloc, "x", kp);
+    defer fx.deinit(alloc);
+    // Zig's real key has a different key_id than our fixture's {1..8}.
+    try testing.expectError(MinisignError.MinisignKeyIdMismatch, verifyMinisign(MINISIGN_PUBLIC_KEY, "x", fx.sig_text));
+}


### PR DESCRIPTION
Part of #25 (zero-install labelle-studio epic, SUB1). Closes #279. Supersedes cli#203 options 3+4; folds cli#203 options 1-2 in as env/flag escape hatches.

The CLI now **owns the Zig toolchain** the way it already owns `labelle-assembler`: it reads the required Zig version from the project, resolves it to a per-version managed cache under `~/.labelle/`, downloads + **verifies** + extracts it if absent, and points every `zig` spawn at the managed binary instead of PATH. This removes the studio's Finder-PATH failure mode (the epic's canonical pain).

## New modules (siblings of the assembler resolver)
- **`src/cli/zig_toolchain.zig`** — mirrors `assembler.zig`: `resolveZig`, `resolveRequiredVersion`, `ensureInstalled`, download/verify/extract, and the new `install zig` / `toolchain list|which` commands.
- **`src/cli/zig_cache.zig`** — mirrors `asm_cache.zig`: per-version cache paths + `ZIG_*_CACHE_DIR` locations. Reuses `asm_cache.getCacheRoot` so Zig, the assembler, and the package cache share one `~/.labelle/` tree (and one test override).

## Version-resolution precedence + source
`LABELLE_ZIG` env (path) > `--zig <path>` flag > `zig_version` in `project.labelle` > **engine-derived** (map the pinned engine version, from `project.labelle` `engine_version` or `labelle.lock`, via `zigVersionForEngine`) > `DEFAULT_ZIG_VERSION` (`0.16.0`).

**On the authoritative source:** there is no first-class engine→Zig table in the toolkit today — the engine's `minimum_zig_version` is not surfaced to the CLI at runtime, and the whole toolkit currently rides a single Zig train (0.16.x). So `zigVersionForEngine` maps any 1.x engine to the default but *attributes the source to the engine* (so `toolchain which` reports it honestly), and is the seam where future train-divergence lands. `DEFAULT_ZIG_VERSION` is kept in lockstep with the CLI's own build Zig and the #280 seed. `labelle toolchain which` prints the resolved version, its source, the path, and whether it's installed.

## Cache layout (the #280 seed contract)
```
<cache-root>/<subdir>/<version>/zig[.exe]   ← managed binary
<cache-root>/<subdir>/<version>/lib/, doc/, …
```
The version dir holds the **flattened** release (`zig`, `lib/`, `doc/` directly under `<version>/`, not a nested `zig-<arch>-<os>-<ver>/`). `subdir` = `zig` on Unix, **`tc` on Windows** (short, for MAX_PATH). A #280 seed archive MUST extract to this identical flat layout so seeded and downloaded toolchains are indistinguishable. Verified end-to-end: `labelle install zig 0.16.0` produces `LICENSE README.md doc lib zig` at the version-dir top level and the binary runs.

## Verification (NEW — the assembler path does none)
Full **minisign** verification in pure Zig — no shelling to a `minisign` binary. Downloads the matching `.minisig`, parses the trusted-comment format, and verifies with Zig's pinned well-known public key (`RWSGOq2NVecA…`) using `std.crypto.sign.Ed25519` over the `Blake2b-512` prehash (Zig's `ED` variant), plus the global (trusted-comment) signature. Fails closed: a bad signature deletes the download and returns `error.ZigSignatureInvalid`. **No SHA-256 fallback / no minisign TODO — the full thing is implemented.** Validated against Zig 0.16.0's *real* published signature (not just self-signed fixtures).

## Windows short-path handling
Toolchains extract under the short `tc\<ver>\` segment (not `zig\<full-version>\`) to keep `lib\std\…` + the compiler's nested build cache under 260 chars. `LABELLE_HOME=C:\labelle` (honored by `asm_cache.getCacheRoot`) moves the whole tree to a short root for deep profiles.

## Spawn seam + `ZIG_*_CACHE_DIR` wiring
Every `zig` spawn now uses the resolved managed path — grep-clean of bare `"zig"` argv[0] across `src/cli/` (build/run in `cli.zig`, `runner.fixFingerprint`, local-assembler build, `test.zig`, `ios.zig`, `android/build.zig`). `doctor` reports the managed toolchain instead of probing PATH. `ZIG_GLOBAL_CACHE_DIR`/`ZIG_LOCAL_CACHE_DIR` are pinned into `~/.labelle/zig-{global,local}-cache` on every managed spawn so the compiler cache lands in user-writable space, never next to a read-only install. Docker builds skip resolution (toolchain lives in the container).

## Escape hatches (cli#203 options 1-2)
`LABELLE_ZIG=/path/to/zig` (env, wins over everything) and `--zig <path>` / `--zig=<path>` (on build/run/generate). Graceful degradation: a provision failure prints an actionable message naming the fixes, not a bare FileNotFound (coordinates cli#277).

## Out of scope
emsdk/`emcc` management is SUB2/#26 — not touched; the wasm build path keeps using the managed Zig only. Bundled/seeded first-run extraction is #280.

## Tests
15 new unit tests (all network/fs boundaries mocked, no real network): URL construction per host triple (asserts the modern arch-os order), version precedence (env/flag/pin/engine/lock/default), per-platform cache paths incl. the Windows short-root, escape-hatch precedence, and minisign verify (self-signed good vs tampered vs wrong-key vs key-id-mismatch → accept/reject). `zig build` compiles on 0.16.0; `zig build test` green — **319/319** tests pass.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw