### PR TITLE
fix(run): stage SDL2.dll beside the game exe + name exe on spawn failure (#285)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -905,8 +905,14 @@ pub fn main(proc_init: std.process.Init) !void {
     // user already set the var. Scoped like `labelle doctor`: the sdl
     // backend always needs SDL2; raylib/sokol only for the gamepad
     // source, so `.gamepad = .none` projects get nothing injected.
+    // Backends that pull in SDL2: the `sdl` renderer always, and
+    // raylib/sokol/bgfx for the shared desktop gamepad source unless gamepad
+    // is opted out. Mirrors the assembler's `deps_linker.stagesSdlGamepad`
+    // (raylib/sokol/bgfx with `gamepad == .auto`) — bgfx was previously
+    // missing here, so its default gamepad-enabled desktop builds never got
+    // SDL2 auto-wired or the runtime DLL staged (cli#285 / cli#286).
     const wants_sdl2 = parsed.backend == .sdl or
-        ((parsed.backend == .raylib or parsed.backend == .sokol) and parsed.gamepad != .none);
+        ((parsed.backend == .raylib or parsed.backend == .sokol or parsed.backend == .bgfx) and parsed.gamepad != .none);
     if (parsed.platform == .desktop and wants_sdl2) {
         sdl_provision.autoWireEnv(allocator);
     }
@@ -1081,6 +1087,19 @@ pub fn main(proc_init: std.process.Init) !void {
         }
     }
     std.debug.print("  build ok\n", .{});
+
+    // Stage the runtime SDL2.dll next to the freshly-built desktop exe. A
+    // gamepad/SDL2 build's exe fails process creation with a bare
+    // `FileNotFound` when SDL2.dll isn't in its own directory (cli#285): the
+    // Windows loader resolves implicitly-linked DLLs from the exe dir first,
+    // and neither the PATH prepend from autoWireEnv nor a user-set
+    // LABELLE_SDL2_LIB puts the DLL there. Docker builds are skipped — their
+    // exe is built for the container's OS, so a host SDL2.dll is irrelevant.
+    if (!parsed_args.docker and parsed.platform == .desktop and wants_sdl2) {
+        const bin_dir = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "bin" });
+        defer allocator.free(bin_dir);
+        sdl_provision.stageSdl2DllBesideExe(allocator, bin_dir);
+    }
 
     if (command == .build) {
         // `labelle build --platform=android` builds the shared library

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -36,13 +36,23 @@ const TimeoutState = struct {
 fn reportSpawnFailure(err: anyerror, argv: []const []const u8, cwd: []const u8) void {
     if (err != error.FileNotFound) return;
     const exe = if (argv.len > 0) argv[0] else "(no executable)";
-    std.debug.print(
-        "labelle: could not launch `{s}` in {s}\n" ++
+    std.debug.print("labelle: could not launch `{s}` in {s}\n", .{ exe, cwd });
+    if (is_windows) {
+        // On Windows a missing implicitly-linked DLL also surfaces as
+        // FileNotFound from process creation, so name it here.
+        std.debug.print(
             "  hint: the executable was not found on PATH, or a required DLL\n" ++
-            "        (e.g. SDL2.dll) is missing next to it. Run `labelle doctor`\n" ++
-            "        to check your toolchain and system libraries.\n",
-        .{ exe, cwd },
-    );
+                "        (e.g. SDL2.dll) is missing next to it. Run `labelle doctor`\n" ++
+                "        to check your toolchain and system libraries.\n",
+            .{},
+        );
+    } else {
+        std.debug.print(
+            "  hint: the executable was not found on PATH or at that path. Run\n" ++
+                "        `labelle doctor` to check your toolchain.\n",
+            .{},
+        );
+    }
 }
 
 /// Run a zig command capturing stdout/stderr.

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -28,12 +28,32 @@ const TimeoutState = struct {
     }
 };
 
+/// Report a failed process spawn with the executable + cwd, so a missing
+/// tool or DLL is diagnosable instead of surfacing as a bare
+/// `error: FileNotFound` from main's default error printer (cli#277, cli#285).
+/// On Windows a missing implicitly-linked DLL (e.g. SDL2.dll) also makes
+/// process creation fail with FileNotFound, so the hint names it too.
+fn reportSpawnFailure(err: anyerror, argv: []const []const u8, cwd: []const u8) void {
+    if (err != error.FileNotFound) return;
+    const exe = if (argv.len > 0) argv[0] else "(no executable)";
+    std.debug.print(
+        "labelle: could not launch `{s}` in {s}\n" ++
+            "  hint: the executable was not found on PATH, or a required DLL\n" ++
+            "        (e.g. SDL2.dll) is missing next to it. Run `labelle doctor`\n" ++
+            "        to check your toolchain and system libraries.\n",
+        .{ exe, cwd },
+    );
+}
+
 /// Run a zig command capturing stdout/stderr.
 pub fn runZig(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []const u8) !std.process.RunResult {
     return std.process.run(allocator, config.globalIo(), .{
         .argv = argv,
         .cwd = .{ .path = cwd },
-    });
+    }) catch |err| {
+        reportSpawnFailure(err, argv, cwd);
+        return err;
+    };
 }
 
 /// Run a zig command with inherited stdio (output goes straight to terminal).
@@ -61,7 +81,7 @@ pub fn runZigInheritWithEnv(
     environ_map: ?*const std.process.Environ.Map,
 ) !u8 {
     const io = config.globalIo();
-    var child = try std.process.spawn(io, .{
+    var child = std.process.spawn(io, .{
         .argv = argv,
         .cwd = .{ .path = cwd },
         .stdin = .inherit,
@@ -69,7 +89,10 @@ pub fn runZigInheritWithEnv(
         .stderr = .inherit,
         .pgid = if (!is_windows and timeout_ns != null) 0 else null,
         .environ_map = environ_map,
-    });
+    }) catch |err| {
+        reportSpawnFailure(err, argv, cwd);
+        return err;
+    };
 
     // Heap-allocate so the detached thread can safely access it after this function returns
     var state: ?*TimeoutState = null;

--- a/src/cli/sdl_provision.zig
+++ b/src/cli/sdl_provision.zig
@@ -159,6 +159,11 @@ pub fn stageSdl2DllBesideExe(gpa: std.mem.Allocator, bin_dir: []const u8) void {
     copyFileVia(a, io, src, dst);
     if (util.fileExists(dst)) {
         std.debug.print("labelle: staged SDL2.dll next to the game exe ({s})\n", .{dst});
+    } else {
+        // Located a source DLL but the copy did not land (permissions, AV
+        // lock, ...). Surface it so this failure mode is diagnosable rather
+        // than silently indistinguishable from "nothing to stage".
+        std.debug.print("labelle: found SDL2.dll at {s} but failed to copy it to {s}\n", .{ src, dst });
     }
 }
 

--- a/src/cli/sdl_provision.zig
+++ b/src/cli/sdl_provision.zig
@@ -131,6 +131,62 @@ pub fn autoWireEnv(gpa: std.mem.Allocator) void {
     }
 }
 
+/// Stage the runtime `SDL2.dll` next to a freshly-built desktop game exe so
+/// the build is launchable in place. On Windows the OS resolves a process's
+/// implicitly-linked DLLs from the exe's OWN directory first; the build
+/// installs the exe into `.labelle/<target>/zig-out/bin/` but nothing puts
+/// `SDL2.dll` there, so `labelle run` (and a hand-launched `zig-out/bin` exe)
+/// fails at process creation with a bare `error: FileNotFound` (cli#285).
+///
+/// This complements `autoWireEnv`, which only *prepends* the SDL2 cache dir to
+/// PATH — PATH is consulted by the loader AFTER the exe's own dir, and a
+/// user-provided `LABELLE_SDL2_LIB` is not on PATH at all, so neither
+/// reliably covers the launched exe. Copying the DLL beside the exe does.
+///
+/// No-op off Windows, when no `SDL2.dll` can be located, or when it is already
+/// staged. `bin_dir` is the exe's output dir (`.labelle/<target>/zig-out/bin`).
+pub fn stageSdl2DllBesideExe(gpa: std.mem.Allocator, bin_dir: []const u8) void {
+    if (builtin.os.tag != .windows) return;
+    var arena_inst = std.heap.ArenaAllocator.init(gpa);
+    defer arena_inst.deinit();
+    const a = arena_inst.allocator();
+    const io = config.globalIo();
+
+    const dst = join(a, &.{ bin_dir, "SDL2.dll" }) orelse return;
+    if (util.fileExists(dst)) return; // already staged — leave it in place
+
+    const src = locateSdl2Dll(a) orelse return; // nothing to stage
+    copyFileVia(a, io, src, dst);
+    if (util.fileExists(dst)) {
+        std.debug.print("labelle: staged SDL2.dll next to the game exe ({s})\n", .{dst});
+    }
+}
+
+/// Locate a runtime `SDL2.dll`, mirroring the linker's own SDL2 resolution:
+///   1. `LABELLE_SDL2_LIB`/SDL2.dll   (the provisioner drops the DLL in lib/)
+///   2. `LABELLE_SDL2_LIB`/../bin/SDL2.dll   (upstream MinGW package layout)
+///   3. the labelle SDL2 cache lib dir (`findCachedLibDir`, holds SDL2.dll)
+/// Arena-allocated; returns null when none is present.
+fn locateSdl2Dll(a: std.mem.Allocator) ?[]const u8 {
+    const env = config.globalEnviron();
+    if (env.getAlloc(a, "LABELLE_SDL2_LIB") catch null) |lib| {
+        if (lib.len > 0) {
+            if (join(a, &.{ lib, "SDL2.dll" })) |p| {
+                if (util.fileExists(p)) return p;
+            }
+            if (join(a, &.{ lib, "..", "bin", "SDL2.dll" })) |p| {
+                if (util.fileExists(p)) return p;
+            }
+        }
+    }
+    if (findCachedLibDir(a)) |lib| {
+        if (join(a, &.{ lib, "SDL2.dll" })) |p| {
+            if (util.fileExists(p)) return p;
+        }
+    }
+    return null;
+}
+
 extern "kernel32" fn SetEnvironmentVariableW(name: [*:0]const u16, value: ?[*:0]const u16) callconv(.winapi) i32;
 
 /// Set an environment variable on the current process (Windows). Children


### PR DESCRIPTION
## Root cause

After a successful build, `labelle run` on a bgfx/gamepad (SDL2) desktop project fails with a bare `error: FileNotFound` and no filename, even though the exe runs fine when SDL2.dll sits beside it.

- On Windows the loader resolves a process's implicitly-linked DLLs from the **exe's own directory first**. The build installs the exe to `.labelle/<target>/zig-out/bin/`, but nothing stages `SDL2.dll` there, so process creation fails.
- `autoWireEnv` only *prepends* the SDL2 cache dir to `PATH`, which the loader consults **after** the exe dir — and a user-set `LABELLE_SDL2_LIB` is never on `PATH` — so neither reliably covers the launched exe.
- The spawn seam (`runner.zig` `runZig`/`runZigInherit` → `std.process.run`/`spawn`) `try`-propagated the error untouched, so it reached main's default printer as a bare `error: FileNotFound`.
- The CLI's `wants_sdl2` predicate omitted `.bgfx`, so bgfx's default gamepad-enabled builds never even triggered the SDL2 auto-wire (same backend→gamepad skew as #286).

## Fix

1. **Stage `SDL2.dll` next to the exe** — new `sdl_provision.stageSdl2DllBesideExe`. After `build ok`, for a non-docker desktop build that wants SDL2, copy `SDL2.dll` into `zig-out/bin/` from `LABELLE_SDL2_LIB` (or its sibling `bin`, or the `~/.labelle/sdl2` cache), mirroring the linker's own SDL2 resolution order. No-op off Windows / when the DLL can't be found / when already staged.
2. **Add `.bgfx` to the CLI `wants_sdl2` predicate** so bgfx desktop builds get SDL2 auto-wired and staged — matching the assembler's `deps_linker.stagesSdlGamepad` (raylib/sokol/bgfx with `gamepad == .auto`).
3. **Name the executable on spawn failure** — new `runner.reportSpawnFailure`. The `runZig`/`runZigInherit` seam catches `error.FileNotFound`, prints the exe + cwd and a hint that a required DLL such as `SDL2.dll` may be missing and to run `labelle doctor`, then re-raises. This also addresses **#277** (bare `FileNotFound` when `zig`/a toolchain is missing).

## Testing

- `zig build` and `zig build test` pass; `zig fmt --check` clean (Zig 0.16.0, the repo's `minimum_zig_version`).
- A full bgfx run could not be exercised end-to-end on the test machine because **SDL2 isn't installed there** (the exact case `labelle doctor` now flags via #286) — without it the backend can't link. The staging and diagnostic paths are compile- and logic-verified; the `error.FileNotFound` identity handled is the one reported in the issue.

Closes #285. Also improves #277 (executable is now named on spawn failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
