### PR TITLE
feat(progress): structured build-progress feed — NDJSON, status file, labelle status (#284)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -197,17 +197,27 @@ const WasmServeArgs = struct {
     port: u16 = 8080,
     no_build: bool = false,
     no_open: bool = false,
+    // `wasm serve` runs the same resolve→generate→build pipeline as
+    // `labelle build`, so it carries the cli#284 progress feed too (the
+    // reporter marks the pipeline `done` before the interactive serve
+    // loop takes over).
+    progress_mode: progress.Mode = .human,
 };
 
 /// Parse the flags of `labelle wasm serve [dir] [--port <n>]
-/// [--no-build] [--no-open]`. `args` is `anytype` so tests can drive
-/// it with an in-memory `Args.IteratorGeneral`, mirroring
+/// [--no-build] [--no-open] [--progress=<m>]`. `args` is `anytype` so
+/// tests can drive it with an in-memory `Args.IteratorGeneral`, mirroring
 /// `parseRunArgs`.
 fn parseWasmServeArgs(args: anytype) ?WasmServeArgs {
     var result = WasmServeArgs{};
     var dir_set = false;
 
     while (args.next()) |arg| {
+        // Same tri-state idiom as parseRunArgs: consumed → next arg,
+        // not-a-progress-flag → fall through, bad value → parse error.
+        if (parseProgressFlag(arg, &result.progress_mode, "wasm serve")) |consumed| {
+            if (consumed) continue;
+        } else return null;
         if (std.mem.eql(u8, arg, "--no-build")) {
             result.no_build = true;
         } else if (std.mem.eql(u8, arg, "--no-open")) {
@@ -850,7 +860,7 @@ pub fn main(proc_init: std.process.Init) !void {
                 } else {
                     std.debug.print("labelle wasm: missing subcommand\n", .{});
                 }
-                std.debug.print("  usage: labelle wasm serve [dir] [--port <n>] [--no-build] [--no-open]\n", .{});
+                std.debug.print("  usage: labelle wasm serve [dir] [--port <n>] [--no-build] [--no-open] [--progress=<m>]\n", .{});
                 return;
             }
             parsed_args.command = .wasm_cmd;
@@ -859,6 +869,7 @@ pub fn main(proc_init: std.process.Init) !void {
             parsed_args.serve_port = result.port;
             parsed_args.serve_no_build = result.no_build;
             parsed_args.serve_no_open = result.no_open;
+            parsed_args.progress_mode = result.progress_mode;
             // `wasm serve` always builds/serves the WASM target.
             parsed_args.platform_override = .wasm;
         } else if (std.mem.eql(u8, first, "assembler")) {
@@ -2117,7 +2128,36 @@ pub const ParseWasmServeArgsSpec = struct {
             try expect.equal(result.port, @as(u16, 8080));
             try expect.equal(result.no_build, false);
             try expect.equal(result.no_open, false);
+            try expect.equal(result.progress_mode, progress.Mode.human);
             try std.testing.expectEqualStrings(".", result.dir);
+        }
+    };
+
+    // cli#284 review follow-up: `wasm serve` runs the same build pipeline,
+    // so `--progress=` must parse here too instead of dying in the
+    // unknown-flag branch.
+    pub const progress_flag = struct {
+        test "--progress=json is accepted and sets the mode" {
+            var iter = testIter("--progress=json");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.progress_mode, progress.Mode.json);
+        }
+
+        test "--progress=off combines with other flags" {
+            var iter = testIter("mygame --port 5000 --progress=off --no-open");
+            defer iter.deinit();
+            const result = parseWasmServeArgs(&iter) orelse return error.TestFailed;
+            try expect.equal(result.progress_mode, progress.Mode.off);
+            try expect.equal(result.port, @as(u16, 5000));
+            try expect.equal(result.no_open, true);
+            try std.testing.expectEqualStrings("mygame", result.dir);
+        }
+
+        test "invalid --progress value is rejected" {
+            var iter = testIter("--progress=verbose");
+            defer iter.deinit();
+            try std.testing.expect(parseWasmServeArgs(&iter) == null);
         }
     };
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2,8 +2,9 @@
 ///
 /// Usage:
 ///   labelle generate [dir] [--scene=name] [--optimize=MODE] — generate .labelle/ assembler files
-///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [--screenshot=<path> [--after=<dur>]] [-- <args>...] — generate + build + run; `--screenshot` captures a frame to <path> (raylib picks PNG/BMP by extension); `--` forwards trailing args to the game
-///   labelle build [dir] [--scene=name] [--optimize=MODE] — generate + build (no run)
+///   labelle run [dir] [--timeout=30s] [--scene=name] [--optimize=MODE] [--progress=json] [--screenshot=<path> [--after=<dur>]] [-- <args>...] — generate + build + run; `--screenshot` captures a frame to <path> (raylib picks PNG/BMP by extension); `--` forwards trailing args to the game
+///   labelle build [dir] [--scene=name] [--optimize=MODE] [--progress=json] — generate + build (no run)
+///   labelle status [dir] [--json]       — print the current/last build progress (reads .labelle/<target>/.build-progress.json)
 ///   labelle wasm serve [dir] [--port n] [--no-build] [--no-open] — build the WASM target and serve it locally
 ///   labelle [dir]                       — alias for `run`
 ///   labelle init <name> [dir]           — scaffold a new project
@@ -42,6 +43,8 @@ const ios = @import("cli/ios.zig");
 const android = @import("cli/android.zig");
 const util = @import("cli/util.zig");
 const pack = @import("cli/pack.zig");
+const progress = @import("cli/progress.zig");
+const status_mod = @import("cli/status.zig");
 const astc_cmd = @import("astc/cmd.zig");
 const audit = @import("cli/audit.zig");
 const migrate = @import("cli/migrate.zig");
@@ -49,7 +52,7 @@ const check = @import("cli/check.zig");
 const doctor = @import("cli/doctor.zig");
 const sdl_provision = @import("cli/sdl_provision.zig");
 
-const Command = enum { generate, build, run, init_cmd, add_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd, check_cmd, toolchain_cmd };
+const Command = enum { generate, build, run, init_cmd, add_cmd, install_cmd, upgrade_cmd, update_cmd, clean_cmd, ios_cmd, android_cmd, wasm_cmd, help_cmd, version, targets, assembler_cmd, test_cmd, pack_cmd, astc_cmd, audit_cmd, migrate_cmd, doctor_cmd, check_cmd, toolchain_cmd, status_cmd };
 
 const SceneResult = enum { not_scene, parsed, needs_next, err };
 
@@ -179,6 +182,12 @@ const ParsedArgs = struct {
     // `std.log.scoped(.profiler)`). Independent of `--headless` — you can
     // profile a windowed run too.
     profile: bool = false,
+    // `--progress=<mode>` (cli#284): how build/run progress is surfaced on
+    // the terminal — `human` (default; spinner on TTY stderr), `json`
+    // (NDJSON records on stdout for studio/CI), or `off`. The live status
+    // file `.labelle/<target>/.build-progress.json` is written in every
+    // mode (that's what `labelle status` reads).
+    progress_mode: progress.Mode = .human,
 };
 
 /// Parsed `wasm serve` flags. Returned by `parseWasmServeArgs`; `null`
@@ -333,6 +342,19 @@ fn parseToolchainFlag(arg: []const u8, args: anytype) ?bool {
     return parseEmccFlag(arg, args);
 }
 
+/// Try to parse `--progress=<mode>` (cli#284). Returns true if consumed,
+/// false if `arg` is not a `--progress` flag, and null on an invalid value.
+fn parseProgressFlag(arg: []const u8, mode: *progress.Mode, cmd_name: []const u8) ?bool {
+    if (!std.mem.startsWith(u8, arg, "--progress=")) return false;
+    const val = arg["--progress=".len..];
+    if (std.meta.stringToEnum(progress.Mode, val)) |m| {
+        mode.* = m;
+        return true;
+    }
+    std.debug.print("labelle {s}: unknown progress mode '{s}' (expected: human, json, off)\n", .{ cmd_name, val });
+    return null;
+}
+
 const valid_optimize_modes = [_][]const u8{ "Debug", "ReleaseSafe", "ReleaseFast", "ReleaseSmall" };
 
 /// Try to parse --optimize=<value> from an argument. Returns true if consumed,
@@ -362,8 +384,8 @@ fn parseOptimizeFlag(arg: []const u8, optimize: *?[]const u8, cmd_name: []const 
     return null;
 }
 
-/// Parse [dir], --scene, --platform, --optimize, --docker, and --target flags for generate/build commands.
-fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?struct { dir: []const u8, scene: ?[]const u8, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool } {
+/// Parse [dir], --scene, --platform, --optimize, --progress, --docker, and --target flags for generate/build commands.
+fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?struct { dir: []const u8, scene: ?[]const u8, platform: ?Platform, optimize: ?[]const u8, docker_build: bool, docker_target: ?[]const u8, bake: bool, progress_mode: progress.Mode } {
     var dir: []const u8 = ".";
     var dir_set = false;
     var scene: ?[]const u8 = null;
@@ -372,6 +394,7 @@ fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?str
     var docker_build = false;
     var docker_target: ?[]const u8 = null;
     var bake = false;
+    var progress_mode: progress.Mode = .human;
 
     while (args.next()) |arg| {
         switch (parseSceneFlag(arg, args, &scene, cmd_name)) {
@@ -382,6 +405,7 @@ fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?str
         }
         if (parsePlatformFlag(arg, &platform, cmd_name) orelse return null) continue;
         if (parseOptimizeFlag(arg, &optimize, cmd_name) orelse return null) continue;
+        if (parseProgressFlag(arg, &progress_mode, cmd_name) orelse return null) continue;
         if (std.mem.eql(u8, arg, "--docker")) {
             docker_build = true;
             continue;
@@ -414,7 +438,7 @@ fn parseDirAndScene(args: *std.process.Args.Iterator, cmd_name: []const u8) ?str
             dir_set = true;
         }
     }
-    return .{ .dir = dir, .scene = scene, .platform = platform, .optimize = optimize, .docker_build = docker_build, .docker_target = docker_target, .bake = bake };
+    return .{ .dir = dir, .scene = scene, .platform = platform, .optimize = optimize, .docker_build = docker_build, .docker_target = docker_target, .bake = bake, .progress_mode = progress_mode };
 }
 
 /// Parse [dir], --scene, --timeout, --platform, --optimize, --docker, and --target flags for run command (explicit or implicit).
@@ -456,6 +480,9 @@ fn parseRunArgs(args: anytype, cmd_name: []const u8, allow_dir: bool, parsed_arg
             if (consumed) continue;
         } else return null;
         if (parseOptimizeFlag(arg, &optimize, cmd_name)) |consumed| {
+            if (consumed) continue;
+        } else return null;
+        if (parseProgressFlag(arg, &parsed_args.progress_mode, cmd_name)) |consumed| {
             if (consumed) continue;
         } else return null;
         if (std.mem.eql(u8, arg, "--docker")) {
@@ -688,6 +715,7 @@ pub fn main(proc_init: std.process.Init) !void {
             parsed_args.docker = result.docker_build;
             parsed_args.docker_target = result.docker_target;
             parsed_args.bake = result.bake;
+            parsed_args.progress_mode = result.progress_mode;
         } else if (std.mem.eql(u8, first, "run")) {
             parsed_args.command = .run;
             const result = parseRunArgs(&args, "run", true, &parsed_args) orelse return;
@@ -756,6 +784,11 @@ pub fn main(proc_init: std.process.Init) !void {
         } else if (std.mem.eql(u8, first, "toolchain")) {
             // `labelle toolchain list|which` — managed Zig introspection (cli#279).
             parsed_args.command = .toolchain_cmd;
+            try collectExtraArgs(&args, &parsed_args);
+        } else if (std.mem.eql(u8, first, "status")) {
+            // `labelle status [dir] [--json]` — read the live build-progress
+            // status file from a second shell (cli#284).
+            parsed_args.command = .status_cmd;
             try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "doctor")) {
             parsed_args.command = .doctor_cmd;
@@ -876,6 +909,7 @@ pub fn main(proc_init: std.process.Init) !void {
         .doctor_cmd => return doctor.cmdDoctor(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .assembler_cmd => return handleAssemblerCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         .toolchain_cmd => return handleToolchainCmd(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
+        .status_cmd => return status_mod.cmdStatus(allocator, parsed_args.extra_args[0..parsed_args.extra_count]),
         else => {},
     }
 
@@ -998,6 +1032,44 @@ pub fn main(proc_init: std.process.Init) !void {
         return serve.serveAndOpen(allocator, web_dir, project_web_dir, parsed_args.serve_port, !parsed_args.serve_no_open);
     }
 
+    // ── Build-progress feed (cli#284) ──────────────────────────────────
+    // Target subdir: .labelle/raylib_desktop/, etc. Computed up front so
+    // the live status file `.labelle/<target>/.build-progress.json` has a
+    // home from the first `resolve` record onward (the dir is created by
+    // the reporter; the assembler generates into it later).
+    const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(parsed.backend), @tagName(parsed.platform) });
+    defer allocator.free(target_name);
+    const target_dir = try std.fs.path.join(allocator, &.{ project_dir, ".labelle", target_name });
+    defer allocator.free(target_dir);
+
+    // One event source, three access modes: NDJSON on stdout
+    // (`--progress=json`), the atomically-rewritten status file (all
+    // modes; read by `labelle status` + studio), and a spinner on TTY
+    // stderr (default human mode). Enabled for the commands that run the
+    // shared build pipeline; `labelle generate` and the ios/android
+    // subcommands (which own their own build flows) stay report-free. A
+    // reporter that fails to initialize downgrades to the pre-#284
+    // behavior instead of blocking the build.
+    var reporter_storage: progress.Reporter = undefined;
+    const reporter: ?*progress.Reporter = blk: {
+        if (command != .build and command != .run and command != .wasm_cmd) break :blk null;
+        reporter_storage = progress.Reporter.init(allocator, config.globalIo(), parsed_args.progress_mode, target_dir) catch break :blk null;
+        break :blk &reporter_storage;
+    };
+    defer if (reporter) |r| r.deinit();
+    // Any error path from here on marks the status file `failed`, so an
+    // out-of-band reader never sees a live phase for a dead build.
+    // (Pipeline code that terminates via process-exit instead of an error
+    // return goes through `progress.fatalExit`, which does the same.)
+    errdefer if (reporter) |r| r.failIfActive(1);
+    if (reporter) |r| {
+        // Registers the fatalExit hook + starts the keepalive ticker that
+        // refreshes elapsed/updated timestamps while child processes own
+        // the foreground (assembler, zig, game).
+        r.activate();
+        r.beginPhase(.resolve, "resolving toolchain + packages");
+    }
+
     // Validate version compatibility
     compatibility.validateCompatibility(parsed);
 
@@ -1057,6 +1129,7 @@ pub fn main(proc_init: std.process.Init) !void {
     // resolves it. The status line reports whether a GUI is *configured*
     // in project.labelle; the assembler logs the resolved plugin name.
     const gui_label: []const u8 = if (parsed.gui != null) "configured" else "none";
+    if (reporter) |r| r.beginPhase(.generate, "assembler generate");
     std.debug.print("labelle: generating '{s}'...\n", .{parsed.name});
     std.debug.print("  backend: {s}  platform: {s}  ecs: {s}  gui: {s}  window: {d}x{d}\n", .{
         @tagName(parsed.backend), @tagName(parsed.platform), @tagName(parsed.ecs), gui_label, parsed.width, parsed.height,
@@ -1103,11 +1176,8 @@ pub fn main(proc_init: std.process.Init) !void {
         @tagName(parsed.backend),
     );
 
-    // Target subdir: .labelle/raylib_desktop/, etc.
-    const target_name = try std.fmt.allocPrint(allocator, "{s}_{s}", .{ @tagName(parsed.backend), @tagName(parsed.platform) });
-    defer allocator.free(target_name);
-    const target_dir = try std.fs.path.join(allocator, &.{ output_dir, target_name });
-    defer allocator.free(target_dir);
+    // (`target_name`/`target_dir` — .labelle/raylib_desktop/, etc. — are
+    // computed up front, before the progress reporter init; see cli#284.)
 
     // fixFingerprints runs `zig build` locally per emitted target dir to
     // discover the correct hash. With assembler >=0.14.0 there are two
@@ -1187,10 +1257,31 @@ pub fn main(proc_init: std.process.Init) !void {
     if (optimize_flag) |flag| try zig_args.append(allocator, flag);
 
     if (parsed_args.docker) {
+        // Docker builds get phase-level progress only: the toolchain (and
+        // its progress pipe) lives inside the container.
+        if (reporter) |r| r.beginPhase(.compile, "docker build");
         std.debug.print("labelle: building via docker...\n", .{});
         const docker_exit = try docker.runBuild(allocator, target_dir, parsed.platform, parsed_args.docker_target, effective_optimize);
+        if (reporter) |r| r.clearSpinner();
         if (docker_exit != 0) {
+            if (reporter) |r| r.finishFailed(docker_exit, "docker build failed");
             std.debug.print("labelle: docker build failed (exit code {d})\n", .{docker_exit});
+            return error.BuildFailed;
+        }
+    } else if (reporter) |r| {
+        // cli#284: spawn `zig build` with Zig's std.Progress IPC pipe
+        // attached — live node names + keepalives flow into the feed
+        // during the compile (see runner.zig for what Zig 0.16 actually
+        // relays), and stdio is inherited so compile errors stream to the
+        // terminal unaltered (nothing is captured or eaten).
+        std.debug.print("labelle: building...\n", .{});
+        r.beginPhase(.compile, "zig build");
+        const build_code = try runner.runZigInheritProgress(allocator, target_dir, zig_args.items, zig_env_ptr, r);
+        // Wipe the spinner line before anything else prints on it.
+        r.clearSpinner();
+        if (build_code != 0) {
+            r.finishFailed(build_code, "zig build failed");
+            std.debug.print("labelle: build failed (exit {d})\n", .{build_code});
             return error.BuildFailed;
         }
     } else {
@@ -1236,12 +1327,16 @@ pub fn main(proc_init: std.process.Init) !void {
             defer allocator.free(apk_path);
             std.debug.print("labelle: APK ready: {s}\n", .{apk_path});
         }
+        if (reporter) |r| r.finishDone(0);
         return;
     }
 
     // Run
     if (parsed.platform == .wasm) {
-        // WASM: serve via local HTTP server + open browser
+        // WASM: serve via local HTTP server + open browser. The build
+        // pipeline is complete here — the serve loop is interactive (runs
+        // until Ctrl+C), so the terminal `done` record lands first.
+        if (reporter) |r| r.finishDone(0);
         const web_dir = try std.fs.path.join(allocator, &.{ target_dir, "zig-out", "web" });
         defer allocator.free(web_dir);
         const project_web_dir = try std.fs.path.join(allocator, &.{ project_dir, "web" });
@@ -1249,12 +1344,16 @@ pub fn main(proc_init: std.process.Init) !void {
         try serve.serveAndOpen(allocator, web_dir, project_web_dir, parsed_args.serve_port, !parsed_args.serve_no_open);
     } else if (parsed.platform == .ios) {
         // iOS: deploy to simulator
+        if (reporter) |r| r.beginPhase(.run, "deploying to iOS Simulator");
         std.debug.print("labelle: deploying to iOS Simulator...\n", .{});
         try ios.deployToSimulator(allocator, target_dir, parsed);
+        if (reporter) |r| r.finishDone(0);
     } else if (parsed.platform == .android) {
         // Android: deploy to device/emulator
+        if (reporter) |r| r.beginPhase(.run, "deploying to Android");
         std.debug.print("labelle: deploying to Android...\n", .{});
         try android.deployToDevice(allocator, target_dir, parsed, false, .{});
+        if (reporter) |r| r.finishDone(0);
     } else {
         if (timeout_ns) |t| {
             const secs = t / std.time.ns_per_s;
@@ -1344,6 +1443,7 @@ pub fn main(proc_init: std.process.Init) !void {
             if (parsed_args.docker_target) |t| {
                 std.debug.print("labelle: cannot run cross-compiled binary (target: {s})\n", .{t});
                 std.debug.print("  binary is at: {s}/zig-out/bin/\n", .{target_dir});
+                if (reporter) |r| r.finishDone(0); // build succeeded; run skipped
                 return;
             }
             // The assembler names the desktop binary after the project
@@ -1358,10 +1458,14 @@ pub fn main(proc_init: std.process.Init) !void {
             defer run_args.deinit(allocator);
             try run_args.append(allocator, bin_path);
             try appendRunForwardedArgs(&run_args, allocator, &parsed_args);
+            if (reporter) |r| r.beginPhase(.run, exe_name);
             const run_result = try runner.runZigInheritWithEnv(allocator, project_dir, run_args.items, timeout_ns, env_map_ptr);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }
+            // The game ran: the pipeline is `done` even on a nonzero game
+            // exit — the code is carried in the terminal record.
+            if (reporter) |r| r.finishDone(run_result);
         } else {
             // Build, then run the game BINARY DIRECTLY rather than via
             // `zig build run`. `zig build run` launches the game in its own
@@ -1375,8 +1479,13 @@ pub fn main(proc_init: std.process.Init) !void {
             // Build with no timeout (only the run is time-limited); keep the
             // game's cwd at `target_dir` (a target_dir-relative argv[0]) so
             // saves land exactly where `zig build run` put them.
+            // The main compile already ran under the `compile`/`link`
+            // phases above; this re-build is a warm-cache no-op, so it
+            // stays in the compile/link phase — `run` begins when the game
+            // binary is about to spawn.
             const build_result = try runner.runZigInheritWithEnv(allocator, target_dir, zig_args.items, null, env_map_ptr);
             if (build_result != 0) {
+                if (reporter) |r| r.finishFailed(build_result, "zig build failed");
                 std.debug.print("\nlabelle: build failed (exit {d})\n", .{build_result});
                 return;
             }
@@ -1398,10 +1507,14 @@ pub fn main(proc_init: std.process.Init) !void {
             defer run_args.deinit(allocator);
             try run_args.append(allocator, rel_bin);
             try appendRunForwardedArgs(&run_args, allocator, &parsed_args);
+            if (reporter) |r| r.beginPhase(.run, exe_basename);
             const run_result = try runner.runZigInheritWithEnv(allocator, target_dir, run_args.items, timeout_ns, env_map_ptr);
             if (run_result != 0) {
                 std.debug.print("\nlabelle: process exited with code {d}\n", .{run_result});
             }
+            // The game ran: the pipeline is `done` even on a nonzero game
+            // exit — the code is carried in the terminal record.
+            if (reporter) |r| r.finishDone(run_result);
         }
     }
 }
@@ -1729,6 +1842,18 @@ pub const MigrateDeleteTopLevelKeyBlockCommentSpec = migrate.DeleteTopLevelKeyBl
 // Surface the check-command spec namespace so `zspec.runAll(@This())`
 // walks into it (mirrors the audit/migrate re-exports above).
 pub const CheckParseCheckArgsSpec = check.ParseCheckArgsSpec;
+
+// Surface the build-progress feed specs (cli#284) so
+// `zspec.runAll(@This())` walks into them: the phase state machine,
+// NDJSON encoding, atomic status-file writes, the fake-build reporter
+// pipeline, the std.Progress IPC packet decoder, and `labelle status`
+// formatting.
+pub const ProgressPhaseMachineSpec = progress.PhaseMachineSpec;
+pub const ProgressNdjsonEncodingSpec = progress.NdjsonEncodingSpec;
+pub const ProgressAtomicStatusFileSpec = progress.AtomicStatusFileSpec;
+pub const ProgressReporterPipelineSpec = progress.ReporterPipelineSpec;
+pub const ZigProgressPacketDecodingSpec = @import("cli/zig_progress.zig").PacketDecodingSpec;
+pub const StatusFormatHumanSpec = status_mod.FormatHumanSpec;
 
 pub const ParsePlatformValueSpec = struct {
     pub const valid_platforms = struct {

--- a/src/cli/assembler_proc.zig
+++ b/src/cli/assembler_proc.zig
@@ -27,6 +27,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const assembler = @import("assembler.zig");
+const progress = @import("progress.zig");
 
 /// Global floor: every subcommand the CLI delegates needs at least this
 /// protocol (`install`/`clean`/`upgrade` arrived at protocol 2, `init` at
@@ -352,8 +353,11 @@ fn spawnAndWait(
             // proxy for the delegated subcommand — returning a plain
             // `error.AssemblerFailed` would collapse every distinct
             // failure (usage error, config error, build failure) to a
-            // single exit status 1.
-            std.process.exit(code);
+            // single exit status 1. `progress.fatalExit` (cli#284) first
+            // marks any active build-status file `failed` — a bare
+            // process-exit would skip the errdefer that does that and
+            // leave the status file claiming the build is still alive.
+            progress.fatalExit(code);
         },
         else => {
             std.debug.print("labelle: assembler '{s}' terminated abnormally\n", .{exe_path});

--- a/src/cli/compatibility.zig
+++ b/src/cli/compatibility.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const project_config = @import("project_config.zig");
+const progress = @import("progress.zig");
 
 /// Validate that declared dependency versions are compatible with each other.
 pub fn validateCompatibility(cfg: project_config.ProjectConfig) void {
@@ -9,7 +10,7 @@ pub fn validateCompatibility(cfg: project_config.ProjectConfig) void {
     if (cfg.platform == .wasm and cfg.backend != .raylib and cfg.backend != .sokol and cfg.backend != .bgfx) {
         std.debug.print("labelle: error: WASM builds are only supported with raylib, sokol, or bgfx backends (got {s})\n", .{@tagName(cfg.backend)});
         std.debug.print("  hint: set backend = \"raylib\", \"sokol\", or \"bgfx\" in project.labelle\n\n", .{});
-        std.process.exit(1);
+        progress.fatalExit(1);
     }
 
     const is_local = project_config.isLocalVersion;
@@ -63,25 +64,25 @@ fn validateStates(states: []const []const u8) void {
     if (states.len == 0) {
         std.debug.print("labelle: error: .states must contain at least one state\n", .{});
         std.debug.print("  hint: remove .states to use the default (\"running\"), or add at least one state name\n\n", .{});
-        std.process.exit(1);
+        progress.fatalExit(1);
     }
 
     for (states) |name| {
         if (name.len == 0) {
             std.debug.print("labelle: error: state name cannot be empty\n", .{});
-            std.process.exit(1);
+            progress.fatalExit(1);
         }
         // First character must be [a-z_] — digits would produce invalid Zig identifiers in codegen
         if (name[0] >= '0' and name[0] <= '9') {
             std.debug.print("labelle: error: state name \"{s}\" cannot start with a digit\n", .{name});
             std.debug.print("  hint: prefix with a letter (e.g., \"level_1\" not \"1_level\")\n\n", .{});
-            std.process.exit(1);
+            progress.fatalExit(1);
         }
         for (name) |c| {
             if (!((c >= 'a' and c <= 'z') or (c >= '0' and c <= '9') or c == '_')) {
                 std.debug.print("labelle: error: invalid state name \"{s}\" — must be lowercase alphanumeric with underscores [a-z0-9_]\n", .{name});
                 std.debug.print("  hint: rename to a valid identifier (e.g., \"main_menu\" not \"Main Menu\")\n\n", .{});
-                std.process.exit(1);
+                progress.fatalExit(1);
             }
         }
     }
@@ -91,7 +92,7 @@ fn validateStates(states: []const []const u8) void {
         for (states[i + 1 ..]) |other| {
             if (std.mem.eql(u8, name, other)) {
                 std.debug.print("labelle: error: duplicate state name \"{s}\" in .states\n", .{name});
-                std.process.exit(1);
+                progress.fatalExit(1);
             }
         }
     }

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -15,7 +15,7 @@ pub fn printHelp() void {
         \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--progress=<m>] [--docker] [--target=<t>]  Generate + build the project (`--progress=json` streams NDJSON progress records on stdout; modes: human, json, off)
         \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--progress=<m>] [--docker] [--target=<t>] [--screenshot=<path> [--after=<dur>]] [--headless] [--uncapped] [--ticks=<N>] [--profile] [-- <args>...]  Generate + build + run (default; `--screenshot` captures one frame; `--headless` runs windowless, `--uncapped` removes the frame sleep, `--ticks=<N>` exits after N frames — last two imply `--headless`; `--profile` enables the engine frame profiler (per-script/per-plugin ms to the log); `--` forwards trailing args to the game)
         \\  status [dir] [--json]  Print the current/last build progress from .labelle/<target>/.build-progress.json (works from a second shell while a build runs)
-        \\  wasm serve [dir] [--port <n>] [--no-build] [--no-open]  Build the WASM target, serve it locally (default port 8080), open the browser
+        \\  wasm serve [dir] [--port <n>] [--no-build] [--no-open] [--progress=<m>]  Build the WASM target, serve it locally (default port 8080), open the browser
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
         \\  install assembler <ver>  Download and cache an assembler binary

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -12,8 +12,9 @@ pub fn printHelp() void {
         \\  add pack <name>      Scaffold a pack (packs/<name>/ + pack.labelle)
         \\  add feature <kind> <name>  Scaffold a feature-unit (kind: need, role, status)
         \\  generate [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>]  Generate .labelle/ assembler files
-        \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>]  Generate + build the project
-        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--docker] [--target=<t>] [--screenshot=<path> [--after=<dur>]] [--headless] [--uncapped] [--ticks=<N>] [--profile] [-- <args>...]  Generate + build + run (default; `--screenshot` captures one frame; `--headless` runs windowless, `--uncapped` removes the frame sleep, `--ticks=<N>` exits after N frames — last two imply `--headless`; `--profile` enables the engine frame profiler (per-script/per-plugin ms to the log); `--` forwards trailing args to the game)
+        \\  build [dir] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--progress=<m>] [--docker] [--target=<t>]  Generate + build the project (`--progress=json` streams NDJSON progress records on stdout; modes: human, json, off)
+        \\  run [dir] [--timeout=<dur>] [--scene=<name>] [--platform=<p>] [--optimize=<mode>] [--progress=<m>] [--docker] [--target=<t>] [--screenshot=<path> [--after=<dur>]] [--headless] [--uncapped] [--ticks=<N>] [--profile] [-- <args>...]  Generate + build + run (default; `--screenshot` captures one frame; `--headless` runs windowless, `--uncapped` removes the frame sleep, `--ticks=<N>` exits after N frames — last two imply `--headless`; `--profile` enables the engine frame profiler (per-script/per-plugin ms to the log); `--` forwards trailing args to the game)
+        \\  status [dir] [--json]  Print the current/last build progress from .labelle/<target>/.build-progress.json (works from a second shell while a build runs)
         \\  wasm serve [dir] [--port <n>] [--no-build] [--no-open]  Build the WASM target, serve it locally (default port 8080), open the browser
         \\  targets              List available build targets
         \\  install [pkg] [ver]  Fetch packages into cache
@@ -38,6 +39,9 @@ pub fn printHelp() void {
         \\  labelle run
         \\  labelle run --timeout=30s
         \\  labelle run --scene=settings_menu
+        \\  labelle build --progress=json
+        \\  labelle status
+        \\  labelle status --json
         \\  labelle run --screenshot=/tmp/shot.png --after=2s
         \\  labelle run --headless --uncapped --ticks=600
         \\  labelle run --headless --uncapped --profile

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -1,0 +1,757 @@
+//! Structured build-progress feed (labelle-cli#284).
+//!
+//! One event source, three access modes:
+//!   - `--progress=json` — one NDJSON record per line on **stdout** for
+//!     programmatic consumers (labelle-studio's `spawn_build`, CI).
+//!   - a live status file `.labelle/<target>/.build-progress.json`,
+//!     atomically rewritten (temp + rename) with the CURRENT record so any
+//!     unrelated process can read build state mid-flight (`labelle status`,
+//!     studio's fs bridge). Written in ALL modes.
+//!   - the default human mode — a single-line terminal spinner during the
+//!     otherwise-silent `zig build` compile/link gap (TTY stderr only).
+//!
+//! The compile-phase step/total/detail granularity comes from Zig's native
+//! `std.Progress` IPC (see `zig_progress.zig`); this module is the pure
+//! phase model + fan-out sink and knows nothing about the wire format.
+//!
+//! Record schema (stable; additive changes only — studio#28 consumes it):
+//!   { "phase":"resolve|generate|compile|link|run|done|failed",
+//!     "step":int?, "total":int?, "percent":float?,
+//!     "detail":"...", "elapsed_ms":int,
+//!     "exit_code":int?, "updated_at_ms":int }
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Build phases in pipeline order, plus the two terminal states. A build
+/// may legally SKIP forward (e.g. no `link` granularity was detected, or a
+/// `labelle build` never enters `run`) but may never move backward, and
+/// terminal states absorb.
+pub const Phase = enum {
+    resolve,
+    generate,
+    compile,
+    link,
+    run,
+    done,
+    failed,
+
+    pub fn isTerminal(p: Phase) bool {
+        return p == .done or p == .failed;
+    }
+
+    fn rank(p: Phase) u8 {
+        return switch (p) {
+            .resolve => 0,
+            .generate => 1,
+            .compile => 2,
+            .link => 3,
+            .run => 4,
+            .done, .failed => 5,
+        };
+    }
+};
+
+/// One progress record — what a consumer sees per NDJSON line and what the
+/// status file holds at any instant. `null` means "unknown/not applicable".
+/// `exit_code` is populated on the terminal `done`/`failed` record (`done`
+/// carries the run's exit code for `labelle run`; `failed` the failing
+/// stage's). `updated_at_ms` is wall-clock unix ms of the write, so an
+/// out-of-band reader can tell "progressing" from "stale/dead".
+pub const Record = struct {
+    phase: Phase,
+    step: ?u64 = null,
+    total: ?u64 = null,
+    percent: ?f32 = null,
+    detail: []const u8 = "",
+    elapsed_ms: u64 = 0,
+    exit_code: ?u8 = null,
+    updated_at_ms: u64 = 0,
+};
+
+/// How the CLI surfaces progress. Parsed from `--progress=<mode>`.
+///   human — default; terminal spinner on TTY stderr, nothing when piped.
+///   json  — NDJSON records on stdout, no spinner.
+///   off   — no terminal output at all.
+/// The status file is written in every mode.
+pub const Mode = enum { human, json, off };
+
+/// Phase state machine. Pure — no I/O, no clock.
+pub const Machine = struct {
+    current: ?Phase = null,
+
+    pub const TransitionError = error{InvalidTransition};
+
+    /// Enforce the phase order: forward-only (skips allowed), `failed`
+    /// reachable from any non-terminal state (including before the first
+    /// phase), `done` from any started non-terminal state, terminal states
+    /// absorbing.
+    pub fn transition(m: *Machine, to: Phase) TransitionError!void {
+        if (m.current) |cur| {
+            if (cur.isTerminal()) return error.InvalidTransition;
+            switch (to) {
+                .done, .failed => {},
+                else => if (to.rank() <= cur.rank()) return error.InvalidTransition,
+            }
+        } else {
+            // Nothing has started yet: any working phase may open the
+            // pipeline, and an early setup error may fail it — but there
+            // is nothing to be "done" with.
+            if (to == .done) return error.InvalidTransition;
+        }
+        m.current = to;
+    }
+
+    pub fn isTerminal(m: *const Machine) bool {
+        return if (m.current) |c| c.isTerminal() else false;
+    }
+};
+
+/// Serialize one record as a single JSON line (no trailing newline) into
+/// `buf`. All keys are always present (`null` when unknown) so typed
+/// consumers get a stable shape. Pure; unit-tested.
+pub fn encodeRecord(buf: []u8, rec: Record) error{WriteFailed}![]const u8 {
+    var w = std.Io.Writer.fixed(buf);
+    try std.json.Stringify.value(rec, .{}, &w);
+    return w.buffered();
+}
+
+/// Atomically publish `bytes` at `final_path`: write `tmp_path` fully, then
+/// rename over the destination. A concurrent reader sees either the previous
+/// complete JSON document or the new one — never a torn write.
+pub fn writeFileAtomic(
+    io: std.Io,
+    final_path: []const u8,
+    tmp_path: []const u8,
+    bytes: []const u8,
+) !void {
+    const cwd = std.Io.Dir.cwd();
+    try cwd.writeFile(io, .{ .sub_path = tmp_path, .data = bytes });
+    try cwd.rename(tmp_path, cwd, final_path, io);
+}
+
+/// Basename of the live status file inside `.labelle/<target>/`.
+pub const status_file_name = ".build-progress.json";
+const status_tmp_name = ".build-progress.json.tmp";
+
+/// Longest `detail` we retain (a `std.Progress` node name is at most 120
+/// bytes; phase labels are shorter).
+pub const max_detail_len = 120;
+
+// Emission throttles (milliseconds). Phase transitions and terminal
+// records always flush immediately; these only pace the high-frequency
+// compile-phase updates (zig writes a snapshot ~every 80ms).
+const file_throttle_ms: u64 = 250;
+const json_change_throttle_ms: u64 = 200;
+const json_heartbeat_ms: u64 = 1000;
+const spinner_throttle_ms: u64 = 100;
+/// Keepalive ticker period: refreshes `elapsed_ms`/`updated_at_ms` while a
+/// child (assembler, zig, game) owns the foreground, so an out-of-band
+/// reader can distinguish "working" from "dead" in every phase.
+const ticker_period_ms: i64 = 500;
+
+/// The process-wide active reporter, registered by `Reporter.activate` and
+/// cleared by `Reporter.deinit`. Exists for one reason: some pipeline
+/// helpers terminate the CLI via `std.process.exit` to proxy a child's
+/// exact exit code (assembler delegation, compatibility validation), which
+/// skips every `errdefer` up the stack — including the one that marks the
+/// status file `failed`. Those sites call `fatalExit` instead, which
+/// notifies the active reporter first. Main-thread only.
+var active_reporter: ?*Reporter = null;
+
+/// Mark the active build `failed` (if a reporter is active) and terminate
+/// the process with `code`. Drop-in replacement for `std.process.exit` in
+/// code reachable from the build pipeline.
+pub fn fatalExit(code: u8) noreturn {
+    if (active_reporter) |r| r.failIfActive(code);
+    std.process.exit(code);
+}
+
+/// Fan-out sink: takes phase transitions from the CLI command flow and
+/// compile-granularity updates from the `std.Progress` pump thread, and
+/// drives all three access modes from that single source. Thread-safe (one
+/// internal mutex); does not allocate after `init`.
+pub const Reporter = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    mode: Mode,
+    /// `.labelle/<target>/<status_file_name>` (owned).
+    status_path: []u8,
+    /// Sibling temp path for the atomic rename (owned).
+    tmp_path: []u8,
+    start: std.Io.Timestamp,
+    stderr_is_tty: bool,
+
+    mutex: std.Io.Mutex = .init,
+    machine: Machine = .{},
+    step: ?u64 = null,
+    total: ?u64 = null,
+    exit_code: ?u8 = null,
+    detail_buf: [max_detail_len]u8 = undefined,
+    detail_len: usize = 0,
+
+    last_file_ms: u64 = 0,
+    last_json_ms: u64 = 0,
+    last_spin_ms: u64 = 0,
+    file_ever_written: bool = false,
+    json_ever_written: bool = false,
+    spinner_frame: usize = 0,
+    spinner_visible_len: usize = 0,
+
+    ticker: ?std.Thread = null,
+    ticker_stop: std.Io.Event = .unset,
+
+    const spinner_frames = [_]u8{ '|', '/', '-', '\\' };
+
+    /// `target_dir` is `.labelle/<backend>_<platform>` relative to (or
+    /// absolute under) the project; it is created if missing so the status
+    /// file exists from the first `resolve` record onward — before the
+    /// assembler has generated anything.
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        mode: Mode,
+        target_dir: []const u8,
+    ) !Reporter {
+        std.Io.Dir.cwd().createDirPath(io, target_dir) catch {};
+        const status_path = try std.fs.path.join(allocator, &.{ target_dir, status_file_name });
+        errdefer allocator.free(status_path);
+        const tmp_path = try std.fs.path.join(allocator, &.{ target_dir, status_tmp_name });
+        errdefer allocator.free(tmp_path);
+        const is_tty = std.Io.File.stderr().isTty(io) catch false;
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .mode = mode,
+            .status_path = status_path,
+            .tmp_path = tmp_path,
+            .start = std.Io.Timestamp.now(io, .awake),
+            .stderr_is_tty = is_tty,
+        };
+    }
+
+    /// Register as the process-wide reporter (see `fatalExit`) and start
+    /// the keepalive ticker. Call once, after the reporter sits at its
+    /// final address — `init` returns by value, so the ticker thread must
+    /// not capture the pre-move location.
+    pub fn activate(self: *Reporter) void {
+        active_reporter = self;
+        self.ticker = std.Thread.spawn(.{}, tickerMain, .{self}) catch null;
+    }
+
+    pub fn deinit(self: *Reporter) void {
+        self.ticker_stop.set(self.io);
+        if (self.ticker) |t| t.join();
+        if (active_reporter == self) active_reporter = null;
+        self.allocator.free(self.status_path);
+        self.allocator.free(self.tmp_path);
+    }
+
+    /// Keepalive loop: refresh the sinks every `ticker_period_ms` until
+    /// `deinit` sets the stop event. Heartbeats no-op once terminal.
+    fn tickerMain(self: *Reporter) void {
+        const timeout: std.Io.Timeout = .{ .duration = .{
+            .clock = .awake,
+            .raw = .fromMilliseconds(ticker_period_ms),
+        } };
+        while (true) {
+            if (self.ticker_stop.waitTimeout(self.io, timeout)) |_| {
+                return; // stop event set
+            } else |err| switch (err) {
+                error.Timeout => self.heartbeat(),
+                error.Canceled => return,
+            }
+        }
+    }
+
+    /// Enter a pipeline phase. Illegal transitions (programmer error) are
+    /// dropped rather than crashing a build that is otherwise working.
+    pub fn beginPhase(self: *Reporter, phase: Phase, detail: []const u8) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.machine.transition(phase) catch return;
+        self.step = null;
+        self.total = null;
+        self.setDetailLocked(detail);
+        self.emitLocked(true, true);
+    }
+
+    /// Compile-granularity update from the zig `std.Progress` pump thread.
+    /// `saw_link` flips `compile` → `link` (forward-only; enforced by the
+    /// machine). No-op outside the compile/link phases.
+    pub fn compileUpdate(self: *Reporter, step: ?u64, total: ?u64, detail: []const u8, saw_link: bool) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        const cur = self.machine.current orelse return;
+        if (cur != .compile and cur != .link) return;
+        const entered_link = saw_link and cur == .compile;
+        if (entered_link) {
+            self.machine.transition(.link) catch {};
+        }
+        const changed = entered_link or
+            !std.meta.eql(step, self.step) or
+            !std.meta.eql(total, self.total) or
+            !std.mem.eql(u8, detail, self.detailSliceLocked());
+        self.step = step;
+        self.total = total;
+        self.setDetailLocked(detail);
+        // The link transition is a phase change and flushes immediately;
+        // ordinary within-phase updates ride the per-sink throttles (zig
+        // sends a snapshot ~every 80ms — no consumer needs them all).
+        self.emitLocked(entered_link, changed);
+    }
+
+    /// Periodic tick while a child is running and no packet arrived —
+    /// refreshes `elapsed_ms`/spinner so "alive but quiet" is visible.
+    pub fn heartbeat(self: *Reporter) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        if (self.machine.isTerminal()) return;
+        self.emitLocked(false, false);
+    }
+
+    /// Terminal success record. `exit_code` is the exit status of the last
+    /// stage (0 for a plain build; the game's exit code for `labelle run`).
+    pub fn finishDone(self: *Reporter, exit_code: u8) void {
+        self.finishWith(.done, exit_code, "");
+    }
+
+    /// Terminal failure record carrying the failing stage's exit code.
+    pub fn finishFailed(self: *Reporter, exit_code: u8, detail: []const u8) void {
+        self.finishWith(.failed, exit_code, detail);
+    }
+
+    /// Wipe the spinner line (no-op when nothing is drawn) so a subsequent
+    /// plain print starts on a clean column. Called at the compile → next
+    /// output seam; terminal records clear it themselves.
+    pub fn clearSpinner(self: *Reporter) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.clearSpinnerLocked();
+    }
+
+    /// errdefer hook: mark `failed` unless a terminal record was already
+    /// emitted. Keeps the status file truthful on any early-error path.
+    pub fn failIfActive(self: *Reporter, exit_code: u8) void {
+        self.mutex.lockUncancelable(self.io);
+        const terminal = self.machine.isTerminal();
+        self.mutex.unlock(self.io);
+        if (!terminal) self.finishFailed(exit_code, "error");
+    }
+
+    fn finishWith(self: *Reporter, phase: Phase, exit_code: u8, detail: []const u8) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        if (self.machine.isTerminal()) return;
+        self.machine.transition(phase) catch return;
+        self.exit_code = exit_code;
+        if (detail.len > 0) self.setDetailLocked(detail);
+        self.emitLocked(true, true);
+        self.clearSpinnerLocked();
+    }
+
+    // ── Internals (mutex held) ──────────────────────────────────────────
+
+    fn setDetailLocked(self: *Reporter, detail: []const u8) void {
+        const n = @min(detail.len, self.detail_buf.len);
+        @memcpy(self.detail_buf[0..n], detail[0..n]);
+        self.detail_len = n;
+    }
+
+    fn detailSliceLocked(self: *const Reporter) []const u8 {
+        return self.detail_buf[0..self.detail_len];
+    }
+
+    fn elapsedMs(self: *const Reporter) u64 {
+        const now = std.Io.Timestamp.now(self.io, .awake);
+        const ms = self.start.durationTo(now).toMilliseconds();
+        return if (ms > 0) @intCast(ms) else 0;
+    }
+
+    fn wallMs(self: *const Reporter) u64 {
+        const ms = std.Io.Timestamp.now(self.io, .real).toMilliseconds();
+        return if (ms > 0) @intCast(ms) else 0;
+    }
+
+    fn recordLocked(self: *const Reporter, elapsed: u64) Record {
+        const percent: ?f32 = blk: {
+            const s = self.step orelse break :blk null;
+            const t = self.total orelse break :blk null;
+            if (t == 0) break :blk null;
+            const p = @as(f32, @floatFromInt(s)) / @as(f32, @floatFromInt(t)) * 100.0;
+            break :blk @round(@min(p, 100.0) * 10.0) / 10.0;
+        };
+        return .{
+            .phase = self.machine.current orelse .resolve,
+            .step = self.step,
+            .total = self.total,
+            .percent = percent,
+            .detail = self.detailSliceLocked(),
+            .elapsed_ms = elapsed,
+            .exit_code = self.exit_code,
+            .updated_at_ms = self.wallMs(),
+        };
+    }
+
+    /// Fan one record out to the three sinks, honoring per-sink throttles.
+    /// `force` (phase transitions, terminal records) bypasses throttling
+    /// for the NDJSON stream and the status file. `changed` marks a record
+    /// whose data differs from the last one: changes stream at up to
+    /// 1/200ms, while pure keepalives (elapsed only) drop to 1/s.
+    fn emitLocked(self: *Reporter, force: bool, changed: bool) void {
+        const elapsed = self.elapsedMs();
+        var enc_buf: [512 + max_detail_len * 6]u8 = undefined;
+        const line = encodeRecord(&enc_buf, self.recordLocked(elapsed)) catch return;
+
+        if (self.mode == .json) {
+            const due_change = changed and elapsed >= self.last_json_ms + json_change_throttle_ms;
+            const due_heartbeat = elapsed >= self.last_json_ms + json_heartbeat_ms;
+            if (force or due_change or due_heartbeat or !self.json_ever_written) {
+                self.writeJsonLine(line);
+                self.last_json_ms = elapsed;
+                self.json_ever_written = true;
+            }
+        }
+
+        if (force or !self.file_ever_written or elapsed >= self.last_file_ms + file_throttle_ms) {
+            writeFileAtomic(self.io, self.status_path, self.tmp_path, line) catch {};
+            self.last_file_ms = elapsed;
+            self.file_ever_written = true;
+        }
+
+        if (self.mode == .human and self.stderr_is_tty) {
+            if (force or elapsed >= self.last_spin_ms + spinner_throttle_ms) {
+                self.drawSpinnerLocked(elapsed);
+                self.last_spin_ms = elapsed;
+            }
+        }
+    }
+
+    fn writeJsonLine(self: *Reporter, line: []const u8) void {
+        // MUST be a *streaming* writer: the positional variant tracks its
+        // own offset starting at 0, so with stdout redirected to a file
+        // every record would overwrite the first line (found by the #284
+        // smoke test). Streaming writes append at the fd's own offset.
+        var w = std.Io.File.stdout().writerStreaming(self.io, &.{});
+        var vec = [2][]const u8{ line, "\n" };
+        w.interface.writeVecAll(&vec) catch return;
+        w.interface.flush() catch return;
+    }
+
+    /// Single-line spinner on TTY stderr. Only during compile/link — in the
+    /// other phases a child process (assembler, game) owns the terminal and
+    /// a rewriting line would fight its output. No ANSI escapes: the line is
+    /// cleared by overwriting with spaces, so it renders anywhere.
+    fn drawSpinnerLocked(self: *Reporter, elapsed: u64) void {
+        const phase = self.machine.current orelse return;
+        if (phase != .compile and phase != .link) {
+            self.clearSpinnerLocked();
+            return;
+        }
+        var line_buf: [160]u8 = undefined;
+        var w = std.Io.Writer.fixed(&line_buf);
+        const frame = spinner_frames[self.spinner_frame % spinner_frames.len];
+        self.spinner_frame +%= 1;
+        const secs = @as(f64, @floatFromInt(elapsed)) / 1000.0;
+        w.print("{c} {s}", .{ frame, @tagName(phase) }) catch {};
+        if (self.step) |s| {
+            if (self.total) |t| {
+                w.print(" [{d}/{d}]", .{ s, t }) catch {};
+            } else {
+                w.print(" [{d}]", .{s}) catch {};
+            }
+        }
+        if (self.detail_len > 0) w.print(" {s}", .{self.detailSliceLocked()}) catch {};
+        w.print(" ({d:.1}s)", .{secs}) catch {};
+        const line = w.buffered();
+
+        var out: [256]u8 = undefined;
+        var ow = std.Io.Writer.fixed(&out);
+        ow.writeAll("\r") catch return;
+        ow.writeAll(line) catch return;
+        // Overwrite any residue from a longer previous line.
+        if (self.spinner_visible_len > line.len) {
+            const pad = @min(self.spinner_visible_len - line.len, out.len - ow.buffered().len);
+            for (0..pad) |_| ow.writeAll(" ") catch break;
+            ow.writeAll("\r") catch {};
+            // Re-draw so the cursor parks at the end of the live text.
+            ow.writeAll(line) catch {};
+        }
+        std.debug.print("{s}", .{ow.buffered()});
+        self.spinner_visible_len = line.len;
+    }
+
+    fn clearSpinnerLocked(self: *Reporter) void {
+        if (self.spinner_visible_len == 0) return;
+        var out: [200]u8 = undefined;
+        var ow = std.Io.Writer.fixed(&out);
+        ow.writeAll("\r") catch return;
+        const pad = @min(self.spinner_visible_len, out.len - 2);
+        for (0..pad) |_| ow.writeAll(" ") catch break;
+        ow.writeAll("\r") catch {};
+        std.debug.print("{s}", .{ow.buffered()});
+        self.spinner_visible_len = 0;
+    }
+};
+
+// --- Tests ---
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+const expect = @import("zspec").expect;
+
+pub const PhaseMachineSpec = struct {
+    pub const legal_order = struct {
+        test "walks the full pipeline in order" {
+            var m = Machine{};
+            try m.transition(.resolve);
+            try m.transition(.generate);
+            try m.transition(.compile);
+            try m.transition(.link);
+            try m.transition(.run);
+            try m.transition(.done);
+            try expect.equal(m.current.?, Phase.done);
+        }
+
+        test "skipping forward is legal (no link granularity, build-only)" {
+            var m = Machine{};
+            try m.transition(.resolve);
+            try m.transition(.compile); // skipped generate
+            try m.transition(.done); // skipped link + run
+        }
+
+        test "failed is reachable from any working phase" {
+            var m = Machine{};
+            try m.transition(.generate);
+            try m.transition(.failed);
+            try expect.equal(m.current.?, Phase.failed);
+        }
+
+        test "failed is reachable before the first phase (early setup error)" {
+            var m = Machine{};
+            try m.transition(.failed);
+        }
+    };
+
+    pub const illegal_moves = struct {
+        test "moving backward is rejected" {
+            var m = Machine{};
+            try m.transition(.link);
+            try std.testing.expectError(error.InvalidTransition, m.transition(.compile));
+        }
+
+        test "re-entering the current phase is rejected" {
+            var m = Machine{};
+            try m.transition(.compile);
+            try std.testing.expectError(error.InvalidTransition, m.transition(.compile));
+        }
+
+        test "done before anything started is rejected" {
+            var m = Machine{};
+            try std.testing.expectError(error.InvalidTransition, m.transition(.done));
+        }
+    };
+
+    pub const terminal_states = struct {
+        test "done absorbs" {
+            var m = Machine{};
+            try m.transition(.run);
+            try m.transition(.done);
+            try std.testing.expectError(error.InvalidTransition, m.transition(.run));
+            try std.testing.expectError(error.InvalidTransition, m.transition(.failed));
+            try expect.toBeTrue(m.isTerminal());
+        }
+
+        test "failed absorbs" {
+            var m = Machine{};
+            try m.transition(.compile);
+            try m.transition(.failed);
+            try std.testing.expectError(error.InvalidTransition, m.transition(.done));
+            try expect.toBeTrue(m.isTerminal());
+        }
+    };
+};
+
+pub const NdjsonEncodingSpec = struct {
+    test "encodes a full record as one valid JSON line" {
+        var buf: [1024]u8 = undefined;
+        const line = try encodeRecord(&buf, .{
+            .phase = .compile,
+            .step = 34,
+            .total = 210,
+            .percent = 16.2,
+            .detail = "engine.zig",
+            .elapsed_ms = 12345,
+            .exit_code = null,
+            .updated_at_ms = 1700000000000,
+        });
+        // One line: no embedded newline.
+        try std.testing.expect(std.mem.indexOfScalar(u8, line, '\n') == null);
+
+        const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, line, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+        try std.testing.expectEqualStrings("compile", obj.get("phase").?.string);
+        try expect.equal(obj.get("step").?.integer, @as(i64, 34));
+        try expect.equal(obj.get("total").?.integer, @as(i64, 210));
+        try std.testing.expectEqualStrings("engine.zig", obj.get("detail").?.string);
+        try expect.equal(obj.get("elapsed_ms").?.integer, @as(i64, 12345));
+        // Unknowns serialize as explicit null so the shape is stable.
+        try std.testing.expect(obj.get("exit_code").? == .null);
+    }
+
+    test "escapes JSON-hostile detail strings" {
+        var buf: [1024]u8 = undefined;
+        const line = try encodeRecord(&buf, .{
+            .phase = .failed,
+            .detail = "quote\" backslash\\ newline\n",
+            .exit_code = 2,
+        });
+        const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, line, .{});
+        defer parsed.deinit();
+        try std.testing.expectEqualStrings(
+            "quote\" backslash\\ newline\n",
+            parsed.value.object.get("detail").?.string,
+        );
+        try expect.equal(parsed.value.object.get("exit_code").?.integer, @as(i64, 2));
+    }
+
+    test "terminal record carries phase failed and exit code" {
+        var buf: [1024]u8 = undefined;
+        const line = try encodeRecord(&buf, .{ .phase = .failed, .exit_code = 1, .elapsed_ms = 7 });
+        const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, line, .{});
+        defer parsed.deinit();
+        try std.testing.expectEqualStrings("failed", parsed.value.object.get("phase").?.string);
+        try expect.equal(parsed.value.object.get("exit_code").?.integer, @as(i64, 1));
+    }
+};
+
+pub const AtomicStatusFileSpec = struct {
+    test "temp file is renamed over the destination and remains parseable" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const io = std.testing.io;
+
+        var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const n = try tmp.dir.realPath(io, &path_buf);
+        const base = path_buf[0..n];
+
+        const final_path = try std.fs.path.join(std.testing.allocator, &.{ base, status_file_name });
+        defer std.testing.allocator.free(final_path);
+        const tmp_path = try std.fs.path.join(std.testing.allocator, &.{ base, status_tmp_name });
+        defer std.testing.allocator.free(tmp_path);
+
+        // First write.
+        try writeFileAtomic(io, final_path, tmp_path, "{\"phase\":\"resolve\"}");
+        // Overwrite (the mid-build rewrite path).
+        try writeFileAtomic(io, final_path, tmp_path, "{\"phase\":\"compile\"}");
+
+        const got = try std.Io.Dir.cwd().readFileAlloc(io, final_path, std.testing.allocator, .limited(4096));
+        defer std.testing.allocator.free(got);
+        try std.testing.expectEqualStrings("{\"phase\":\"compile\"}", got);
+
+        // The temp file must not linger after a successful publish.
+        try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, tmp_path, .{}));
+    }
+};
+
+/// Integration-ish: drive the reporter through a fake build and assert the
+/// status file advances through the phases and lands terminal — the exact
+/// contract `labelle status` and studio#28 rely on.
+pub const ReporterPipelineSpec = struct {
+    fn readPhase(io: std.Io, allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+        const raw = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024));
+        defer allocator.free(raw);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+        defer parsed.deinit();
+        return allocator.dupe(u8, parsed.value.object.get("phase").?.string);
+    }
+
+    test "fake build: resolve → generate → compile updates → done, status file tracks" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const io = std.testing.io;
+        const allocator = std.testing.allocator;
+
+        var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const n = try tmp.dir.realPath(io, &path_buf);
+        const target_dir = try std.fs.path.join(allocator, &.{ path_buf[0..n], "raylib_desktop" });
+        defer allocator.free(target_dir);
+
+        var rep = try Reporter.init(allocator, io, .off, target_dir);
+        defer rep.deinit();
+
+        rep.beginPhase(.resolve, "resolving packages");
+        {
+            const phase = try readPhase(io, allocator, rep.status_path);
+            defer allocator.free(phase);
+            try std.testing.expectEqualStrings("resolve", phase);
+        }
+
+        rep.beginPhase(.generate, "assembler generate");
+        rep.beginPhase(.compile, "zig build");
+        rep.compileUpdate(3, 10, "game.zig", false);
+        rep.compileUpdate(9, 10, "linking game", true); // flips to link
+        {
+            const phase = try readPhase(io, allocator, rep.status_path);
+            defer allocator.free(phase);
+            try std.testing.expectEqualStrings("link", phase);
+        }
+
+        rep.beginPhase(.run, "game");
+        rep.finishDone(0);
+        {
+            const raw = try std.Io.Dir.cwd().readFileAlloc(io, rep.status_path, allocator, .limited(64 * 1024));
+            defer allocator.free(raw);
+            const parsed = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+            defer parsed.deinit();
+            try std.testing.expectEqualStrings("done", parsed.value.object.get("phase").?.string);
+            try expect.equal(parsed.value.object.get("exit_code").?.integer, @as(i64, 0));
+        }
+
+        // Terminal absorbs: further updates must not resurrect the build.
+        rep.compileUpdate(1, 2, "zombie", false);
+        rep.finishFailed(1, "late");
+        {
+            const phase = try readPhase(io, allocator, rep.status_path);
+            defer allocator.free(phase);
+            try std.testing.expectEqualStrings("done", phase);
+        }
+    }
+
+    test "failure path: compile error ends failed with the zig exit code" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const io = std.testing.io;
+        const allocator = std.testing.allocator;
+
+        var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const n = try tmp.dir.realPath(io, &path_buf);
+        const target_dir = try std.fs.path.join(allocator, &.{ path_buf[0..n], "bgfx_desktop" });
+        defer allocator.free(target_dir);
+
+        var rep = try Reporter.init(allocator, io, .off, target_dir);
+        defer rep.deinit();
+
+        rep.beginPhase(.resolve, "");
+        rep.beginPhase(.compile, "zig build");
+        rep.finishFailed(2, "zig build failed");
+
+        const raw = try std.Io.Dir.cwd().readFileAlloc(io, rep.status_path, allocator, .limited(64 * 1024));
+        defer allocator.free(raw);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+        defer parsed.deinit();
+        try std.testing.expectEqualStrings("failed", parsed.value.object.get("phase").?.string);
+        try expect.equal(parsed.value.object.get("exit_code").?.integer, @as(i64, 2));
+
+        // failIfActive after an explicit terminal record is a no-op.
+        rep.failIfActive(9);
+        const raw2 = try std.Io.Dir.cwd().readFileAlloc(io, rep.status_path, allocator, .limited(64 * 1024));
+        defer allocator.free(raw2);
+        const parsed2 = try std.json.parseFromSlice(std.json.Value, allocator, raw2, .{});
+        defer parsed2.deinit();
+        try expect.equal(parsed2.value.object.get("exit_code").?.integer, @as(i64, 2));
+    }
+};

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -5,6 +5,8 @@ const zig_toolchain = @import("zig_toolchain.zig");
 const zig_cache = @import("zig_cache.zig");
 const emsdk_toolchain = @import("emsdk_toolchain.zig");
 const emsdk_cache = @import("emsdk_cache.zig");
+const progress = @import("progress.zig");
+const zig_progress = @import("zig_progress.zig");
 const is_windows = builtin.os.tag == .windows;
 
 /// Resolve the managed `zig` binary for `project_dir` (labelle-cli#279).
@@ -274,6 +276,233 @@ pub fn runZigInheritWithEnv(
     };
 }
 
+// ── Progress-attached build spawn (labelle-cli#284) ─────────────────────
+//
+// A Zig process spawned with `ZIG_PROGRESS=<fd>` in its environment
+// reports its progress tree over that pipe (std.Progress IPC) instead of
+// rendering to the terminal. The functions below attach that pipe to the
+// `zig build` child and pump the decoded snapshots into a
+// `progress.Reporter` (NDJSON / status file / spinner).
+//
+// What actually flows (empirical, Zig 0.16.0): a *compiler* process
+// (`zig build-exe`) streams its full node tree — "Semantic Analysis",
+// "Code Generation", "Linking" with real counts. The `zig build`
+// *frontend*, however, only streams its own nodes ("Compile Build
+// Script"); it hands the build runner a separate `-Z` integration handle
+// and does not fold the runner's steps/compile subtree into its
+// ZIG_PROGRESS packets. So today the feed gets live node names +
+// keepalives from the frontend, while `step`/`total` stay null for `zig
+// build`. `zig_progress.Parser` already decodes the full multi-node
+// format (incl. the runner's "steps" node — unit-tested against
+// synthesized packets), so richer data lights up without code changes if
+// a future Zig relays it.
+//
+// Why the `/usr/bin/env ZIG_PROGRESS=<fd>` argv wrapper instead of putting
+// the var in `environ_map`: `std.process.spawn` actively *strips* a
+// `ZIG_PROGRESS` key from any user-supplied env block unless it manages
+// the pipe itself via `options.progress_node` (see
+// `Environ.Map.createPosixBlock` — a stale inherited fd number would be
+// bogus, so std scrubs it). `progress_node` in turn requires a running
+// `std.Progress` instance whose tree is not readable from outside std. The
+// wrapper sets the variable *after* the env block is materialized, in the
+// exec'd child itself, dodging the scrub while keeping the whole standard
+// spawn path (cwd handling, spawn-failure reporting, etc.).
+//
+// The write end of the pipe has CLOEXEC cleared so it survives the
+// `env` → `zig` execs. Windows passes handles instead of fd numbers and
+// has no `env(1)`, so it (and any pipe/spawn failure) falls back to
+// phase-level heartbeats — same schema, just no node names.
+
+/// Shared state between the spawning thread and the progress pump thread.
+const PumpCtx = struct {
+    fd: std.posix.fd_t,
+    reporter: *progress.Reporter,
+    /// Set after `child.wait` returns; the pump drains remaining packets
+    /// and exits on the next empty read.
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// `LABELLE_PROGRESS_DEBUG=1`: log each new node name to stderr —
+    /// handy for tuning the link heuristic / studio integration.
+    debug: bool = false,
+};
+
+/// Read the `ZIG_PROGRESS` pipe until EOF (all write ends closed — child
+/// tree exited) or until `stop` is set and the pipe is drained. Feeds
+/// decoded snapshots into the reporter; emits heartbeats while the pipe is
+/// quiet so `elapsed_ms` (and the spinner) stay live.
+fn pumpZigProgress(ctx: *PumpCtx) void {
+    var parser = zig_progress.Parser{};
+    var read_buf: [4096]u8 = undefined;
+    var last_detail: [zig_progress.max_name_len]u8 = undefined;
+    var last_detail_len: usize = 0;
+    while (true) {
+        const n = std.posix.read(ctx.fd, &read_buf) catch |err| switch (err) {
+            error.WouldBlock => {
+                if (ctx.stop.load(.acquire)) return;
+                ctx.reporter.heartbeat();
+                sleepNanos(80 * std.time.ns_per_ms);
+                continue;
+            },
+            else => return,
+        };
+        if (n == 0) return; // EOF
+        parser.feed(read_buf[0..n]);
+        const snap = parser.poll() orelse continue;
+        ctx.reporter.compileUpdate(snap.step, snap.total, snap.detail(), snap.saw_link);
+        if (ctx.debug and !std.mem.eql(u8, snap.detail(), last_detail[0..last_detail_len])) {
+            std.debug.print("labelle-progress: node \"{s}\" [{?d}/{?d}] link={}\n", .{
+                snap.detail(), snap.step, snap.total, snap.saw_link,
+            });
+            last_detail_len = snap.detail().len;
+            @memcpy(last_detail[0..last_detail_len], snap.detail());
+        }
+    }
+}
+
+/// Create the progress pipe: read end parent-only (CLOEXEC) and
+/// nonblocking (the pump polls it), write end inheritable (no CLOEXEC —
+/// it must survive the exec) and nonblocking (a stalled parent must never
+/// block the compiler; matches how std's own spawn configures it).
+fn makeProgressPipe() ?[2]std.posix.fd_t {
+    var fds: [2]std.posix.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) return null;
+    _ = std.posix.system.fcntl(fds[0], std.posix.F.SETFD, @as(usize, std.posix.FD_CLOEXEC));
+    setNonblocking(fds[0]);
+    setNonblocking(fds[1]);
+    return fds;
+}
+
+fn setNonblocking(fd: std.posix.fd_t) void {
+    const fl = std.posix.system.fcntl(fd, std.posix.F.GETFL, @as(usize, 0));
+    if (fl < 0) return;
+    const nonblock: u32 = @bitCast(std.c.O{ .NONBLOCK = true });
+    _ = std.posix.system.fcntl(fd, std.posix.F.SETFL, @as(usize, @intCast(fl)) | nonblock);
+}
+
+fn closeFd(fd: std.posix.fd_t) void {
+    _ = std.c.close(fd);
+}
+
+fn termToExitCode(term: anytype) u8 {
+    return switch (term) {
+        .exited => |code| code,
+        .signal => |sig| blk: {
+            std.debug.print("labelle: killed by signal {d}\n", .{@intFromEnum(sig)});
+            break :blk 1;
+        },
+        .stopped => |sig| blk: {
+            std.debug.print("labelle: stopped by signal {d}\n", .{@intFromEnum(sig)});
+            break :blk 1;
+        },
+        .unknown => |val| blk: {
+            std.debug.print("labelle: unknown termination {d}\n", .{val});
+            break :blk 1;
+        },
+    };
+}
+
+/// Like `runZigInheritWithEnv` (inherited stdio — compile errors stream to
+/// the terminal unaltered), but attaches Zig's `std.Progress` IPC pipe and
+/// folds the decoded step/total/current-unit updates into `reporter`'s
+/// compile/link phases. Falls back to phase-level heartbeats when the pipe
+/// can't be attached (Windows, no `/usr/bin/env`, pipe failure).
+pub fn runZigInheritProgress(
+    allocator: std.mem.Allocator,
+    cwd: []const u8,
+    argv: []const []const u8,
+    environ_map: ?*const std.process.Environ.Map,
+    reporter: *progress.Reporter,
+) !u8 {
+    if (comptime is_windows) {
+        // ZIG_PROGRESS on Windows carries a HANDLE value that must be
+        // injected by the spawner itself; there is no wrapper trick.
+        return runZigInheritHeartbeat(allocator, cwd, argv, environ_map, reporter);
+    }
+    const fds = makeProgressPipe() orelse
+        return runZigInheritHeartbeat(allocator, cwd, argv, environ_map, reporter);
+
+    var fd_env_buf: [32]u8 = undefined;
+    const fd_env = std.fmt.bufPrint(&fd_env_buf, "ZIG_PROGRESS={d}", .{fds[1]}) catch unreachable;
+
+    var wrapped: std.ArrayList([]const u8) = .empty;
+    defer wrapped.deinit(allocator);
+    try wrapped.append(allocator, "/usr/bin/env");
+    try wrapped.append(allocator, fd_env);
+    try wrapped.appendSlice(allocator, argv);
+
+    const io = config.globalIo();
+    var child = std.process.spawn(io, .{
+        .argv = wrapped.items,
+        .cwd = .{ .path = cwd },
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+        .environ_map = environ_map,
+    }) catch |err| {
+        closeFd(fds[0]);
+        closeFd(fds[1]);
+        if (err == error.FileNotFound) {
+            // `/usr/bin/env` missing is indistinguishable from a missing
+            // zig here; retry unwrapped so success — or the error report —
+            // is attributed to the real binary.
+            return runZigInheritHeartbeat(allocator, cwd, argv, environ_map, reporter);
+        }
+        reportSpawnFailure(err, argv, cwd);
+        return err;
+    };
+    // The child holds its own copy of the write end; drop ours so the pump
+    // sees EOF when the child process tree exits.
+    closeFd(fds[1]);
+
+    const debug_progress = blk: {
+        const v = config.globalEnviron().getAlloc(allocator, "LABELLE_PROGRESS_DEBUG") catch break :blk false;
+        defer allocator.free(v);
+        break :blk v.len > 0 and !std.mem.eql(u8, v, "0");
+    };
+    var ctx = PumpCtx{ .fd = fds[0], .reporter = reporter, .debug = debug_progress };
+    // If the pump thread can't start, the build still runs — the child's
+    // nonblocking writes fail once the pipe fills and it carries on; we
+    // just lose granularity.
+    const pump_thread: ?std.Thread = std.Thread.spawn(.{}, pumpZigProgress, .{&ctx}) catch null;
+    defer {
+        ctx.stop.store(true, .release);
+        if (pump_thread) |t| t.join();
+        closeFd(fds[0]);
+    }
+
+    const term = try child.wait(io);
+    return termToExitCode(term);
+}
+
+/// Fallback: no IPC granularity available — run with inherited stdio and
+/// tick the reporter every 500ms so `elapsed_ms`/spinner (and the status
+/// file) keep moving during the compile.
+fn runZigInheritHeartbeat(
+    allocator: std.mem.Allocator,
+    cwd: []const u8,
+    argv: []const []const u8,
+    environ_map: ?*const std.process.Environ.Map,
+    reporter: *progress.Reporter,
+) !u8 {
+    const Beat = struct {
+        reporter: *progress.Reporter,
+        stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+        fn run(b: *@This()) void {
+            while (!b.stop.load(.acquire)) {
+                b.reporter.heartbeat();
+                sleepNanos(500 * std.time.ns_per_ms);
+            }
+        }
+    };
+    var beat = Beat{ .reporter = reporter };
+    const thread: ?std.Thread = std.Thread.spawn(.{}, Beat.run, .{&beat}) catch null;
+    defer if (thread) |t| {
+        beat.stop.store(true, .release);
+        t.join();
+    };
+    return runZigInheritWithEnv(allocator, cwd, argv, null, environ_map);
+}
+
 /// Build a fresh `Environ.Map` that mirrors the current process's
 /// environment block plus the entries in `extras`. The caller owns the
 /// returned map and must `deinit()` it after the spawned child has
@@ -423,7 +652,15 @@ pub fn fixFingerprint(allocator: std.mem.Allocator, project_dir: []const u8, out
     // other managed spawn, so its compiler cache lands in user-writable space.
     var zig_env = try buildZigEnv(allocator, &.{});
     defer zig_env.deinit();
-    const result = try runZigWithEnv(allocator, output_dir, &.{ zig_exe, "build" }, &zig_env);
+    // `--list-steps`: the probe only exists to trigger the manifest
+    // fingerprint validation (which happens during configuration, before
+    // any step runs) and read the `use this value:` hint. A bare `zig
+    // build` here did the project's ENTIRE first compile captured and
+    // silent whenever the generated zon already carried a correct
+    // fingerprint — swallowing the real build into this probe (~0.15s vs
+    // minutes; found while wiring the cli#284 progress feed, which showed
+    // the cold compile landing inside the "generate" phase).
+    const result = try runZigWithEnv(allocator, output_dir, &.{ zig_exe, "build", "--list-steps" }, &zig_env);
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 

--- a/src/cli/status.zig
+++ b/src/cli/status.zig
@@ -1,0 +1,259 @@
+//! `labelle status [dir] [--json]` — one-shot read of the live build
+//! status file (labelle-cli#284).
+//!
+//! Answers "how far along is the build / is it stuck?" from a second
+//! terminal without touching the running build: reads
+//! `.labelle/<target>/.build-progress.json` (written atomically by the
+//! build's `progress.Reporter` in every mode) and prints it human-readably
+//! or as raw JSON.
+//!
+//! Rather than re-deriving the `<backend>_<platform>` target from
+//! project.labelle (which `--platform=` overrides would defeat), it scans
+//! every `.labelle/*/` target dir and reports the record with the newest
+//! `updated_at_ms` — i.e. whatever built (or is building) last.
+
+const std = @import("std");
+const config = @import("config.zig");
+const progress = @import("progress.zig");
+
+/// A parsed status record. Field-for-field the schema `progress.Record`
+/// writes, but decoded leniently (`phase` as a plain string, unknown fields
+/// ignored, everything defaulted) so a newer CLI's file never breaks an
+/// older `labelle status` and vice versa.
+pub const FileRecord = struct {
+    phase: []const u8 = "",
+    step: ?u64 = null,
+    total: ?u64 = null,
+    percent: ?f32 = null,
+    detail: []const u8 = "",
+    elapsed_ms: u64 = 0,
+    exit_code: ?u8 = null,
+    updated_at_ms: u64 = 0,
+};
+
+/// A build that stops writing for this long while non-terminal is flagged
+/// as possibly dead (the reporter refreshes the file at least ~1/s).
+const stale_after_ms: u64 = 10_000;
+
+pub fn cmdStatus(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    var dir: []const u8 = ".";
+    var dir_set = false;
+    var json = false;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--json")) {
+            json = true;
+        } else if (std.mem.startsWith(u8, arg, "--")) {
+            std.debug.print("labelle status: unknown flag '{s}'\n", .{arg});
+            std.debug.print("  usage: labelle status [dir] [--json]\n", .{});
+            return error.InvalidArguments;
+        } else {
+            if (dir_set) {
+                std.debug.print("labelle status: unexpected argument '{s}'\n", .{arg});
+                return error.InvalidArguments;
+            }
+            dir = arg;
+            dir_set = true;
+        }
+    }
+
+    const io = config.globalIo();
+    const found = try findNewestStatus(allocator, io, dir);
+    defer if (found) |f| f.deinit(allocator);
+
+    // Streaming writer: the positional variant would rewind a redirected
+    // stdout to offset 0 on each construction (see progress.writeJsonLine).
+    var out_buf: [4096]u8 = undefined;
+    var w = std.Io.File.stdout().writerStreaming(io, &out_buf);
+
+    const f = found orelse {
+        if (json) {
+            w.interface.writeAll("{\"error\":\"not_found\"}\n") catch {};
+        } else {
+            w.interface.print(
+                "labelle status: no build recorded under '{s}/.labelle/'\n" ++
+                    "  run `labelle build` or `labelle run` first.\n",
+                .{dir},
+            ) catch {};
+        }
+        w.interface.flush() catch {};
+        std.process.exit(1);
+    };
+
+    if (json) {
+        const trimmed = std.mem.trim(u8, f.raw, &std.ascii.whitespace);
+        w.interface.writeAll(trimmed) catch {};
+        w.interface.writeAll("\n") catch {};
+        w.interface.flush() catch {};
+        return;
+    }
+
+    const now_ms_i = std.Io.Timestamp.now(io, .real).toMilliseconds();
+    const now_ms: u64 = if (now_ms_i > 0) @intCast(now_ms_i) else 0;
+    try formatHuman(&w.interface, f.record, f.target, now_ms);
+    w.interface.flush() catch {};
+}
+
+/// Render one record as the human `labelle status` report. Pure — takes
+/// "now" so tests are deterministic.
+pub fn formatHuman(
+    w: *std.Io.Writer,
+    rec: FileRecord,
+    target: []const u8,
+    now_ms: u64,
+) !void {
+    try w.print("labelle status: {s}", .{rec.phase});
+    if (rec.exit_code) |code| try w.print(" (exit {d})", .{code});
+    if (rec.step) |s| {
+        if (rec.total) |t| try w.print(" [{d}/{d}]", .{ s, t }) else try w.print(" [{d}]", .{s});
+    }
+    if (rec.percent) |p| try w.print(" {d:.1}%", .{p});
+    if (rec.detail.len > 0) try w.print(" — {s}", .{rec.detail});
+    try w.writeAll("\n");
+
+    const age_ms: u64 = if (now_ms > rec.updated_at_ms) now_ms - rec.updated_at_ms else 0;
+    const terminal = std.mem.eql(u8, rec.phase, "done") or std.mem.eql(u8, rec.phase, "failed");
+    try w.print("  elapsed {d:.1}s, updated {d:.1}s ago  (.labelle/{s})\n", .{
+        @as(f64, @floatFromInt(rec.elapsed_ms)) / 1000.0,
+        @as(f64, @floatFromInt(age_ms)) / 1000.0,
+        target,
+    });
+    if (!terminal and age_ms > stale_after_ms) {
+        try w.print(
+            "  warning: no update for {d}s — the build may no longer be running\n",
+            .{age_ms / 1000},
+        );
+    }
+}
+
+const Found = struct {
+    /// Raw JSON file contents (owned).
+    raw: []u8,
+    /// Target dir basename, e.g. "bgfx_desktop" (owned).
+    target: []u8,
+    /// Views into a parsed copy — kept alive by `parsed`.
+    record: FileRecord,
+    parsed: std.json.Parsed(FileRecord),
+
+    fn deinit(self: Found, allocator: std.mem.Allocator) void {
+        self.parsed.deinit();
+        allocator.free(self.raw);
+        allocator.free(self.target);
+    }
+};
+
+/// Scan `<dir>/.labelle/*/` for status files and return the one with the
+/// newest `updated_at_ms` (unparseable/missing candidates are skipped).
+fn findNewestStatus(allocator: std.mem.Allocator, io: std.Io, project_dir: []const u8) !?Found {
+    const labelle_dir_path = try std.fs.path.join(allocator, &.{ project_dir, ".labelle" });
+    defer allocator.free(labelle_dir_path);
+
+    var labelle_dir = std.Io.Dir.cwd().openDir(io, labelle_dir_path, .{ .iterate = true }) catch return null;
+    defer labelle_dir.close(io);
+
+    var best: ?Found = null;
+    errdefer if (best) |b| b.deinit(allocator);
+
+    var iter = labelle_dir.iterate();
+    while (try iter.next(io)) |entry| {
+        if (entry.kind != .directory) continue;
+        const status_path = try std.fs.path.join(
+            allocator,
+            &.{ labelle_dir_path, entry.name, progress.status_file_name },
+        );
+        defer allocator.free(status_path);
+
+        const raw = std.Io.Dir.cwd().readFileAlloc(io, status_path, allocator, .limited(64 * 1024)) catch continue;
+        var keep_raw = false;
+        defer if (!keep_raw) allocator.free(raw);
+
+        const parsed = std.json.parseFromSlice(FileRecord, allocator, raw, .{
+            .ignore_unknown_fields = true,
+        }) catch continue;
+        var keep_parsed = false;
+        defer if (!keep_parsed) parsed.deinit();
+
+        const newer = if (best) |b| parsed.value.updated_at_ms > b.record.updated_at_ms else true;
+        if (!newer) continue;
+
+        const target = try allocator.dupe(u8, entry.name);
+        if (best) |b| b.deinit(allocator);
+        best = .{ .raw = raw, .target = target, .record = parsed.value, .parsed = parsed };
+        keep_raw = true;
+        keep_parsed = true;
+    }
+    return best;
+}
+
+// --- Tests ---
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+pub const FormatHumanSpec = struct {
+    test "in-flight compile shows phase, counts, percent, detail and target" {
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try formatHuman(&w, .{
+            .phase = "compile",
+            .step = 34,
+            .total = 210,
+            .percent = 16.2,
+            .detail = "Semantic Analysis",
+            .elapsed_ms = 74_300,
+            .updated_at_ms = 1_000_000,
+        }, "bgfx_desktop", 1_000_400);
+        const out = w.buffered();
+        try std.testing.expect(std.mem.indexOf(u8, out, "compile [34/210] 16.2% — Semantic Analysis") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "elapsed 74.3s") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "(.labelle/bgfx_desktop)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "warning") == null);
+    }
+
+    test "silent non-terminal build gets the stale warning" {
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try formatHuman(&w, .{
+            .phase = "compile",
+            .elapsed_ms = 5000,
+            .updated_at_ms = 1_000_000,
+        }, "raylib_desktop", 1_060_000); // 60s later
+        try std.testing.expect(std.mem.indexOf(u8, w.buffered(), "may no longer be running") != null);
+    }
+
+    test "terminal done shows exit code and never warns" {
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try formatHuman(&w, .{
+            .phase = "done",
+            .exit_code = 0,
+            .elapsed_ms = 183_200,
+            .updated_at_ms = 1_000_000,
+        }, "sokol_desktop", 2_000_000); // ages ago
+        const out = w.buffered();
+        try std.testing.expect(std.mem.indexOf(u8, out, "done (exit 0)") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "warning") == null);
+    }
+
+    test "round-trips a record encoded by the reporter's own encoder" {
+        var enc_buf: [1024]u8 = undefined;
+        const line = try progress.encodeRecord(&enc_buf, .{
+            .phase = .failed,
+            .detail = "zig build failed",
+            .exit_code = 2,
+            .elapsed_ms = 900,
+            .updated_at_ms = 42,
+        });
+        const parsed = try std.json.parseFromSlice(FileRecord, std.testing.allocator, line, .{
+            .ignore_unknown_fields = true,
+        });
+        defer parsed.deinit();
+        try std.testing.expectEqualStrings("failed", parsed.value.phase);
+        try std.testing.expectEqual(@as(?u8, 2), parsed.value.exit_code);
+
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try formatHuman(&w, parsed.value, "bgfx_desktop", 42);
+        try std.testing.expect(std.mem.indexOf(u8, w.buffered(), "failed (exit 2) — zig build failed") != null);
+    }
+};

--- a/src/cli/zig_progress.zig
+++ b/src/cli/zig_progress.zig
@@ -1,0 +1,410 @@
+//! Parser for Zig's native `std.Progress` IPC wire format (labelle-cli#284).
+//!
+//! When a child is spawned with `ZIG_PROGRESS=<fd>` in its environment,
+//! `std.Progress.start` inside that child (i.e. inside `zig build` and,
+//! transitively, the compiler processes it spawns) writes progress-tree
+//! snapshots to that fd instead of rendering to the terminal. This module
+//! decodes those snapshots so the CLI gets *real* compile step counts and
+//! the current unit name — no log-line scraping.
+//!
+//! Wire format (verified against `lib/std/Progress.zig` of Zig 0.16.0 —
+//! `serialize`/`writeIpc` on the sending side, `Ipc.Data.findLastPacket`
+//! on the receiving side):
+//!
+//!   packet := nodes_len:u8
+//!             storage[nodes_len]   — 128 bytes each:
+//!                 completed_count:u32 LE
+//!                 estimated_total_count:u32 LE   (0 = unknown)
+//!                 name:[120]u8                   (NUL-padded)
+//!             parent[nodes_len]:u8 — 0xFF = root/none, 0xFE = unused,
+//!                                    else index into THIS packet's nodes
+//!
+//! Every packet is a complete snapshot of the tree (children's subtrees
+//! already folded in by the intermediate `zig build` process), sent about
+//! every 80ms. Like std's own reader, we only ever act on the LAST complete
+//! packet in the buffer and keep any trailing partial packet for the next
+//! read. `estimated_total_count == 0xFFFFFFFF` marks an internal IPC-proxy
+//! node whose `completed_count` is a file-descriptor slot, not a count —
+//! such nodes are skipped.
+//!
+//! Tree shape produced by `zig build` (lib/compiler/build_runner.zig):
+//! node 0 is the root (empty name); a child named "steps" carries
+//! `completed/estimated = finished/total build steps` — that is the N/M a
+//! consumer wants. The deepest named node is the current activity (e.g. a
+//! compiler's "Semantic Analysis" / the unit being processed).
+//!
+//! Pure: no I/O, no clock, no allocation. The pipe pump lives in
+//! `runner.zig`; the phase model in `progress.zig`.
+
+const std = @import("std");
+
+pub const max_name_len = 120;
+const storage_size = 128; // 4 + 4 + 120
+const bytes_per_node = storage_size + 1; // + parent byte
+const parent_none: u8 = 0xFF;
+const parent_unused: u8 = 0xFE;
+/// std's sender serializes at most `node_storage_buffer_len` (127) nodes
+/// per packet; a larger claim means we lost framing.
+const max_nodes_per_packet: usize = 127;
+/// The special `estimated_total_count` marking an IPC-proxy node.
+const ipc_marker: u32 = std.math.maxInt(u32);
+
+/// What one snapshot boils down to for the progress feed.
+pub const Snapshot = struct {
+    /// Completed / total build steps, from the `"steps"` node (fallback:
+    /// the root node when it carries a real total). Null when unknown.
+    step: ?u64 = null,
+    total: ?u64 = null,
+    /// Name of the deepest active node — the current activity.
+    detail_buf: [max_name_len]u8 = @splat(0),
+    detail_len: u8 = 0,
+    /// A node name indicates the linker is running (best-effort heuristic;
+    /// when it never trips, the consumer simply stays in the compile phase).
+    saw_link: bool = false,
+    /// Nodes decoded from the packet (diagnostics).
+    node_count: usize = 0,
+
+    pub fn detail(s: *const Snapshot) []const u8 {
+        return s.detail_buf[0..s.detail_len];
+    }
+};
+
+/// Incremental stream parser. Feed it whatever `read(2)` returns; poll it
+/// for the latest complete snapshot.
+pub const Parser = struct {
+    /// Legit packets are at most `1 + 127*129` = 16384 bytes; keep room for
+    /// a couple plus a partial tail.
+    pub const buffer_capacity = 48 * 1024;
+
+    buf: [buffer_capacity]u8 = undefined,
+    len: usize = 0,
+
+    /// Append raw bytes from the pipe. If the buffer would overflow (which
+    /// a healthy stream never does — `poll` consumes as we go), the buffer
+    /// is reset: losing a snapshot is fine, they are full-state.
+    pub fn feed(p: *Parser, bytes: []const u8) void {
+        if (p.len + bytes.len > buffer_capacity) {
+            p.len = 0;
+            if (bytes.len > buffer_capacity) return; // absurd; drop
+        }
+        @memcpy(p.buf[p.len..][0..bytes.len], bytes);
+        p.len += bytes.len;
+    }
+
+    /// Decode and consume the LAST complete packet buffered, preserving any
+    /// trailing partial packet. Returns null when no complete packet is
+    /// available or the packet is empty (both mean "no new information").
+    pub fn poll(p: *Parser) ?Snapshot {
+        var packet_start: usize = 0;
+        var packet_end: usize = 0;
+        var found = false;
+        while (p.len - packet_end >= 1) {
+            const n: usize = p.buf[packet_end];
+            if (n > max_nodes_per_packet) {
+                // Framing lost (never produced by a real zig): resync by
+                // dropping everything buffered.
+                p.len = 0;
+                return null;
+            }
+            const packet_len = 1 + n * bytes_per_node;
+            if (packet_end + packet_len > p.len) break;
+            packet_start = packet_end;
+            packet_end += packet_len;
+            found = true;
+        }
+        if (!found) return null;
+
+        const snapshot = parsePacket(p.buf[packet_start..packet_end]);
+
+        // Rebase: keep the unconsumed tail for the next feed.
+        const tail_len = p.len - packet_end;
+        std.mem.copyForwards(u8, p.buf[0..tail_len], p.buf[packet_end..p.len]);
+        p.len = tail_len;
+
+        return snapshot;
+    }
+};
+
+/// Decode one complete packet. Exposed for tests.
+pub fn parsePacket(bytes: []const u8) ?Snapshot {
+    const n: usize = bytes[0];
+    if (n == 0) return null;
+    std.debug.assert(bytes.len == 1 + n * bytes_per_node);
+    const storage = bytes[1..][0 .. n * storage_size];
+    const parents = bytes[1 + n * storage_size ..][0..n];
+
+    var snap = Snapshot{ .node_count = n };
+    var steps_found = false;
+    var best_depth: usize = 0;
+    var have_detail = false;
+
+    for (0..n) |i| {
+        const estimated = nodeEstimated(storage, i);
+        if (estimated == ipc_marker) continue; // fd-proxy node, not a count
+        const name = nodeName(storage, i);
+
+        if (!steps_found and std.mem.eql(u8, name, "steps")) {
+            snap.step = nodeCompleted(storage, i);
+            snap.total = if (estimated > 0) estimated else null;
+            steps_found = true;
+        }
+
+        if (name.len > 0) {
+            if (nameIndicatesLink(name)) snap.saw_link = true;
+            const depth = depthOf(parents, i);
+            // `>=` so a later node wins ties: siblings are created in
+            // order, making the most recent activity the better label.
+            if (!have_detail or depth >= best_depth) {
+                best_depth = depth;
+                snap.detail_len = @intCast(name.len);
+                @memcpy(snap.detail_buf[0..name.len], name);
+                have_detail = true;
+            }
+        }
+    }
+
+    if (!steps_found) {
+        // Fallback: the sender's root node, when it carries a real total.
+        const estimated = nodeEstimated(storage, 0);
+        if (estimated != ipc_marker and estimated > 0) {
+            snap.step = nodeCompleted(storage, 0);
+            snap.total = estimated;
+        }
+    }
+
+    return snap;
+}
+
+fn nodeCompleted(storage: []const u8, i: usize) u32 {
+    return std.mem.readInt(u32, storage[i * storage_size ..][0..4], .little);
+}
+
+fn nodeEstimated(storage: []const u8, i: usize) u32 {
+    return std.mem.readInt(u32, storage[i * storage_size + 4 ..][0..4], .little);
+}
+
+fn nodeName(storage: []const u8, i: usize) []const u8 {
+    const raw = storage[i * storage_size + 8 ..][0..max_name_len];
+    const end = std.mem.indexOfScalar(u8, raw, 0) orelse max_name_len;
+    return raw[0..end];
+}
+
+/// Walk the parent chain to the root. Hop count is capped at the node count
+/// so untrusted/cyclic parent data can never loop forever (mirrors std's
+/// own distrust of child data).
+fn depthOf(parents: []const u8, i: usize) usize {
+    var depth: usize = 0;
+    var cur = i;
+    var hops: usize = 0;
+    while (hops < parents.len) : (hops += 1) {
+        const par = parents[cur];
+        if (par == parent_none or par == parent_unused) return depth;
+        if (par >= parents.len) return depth; // out-of-range: treat as root
+        cur = par;
+        depth += 1;
+    }
+    return depth;
+}
+
+/// Does this node name look like the link stage? Zig's linker progress
+/// node is named "linking" ("LLD Link" historically); match conservatively
+/// so a user step named e.g. "blink" can't trip it.
+fn nameIndicatesLink(name: []const u8) bool {
+    if (std.ascii.startsWithIgnoreCase(name, "linking")) return true;
+    if (std.ascii.startsWithIgnoreCase(name, "lld ")) return true;
+    if (std.ascii.eqlIgnoreCase(name, "link")) return true;
+    return false;
+}
+
+// --- Tests ---
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+const expect = @import("zspec").expect;
+
+/// Test helper: append one serialized packet built from (name, completed,
+/// estimated, parent) tuples — the exact byte layout `writeIpc` produces.
+const PacketBuilder = struct {
+    const TestNode = struct {
+        name: []const u8,
+        completed: u32 = 0,
+        estimated: u32 = 0,
+        parent: u8 = parent_none,
+    };
+
+    fn append(list: *std.ArrayList(u8), allocator: std.mem.Allocator, nodes: []const TestNode) !void {
+        try list.append(allocator, @intCast(nodes.len));
+        for (nodes) |node| {
+            var storage: [storage_size]u8 = @splat(0);
+            std.mem.writeInt(u32, storage[0..4], node.completed, .little);
+            std.mem.writeInt(u32, storage[4..8], node.estimated, .little);
+            @memcpy(storage[8..][0..node.name.len], node.name);
+            try list.appendSlice(allocator, &storage);
+        }
+        for (nodes) |node| {
+            try list.append(allocator, node.parent);
+        }
+    }
+};
+
+pub const PacketDecodingSpec = struct {
+    test "decodes step/total from the steps node and detail from the deepest node" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" }, // root: zig build's main node has no name
+            .{ .name = "steps", .completed = 34, .estimated = 210, .parent = 0 },
+            .{ .name = "zig build-exe game Debug native", .parent = 1 },
+            .{ .name = "Semantic Analysis", .completed = 5, .estimated = 40, .parent = 2 },
+        });
+
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.equal(snap.step.?, @as(u64, 34));
+        try expect.equal(snap.total.?, @as(u64, 210));
+        try std.testing.expectEqualStrings("Semantic Analysis", snap.detail());
+        try expect.toBeFalse(snap.saw_link);
+        try expect.equal(snap.node_count, @as(usize, 4));
+    }
+
+    test "last complete packet wins when several are buffered" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" },
+            .{ .name = "steps", .completed = 1, .estimated = 9, .parent = 0 },
+        });
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" },
+            .{ .name = "steps", .completed = 7, .estimated = 9, .parent = 0 },
+        });
+
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.equal(snap.step.?, @as(u64, 7));
+        // Both packets were consumed.
+        try expect.equal(parser.len, @as(usize, 0));
+    }
+
+    test "partial trailing packet is preserved and completes on the next feed" {
+        const allocator = std.testing.allocator;
+        var whole: std.ArrayList(u8) = .empty;
+        defer whole.deinit(allocator);
+        try PacketBuilder.append(&whole, allocator, &.{
+            .{ .name = "" },
+            .{ .name = "steps", .completed = 3, .estimated = 5, .parent = 0 },
+        });
+
+        var parser = Parser{};
+        const split = whole.items.len - 17; // mid-parents/mid-storage cut
+        parser.feed(whole.items[0..split]);
+        try std.testing.expect(parser.poll() == null); // incomplete: nothing to report
+        try expect.equal(parser.len, split); // partial bytes retained
+
+        parser.feed(whole.items[split..]);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.equal(snap.step.?, @as(u64, 3));
+        try expect.equal(snap.total.?, @as(u64, 5));
+    }
+
+    test "empty packet (nodes_len 0) is consumed but reports nothing" {
+        var parser = Parser{};
+        parser.feed(&.{0});
+        try std.testing.expect(parser.poll() == null);
+        try expect.equal(parser.len, @as(usize, 0));
+    }
+
+    test "ipc-proxy nodes (estimated == maxInt u32) are skipped everywhere" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" },
+            // A proxy node whose name would otherwise win the depth race
+            // AND whose counts would be misread as 3/maxInt.
+            .{ .name = "steps", .completed = 3, .estimated = ipc_marker, .parent = 0 },
+            .{ .name = "real work", .completed = 1, .estimated = 2, .parent = 0 },
+        });
+
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try std.testing.expect(snap.step == null);
+        try std.testing.expect(snap.total == null);
+        try std.testing.expectEqualStrings("real work", snap.detail());
+    }
+
+    test "linker node flips saw_link" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" },
+            .{ .name = "steps", .completed = 208, .estimated = 210, .parent = 0 },
+            .{ .name = "linking game", .parent = 1 },
+        });
+
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.toBeTrue(snap.saw_link);
+        try std.testing.expectEqualStrings("linking game", snap.detail());
+    }
+
+    test "a user step merely containing 'link' does not flip saw_link" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "" },
+            .{ .name = "blink assets", .parent = 0 },
+        });
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.toBeFalse(snap.saw_link);
+    }
+
+    test "root counts are the fallback when no steps node exists" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "compiling", .completed = 2, .estimated = 8 },
+        });
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        const snap = parser.poll() orelse return error.TestFailed;
+        try expect.equal(snap.step.?, @as(u64, 2));
+        try expect.equal(snap.total.?, @as(u64, 8));
+        try std.testing.expectEqualStrings("compiling", snap.detail());
+    }
+
+    test "garbage nodes_len resets the stream instead of wedging" {
+        var parser = Parser{};
+        parser.feed(&.{ 200, 1, 2, 3 }); // 200 nodes is beyond std's own cap
+        try std.testing.expect(parser.poll() == null);
+        try expect.equal(parser.len, @as(usize, 0)); // resynced
+    }
+
+    test "cyclic parent data cannot loop the depth walk" {
+        const allocator = std.testing.allocator;
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(allocator);
+        // Two nodes pointing at each other.
+        try PacketBuilder.append(&bytes, allocator, &.{
+            .{ .name = "a", .parent = 1 },
+            .{ .name = "b", .parent = 0 },
+        });
+        var parser = Parser{};
+        parser.feed(bytes.items);
+        // Must terminate; whichever detail wins is fine.
+        _ = parser.poll() orelse return error.TestFailed;
+    }
+};


### PR DESCRIPTION
Implements #284: a single structured progress facility the CLI produces once, consumable three ways — no more scraping human log lines, no more multi-minute silent gap.

## Design

**Phase model** (`src/cli/progress.zig`): `resolve → generate → compile → link → run → done|failed`, enforced by a pure `Machine` (forward-only, skips legal, `failed` from anywhere, terminal states absorb). One `Record` schema everywhere:

```json
{"phase":"compile","step":null,"total":null,"percent":null,"detail":"Compile Build Script","elapsed_ms":2810,"exit_code":null,"updated_at_ms":1783271502846}
```

`exit_code` is set on the terminal record (`done` carries the game's exit code for `labelle run`; `failed` the failing stage's). `updated_at_ms` (wall-clock) lets an out-of-band reader tell *working* from *dead*. All keys always present (`null` = unknown) for typed consumers.

**Three access modes from one source** (`progress.Reporter`, thread-safe fan-out sink):
- `--progress=json` — NDJSON, one record per line on **stdout** (`labelle build`/`run`; modes: `human` (default), `json`, `off`).
- **Live status file** `.labelle/<target>/.build-progress.json` — atomically rewritten (temp + rename) with the current record **in every mode**, from the first `resolve` record to the terminal `done`/`failed`. This is the "loader": any process can read it at any instant.
- **Human mode** — single-line spinner (`- compile Compile Build Script (0.9s)`) on **TTY stderr only** during compile/link (other phases' children own the terminal). No ANSI escapes (clears by overwriting); nothing when piped.

**`labelle status [dir] [--json]`** (`src/cli/status.zig`): one-shot read. Scans all `.labelle/*/` targets and reports the newest by `updated_at_ms` (so `--platform=` overrides need no flag), with a staleness warning when a non-terminal build hasn't written for >10s.

**Phase seams** (cli.zig): `resolve` before assembler/package-cache resolution, `generate` before assembler generate (+fingerprints/lockfile), `compile` at the `zig build` spawn, `link` when a linker-named node appears, `run` at game spawn (deploy for ios/android; wasm marks `done` before the interactive serve loop). Docker builds get phase-level records. `labelle generate` and the ios/android subcommands (own build flows) are report-free for now.

## The std.Progress IPC attach — outcome

Wire format was implemented from `lib/std/Progress.zig` (0.16.0): packets of `[u8 N][N×128-byte node storage (u32 LE completed, u32 LE estimated, 120-byte name)][N×u8 parent]`, full-snapshot semantics, last-complete-packet wins, `estimated==0xFFFFFFFF` marks fd-proxy nodes. `src/cli/zig_progress.zig` is a pure incremental parser for it (partial packets, garbage `nodes_len` resync, cycle-guarded depth walk for the "deepest active node" detail, `"steps"`-node step/total extraction).

Attach mechanics: `std.process.spawn` **scrubs** `ZIG_PROGRESS` from user env blocks unless it owns the pipe via `progress_node` (whose tree isn't readable from outside std), so the spawn wraps argv as `/usr/bin/env ZIG_PROGRESS=<fd> zig build …` with CLOEXEC cleared on the write end (`runner.runZigInheritProgress` + pump thread; stdio stays inherited, so compile errors stream unaltered).

**Empirical result on Zig 0.16.0** (verified with a standalone pipe-dump harness):
- a **compiler** process (`zig build-exe`) streams the full rich tree — `Semantic Analysis`, `Code Generation`, `Linking` with real counts. The protocol, fd-passing and parser all work.
- the **`zig build` frontend**, however, only streams its *own* nodes (`Compile Build Script`, 203 packets over a full cold build) — it hands the build runner a separate `-Z` integration handle and does **not** fold the runner's steps subtree into its `ZIG_PROGRESS` packets.

So per the ticket's fallback rule: for `zig build` today the feed carries live phase + frontend node names + 1/s keepalive heartbeats, and `step`/`total` stay **null** in `compile`. The parser already decodes the full multi-node format including the runner's `"steps"` node (unit-tested against synthesized packets built byte-for-byte per `writeIpc`), so real step counts light up with zero schema/code change when the toolchain relays them. Windows (handle-based `ZIG_PROGRESS`, no `env(1)`) and any pipe/spawn failure degrade to the same schema via a heartbeat ticker. `LABELLE_PROGRESS_DEBUG=1` logs decoded node names for future tuning.

## Bugs found & fixed along the way

- **`fixFingerprint` was doing the project's entire first compile silently.** Its probe ran a bare `zig build` (captured) to fish for the `use this value:` hint; when the generated zon already carries a correct fingerprint (assembler ≥0.74 does), that probe *was* the cold build — inside the "generate" phase, invisible (19s observed on the smoke project). It now probes with `zig build --list-steps` (fingerprint validation happens during configuration): ~0.15s, same error surface.
- **Process-exit paths skipped the failure marking.** `assembler_proc.spawnAndWait` (exit-code proxying) and `compatibility.validateCompatibility` terminate via `std.process.exit`, which skips `errdefer`; the status file was left claiming a live build. They now route through `progress.fatalExit(code)` (marks `failed` first, then exits — exit codes unchanged).
- **Positional stdout writers rewound redirected output to offset 0** per record (found by the smoke test — NDJSON self-overwrote when `> file`). Streaming writers fix it.

## Tests (32 new; suite: 387/387 green via `zig build test`)

- Phase machine: full legal order, forward skips, `failed` from anywhere (incl. pre-start), backward/re-enter/done-before-start rejected, both terminal states absorb.
- NDJSON encoding: valid single-line JSON via `std.json`, stable key set, escaping, terminal `failed` + exit-code record.
- Atomic status file: temp+rename over existing file, readable between writes, no lingering temp.
- Reporter pipeline (integration-ish fake build): `resolve → generate → compile updates → link flip → run → done(0)` tracked through the real status file; failure path ends `failed` with the zig exit code; terminal absorbs late updates; `failIfActive` idempotent.
- IPC parser against synthesized wire bytes: steps-node extraction, deepest-node detail, last-packet-wins, split/partial packet reassembly, empty packet, fd-proxy node skipping, link-name detection (+ no false positive), garbage-length resync, parent-cycle guard.
- `labelle status` formatting: in-flight/terminal/stale rendering, round-trip through the reporter's own encoder.

## Manual verification (real project)

Scaffolded a raylib-desktop project with `labelle init`, pinned to the released set (core 1.23.0 / engine 1.72.0 / gfx 1.19.0 / assembler 0.74.2), built with the branch CLI. (The `labelle-assembler/examples/*` local-pin projects currently fail to compile on main due to unrelated cross-repo drift — `DecodedImage.compressed` — which incidentally exercised the failure path against a real build.)

`labelle build --progress=json` (cold `.labelle/`), stdout:

```
{"phase":"resolve","step":null,"total":null,"percent":null,"detail":"resolving toolchain + packages","elapsed_ms":0,"exit_code":null,"updated_at_ms":1783271500036}
{"phase":"generate","step":null,"total":null,"percent":null,"detail":"assembler generate","elapsed_ms":32,"exit_code":null,"updated_at_ms":1783271500068}
{"phase":"generate","step":null,"total":null,"percent":null,"detail":"assembler generate","elapsed_ms":1505,"exit_code":null,"updated_at_ms":1783271501541}
{"phase":"compile","step":null,"total":null,"percent":null,"detail":"zig build","elapsed_ms":2525,"exit_code":null,"updated_at_ms":1783271502561}
{"phase":"compile","step":null,"total":null,"percent":null,"detail":"Compile Build Script","elapsed_ms":2810,"exit_code":null,"updated_at_ms":1783271502846}
{"phase":"done","step":null,"total":null,"percent":null,"detail":"Compile Build Script","elapsed_ms":2983,"exit_code":0,"updated_at_ms":1783271503020}
```

`labelle status` from a second shell mid-compile (during a longer ReleaseSafe build), then post-build:

```
labelle status: compile — Compile Build Script
  elapsed 23.3s, updated 0.1s ago  (.labelle/raylib_desktop)
```

Failure path (deliberately broken `scripts/broken.zig`, default human mode, output piped): CLI exit 1 unchanged, the real compile error (`scripts/broken.zig:4:5: error: use of undeclared identifier 'this_is_not_a_thing'`) streamed on stderr, stdout byte-empty (no spinner escapes), status file ended:

```
{"phase":"failed","step":null,"total":null,"percent":null,"detail":"zig build failed","elapsed_ms":1684,"exit_code":1,"updated_at_ms":1783271305208}
```

`labelle run --timeout=6s --progress=json`: `run` phase record with the exe name, terminal `done` with the game's exit code. Spinner verified under a real PTY (python `pty`): `| compile zig build (0.6s)` → frame advance in place → clean clear before `  build ok`.

## Notes for studio#28 (consumer)

- Prefer the **status file** (via the Tauri fs bridge) — it's mode-independent and immune to the one NDJSON caveat: during the `run` phase the game inherits stdout, so game prints interleave with the stream (records remain intact lines; the terminal record still lands after game exit).
- Poll cheaply: the file is rewritten at least ~1/s while alive (keepalive ticker) and at most ~4/s; `updated_at_ms` age > ~10s with a non-terminal `phase` ⇒ treat as dead (that's `labelle status`'s own heuristic).
- Treat unknown fields/phases as forward-compat (a `download` phase may join for cli#279); `step`/`total` are nullable and currently null during `compile` (see IPC outcome above).
- A build interrupted by SIGKILL can leave a non-terminal file; the staleness rule covers it.

Closes #284.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
