### PR TITLE
fix(run): false empty-trace DebugAllocator leak line at --timeout shutdown — CLI's own abandoned TimeoutState (labelle-assembler#558)

### DIFF
--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -117,6 +117,20 @@ const windows = if (is_windows) struct {
 
 /// Shared state between the main thread and the timeout thread.
 /// Heap-allocated so it outlives the spawning stack frame.
+///
+/// Allocate it from `std.heap.page_allocator`, NEVER from the CLI's
+/// DebugAllocator: the detached timeout thread is *designed* to be
+/// abandoned mid-sleep at process exit (see `timeoutKillPosix` — it
+/// sleeps out the timeout and then a SIGKILL grace period), so the ref
+/// it holds routinely outlives `main`'s `gpa.deinit()` leak check.
+/// Tracked by the DebugAllocator, that still-referenced state made
+/// EVERY `labelle run --timeout` whose child died on the first SIGTERM
+/// (or exited before the timeout) print a bogus
+/// `error(DebugAllocator): memory address 0x... leaked: (empty stack
+/// trace)` at shutdown — labelle-assembler#558. Page-allocator memory
+/// is invisible to that leak check and is reclaimed by the OS at exit;
+/// when both sides do release in time, the last `release()` still
+/// frees it normally.
 const TimeoutState = struct {
     allocator: std.mem.Allocator,
     timed_out: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -227,13 +241,17 @@ pub fn runZigInheritWithEnv(
         return err;
     };
 
-    // Heap-allocate so the detached thread can safely access it after this function returns
+    // Heap-allocate so the detached thread can safely access it after this
+    // function returns. Page allocator on purpose — the detached thread may
+    // be abandoned still holding its ref at process exit, and the caller's
+    // (Debug)allocator would report that as a shutdown leak (#558); see the
+    // TimeoutState doc comment.
     var state: ?*TimeoutState = null;
     defer if (state) |s| s.release();
 
     if (timeout_ns) |ns| {
-        state = try allocator.create(TimeoutState);
-        state.?.* = .{ .allocator = allocator };
+        state = try std.heap.page_allocator.create(TimeoutState);
+        state.?.* = .{ .allocator = std.heap.page_allocator };
 
         if (is_windows) {
             const win_pid = windows.GetProcessId(child.id.?);
@@ -697,3 +715,27 @@ pub fn fixFingerprint(allocator: std.mem.Allocator, project_dir: []const u8, out
         }
     }
 }
+
+// --- Tests ---
+
+const expect = @import("zspec").expect;
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+pub const TimeoutStateSpec = struct {
+    test "last release frees exactly once" {
+        // Guard for the ref-count contract the #558 fix relies on: two
+        // holders, the LAST `release()` frees. `testing.allocator`'s
+        // per-test leak check fails this test if the final destroy is
+        // ever skipped; a double destroy would trip its double-free
+        // detection. (Production code allocates from `page_allocator`
+        // precisely so an ABANDONED timer-thread ref — process exiting
+        // mid-sleep — is not reported as a shutdown leak.)
+        const s = try std.testing.allocator.create(TimeoutState);
+        s.* = .{ .allocator = std.testing.allocator };
+        s.release(); // timer thread's ref
+        s.release(); // main thread's ref — last one frees
+    }
+};

--- a/src/cli/runner.zig
+++ b/src/cli/runner.zig
@@ -252,6 +252,13 @@ pub fn runZigInheritWithEnv(
     if (timeout_ns) |ns| {
         state = try std.heap.page_allocator.create(TimeoutState);
         state.?.* = .{ .allocator = std.heap.page_allocator };
+        // If the spawn below fails, the timer thread never comes into
+        // existence to take its ref — drop it here so the function-level
+        // `defer` (LIFO: it runs after this errdefer) releases the LAST ref
+        // and actually frees. No-op once the spawn succeeds: this errdefer
+        // is scoped to this block, so later errors (e.g. `child.wait`)
+        // don't double-release the thread's ref.
+        errdefer state.?.release();
 
         if (is_windows) {
             const win_pid = windows.GetProcessId(child.id.?);


### PR DESCRIPTION
Root-causes and fixes labelle-toolkit/labelle-assembler#558 ("0.75-generated games emit one empty-trace DebugAllocator leak line at `--timeout` shutdown; 0.74 generation clean").

## TL;DR — the game never leaked; the CLI does

The leak line is printed by the **labelle CLI process itself**, not the game. `runZigInheritWithEnv` heap-allocates a ref-counted `TimeoutState` from the CLI's `DebugAllocator` and hands one ref to a **detached** timer thread that is *designed* to be abandoned at process exit (it sleeps out the timeout, SIGTERMs the child's process group, then sleeps a 2s grace before the SIGKILL escalation, per #265). Whenever the CLI's main thread reaches `gpa.deinit()` while that thread still holds its ref, the leak check reports the TimeoutState — with an empty stack trace, because the shipped CLI is a release build (0 captured frames). Two paths get there:

1. **child exits before the timeout** — the timer thread sleeps the rest of the timeout; the CLI exits long before;
2. **timeout fires and the child dies on the first SIGTERM** — the CLI reaps + exits during the timer thread's 2s SIGKILL-grace sleep.

## Why it looked like an assembler 0.75 regression

Bisecting the generated FP tree showed the only functional non-pack codegen delta was assembler#534: bgfx desktop flipped from gamepad `.auto` to `.none`. Gamepad `.auto` linked the windowless-SDL gamepad source into 0.74-generated games, and **SDL's default signal handling swallows SIGTERM** — those games survived the SIGTERM and died 2s later on the SIGKILL escalation, *after* the timer thread had already released its ref → clean CLI exit. 0.75 games (no SDL) die on the SIGTERM instantly → path 2 every time → exactly one empty-trace leak line. Timing confirms it: same game, same 8s timeout — 0.74 tree runs ~2s longer (the grace) and is clean; 0.75 tree exits immediately and leaks, 4/4 deterministic.

Decisive counter-evidence against a generated-code leak:
- Debug-built CLI prints the full allocation trace: `runner.zig: state = try allocator.create(TimeoutState)` — the CLI's own allocation.
- The **null-backend** `examples/packs-demo` (assembler repo, headless, exits after `LABELLE_NULL_FRAMES`) reproduces the identical leak line via path 1 — no bgfx, no SDL, no FP code, and it reproduces regardless of assembler generation.
- The same-source generated-tree diff (FP baseline tree, 0.74.2 vs 0.75-head): `main.zig` delta is 100% pack-import rewrites; no shutdown/deinit change; games die raw on SIGTERM (no defers, no gpa report) so they cannot print a leak report on this path at all.

## The fix

Allocate `TimeoutState` from `std.heap.page_allocator` instead of the caller's (Debug)allocator. The deliberately-abandoned thread's allocation is OS-lifetime — invisible to the CLI's leak check and reclaimed at process exit; on the fast path the existing last-`release()` still frees it. The ref-count UAF fix (e96fd50) is untouched. Adds a regression test for the last-release-frees contract.

Not touched (out of scope, pre-existing): the game gets no graceful teardown on `--timeout` (SIGTERM kills it raw — already noted in #558's isolation), and an active intro-video `ffmpeg` child survives the group kill long enough to whine about broken pipes.

## Verification (all with the fixed CLI built from this branch)

| scenario | before | after |
|---|---|---|
| FP `main` (assembler 0.75.0, bgfx) `run --timeout` | 1 empty-trace leak line, 4/4 runs | **0 leak lines**, `labelle: timed out`, game killed |
| FP pre-flip baseline (assembler 0.74.2) `run --timeout` | clean | still clean (no regression) |
| null packs-demo, child exits before timeout | 1 empty-trace leak line | **0 leak lines** |

`zig build test`: green, 384/384 (incl. the new `TimeoutStateSpec`); the one `failed command:` stderr line is pre-existing on untouched origin/main (exit code 0 there too).

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j