### PR TITLE
fix(doctor): classify bgfx as needing SDL2/gamepad (#286)

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -54,8 +54,20 @@ pub fn cmdDoctor(allocator: std.mem.Allocator, cmd_args: []const []const u8) !vo
     const effective_backend = cfg.backend orelse .raylib;
 
     const needs_sdl_render = effective_backend == .sdl;
+    // Which backends pull in SDL2 for the shared desktop gamepad source. This
+    // MUST match what the assembler actually wires, or doctor gives an
+    // all-clear and `labelle build` then fails at link with "unable to find
+    // dynamic system library 'SDL2'" (cli#286). The assembler's source of
+    // truth is `labelle-assembler/src/deps_linker.zig:stagesSdlGamepad`, which
+    // stages `backends/sdl_gamepad` (→ `-lSDL2`) for `.raylib, .sokol, .bgfx`
+    // whenever `gamepad == .auto`. bgfx was missing here, so its default
+    // (gamepad-enabled) desktop builds linked SDL2 while doctor reported
+    // `gamepad: n/a` and `--fix` refused to provision it. `.sdl` is kept in
+    // this set too: the sdl render backend links SDL2 unconditionally (as the
+    // renderer, see needs_sdl_render), so surfacing the requirement there is
+    // correct regardless of gamepad.
     const needs_sdl_gamepad = switch (effective_backend) {
-        .raylib, .sokol, .sdl => !cfg.gamepad_off,
+        .raylib, .sokol, .bgfx, .sdl => !cfg.gamepad_off,
         else => false,
     };
     const needs_sdl = needs_sdl_render or needs_sdl_gamepad;


### PR DESCRIPTION
## Root cause

`labelle doctor` reported `gamepad: n/a` and "no system libraries" for a bgfx desktop project, and `labelle doctor --fix` refused to provision SDL2 — yet the assembler wires `backend_input → sdl_gamepad → SDL2` for bgfx, so `labelle build` then failed at link with `unable to find dynamic system library 'SDL2'`. The all-clear was actively misleading on a fresh machine.

The skew: doctor's `needs_sdl_gamepad` switch (`src/cli/doctor.zig`) classified only `.raylib, .sokol, .sdl` as needing the SDL gamepad source, omitting `.bgfx`. The assembler's source of truth — `labelle-assembler/src/deps_linker.zig` `stagesSdlGamepad` — stages the shared `backends/sdl_gamepad` sub-package (which links `-lSDL2`) for `.raylib, .sokol, .bgfx` whenever `gamepad == .auto`. Doctor and the assembler had drifted for bgfx.

## Fix

Add `.bgfx` to doctor's `needs_sdl_gamepad` set so a gamepad-enabled bgfx desktop project:
- reports `gamepad: on`,
- surfaces the SDL2 library + runtime-DLL requirements (FAIL instead of a false all-clear), and
- lets `labelle doctor --fix` provision SDL2.

Documented the assembler predicate (`stagesSdlGamepad`) as the source of truth in a comment so future edits keep the two classifications in sync — the ask in the issue for a single source of truth. (The assembler lives in a separate binary the thin-driver CLI can't import directly, so the comment is the practical link.)

## Testing

- `zig build` and `zig build test` pass (Zig 0.16.0, the repo's `minimum_zig_version`).
- `labelle doctor <bgfx-project>` now prints `backend: bgfx   gamepad: on` and a `[ FAIL ] SDL2 library` line with the provisioning hint, instead of the previous `gamepad: n/a` / "needs no system libraries" all-clear.

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
