### PR TITLE
fix(wasm): auto-activate managed emsdk on the on-demand fetch path (assembler#492 remaining half)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.52.0",
+    .version = "1.55.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa3d95bf7b905a401,
     .name = .labelle_cli,
-    .version = "1.51.0",
+    .version = "1.52.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Issue #217: labelle-cli is a thin driver over the standalone

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -36,6 +36,7 @@ const assembler = @import("cli/assembler.zig");
 const assembler_proc = @import("cli/assembler_proc.zig");
 const zig_toolchain = @import("cli/zig_toolchain.zig");
 const emsdk_toolchain = @import("cli/emsdk_toolchain.zig");
+const emsdk_activate = @import("cli/emsdk_activate.zig");
 const bake_mod = @import("cli/bake.zig");
 const docker = @import("cli/docker.zig");
 const serve = @import("cli/serve.zig");
@@ -1217,6 +1218,22 @@ pub fn main(proc_init: std.process.Init) !void {
     try lockfile.writeLockFile(allocator, project_dir, parsed);
     std.debug.print("  generated .labelle/{s}/\n", .{target_name});
 
+    // For a wasm build: activate the emsdk checkout Zig just fetched into the
+    // project-local `zig-pkg/` (during the fingerprint pass above) so the emcc
+    // link step finds `upstream/emscripten/emcc`. Without this a fresh
+    // `labelle build --platform wasm` — or `generate --platform wasm` followed
+    // by a manual `zig build` — dies at the emcc step because the fetched emsdk
+    // package is NOT activated: the remaining half of labelle-assembler#492 (the
+    // docker path already does this in-container). Run it BEFORE the `generate`
+    // early-return so the generate-then-build path is covered too. Best-effort +
+    // idempotent; on failure the build still surfaces the clear #492 guidance.
+    // The PINNED version keeps activation deterministic.
+    if (!parsed_args.docker and parsed.platform == .wasm) {
+        const resolved_emsdk = try emsdk_toolchain.resolveRequiredVersion(allocator, project_dir);
+        defer allocator.free(resolved_emsdk.version);
+        emsdk_activate.activateFetchedEmsdk(allocator, target_dir, resolved_emsdk.version);
+    }
+
     if (command == .generate) return;
 
     // `labelle ios` subcommand — handles its own build/xcode/run
@@ -1249,9 +1266,10 @@ pub fn main(proc_init: std.process.Init) !void {
 
     // Build a base env for child `zig` that pins ZIG_*_CACHE_DIR into the
     // labelle cache tree (user-writable, never next to a read-only install).
-    // For a wasm build, also fetch + **activate** the managed emsdk and layer
-    // its EMSDK/EM_CONFIG/PATH wiring on top (labelle-cli#283) so `emcc`
-    // resolves to the managed toolchain, never a PATH `emcc`.
+    // For a wasm build, ALSO layer the managed emsdk's EMSDK/EM_CONFIG/PATH
+    // wiring on top when one is already provisioned (labelle-cli#283) — an
+    // escape hatch for builds/backends that resolve `emcc` via PATH/env rather
+    // than the fetched package activated just above.
     var zig_env_storage: ?std.process.Environ.Map = if (parsed_args.docker)
         null
     else if (parsed.platform == .wasm)

--- a/src/cli/emsdk_activate.zig
+++ b/src/cli/emsdk_activate.zig
@@ -1,0 +1,326 @@
+//! Activate the FETCHED zig-package emsdk in place — the remaining half of
+//! labelle-assembler#492 (the CLI sibling of `emsdk_toolchain.zig`).
+//!
+//! `emsdk_toolchain.ensureInstalled` fetches + activates a MANAGED emsdk under
+//! `~/.labelle/emsdk/` and `runner.buildWasmEnv` wires EMSDK/EM_CONFIG/PATH onto
+//! the `zig build` spawn. That covers a build whose `emcc` resolves via
+//! PATH/env — but the assembler-generated backend hooks (bgfx/sokol/raylib)
+//! DON'T: they link via `b.dependency("emsdk").path("upstream/emscripten/emcc")`,
+//! i.e. the emsdk git checkout Zig fetched into the project-local
+//! `<build_dir>/zig-pkg/<hash>/` (or the global package cache). That package is
+//! FETCHED but NOT ACTIVATED — `emcc` is materialized only by `emsdk install` +
+//! `emsdk activate` — so a fresh `labelle build --platform wasm` dies with
+//! `FileNotFound` on `upstream/emscripten/emcc` (labelle-assembler#492). No
+//! amount of managed-emsdk env wiring fixes it because the hook ignores
+//! EMSDK/PATH. So we mirror the docker path's `activate_emsdk` snippet
+//! (`docker.zig`) on the HOST: locate the fetched package and run activation IN
+//! PLACE so the subsequent `zig build` finds `emcc`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const emsdk_cache = @import("emsdk_cache.zig");
+const zig_cache = @import("zig_cache.zig");
+const config = @import("config.zig");
+const emsdk_toolchain = @import("emsdk_toolchain.zig");
+
+const is_windows = builtin.os.tag == .windows;
+
+/// Auto-activate the fetched zig-package emsdk for a wasm build (the remaining
+/// half of labelle-assembler#492). Call AFTER dependencies are fetched (e.g.
+/// after the fingerprint `zig build --list-steps` pass) and BEFORE the real
+/// `zig build`, on the host wasm path only.
+///
+/// Best-effort by contract: idempotent (skips when `emcc` already exists),
+/// serialized behind an fs2 advisory lock (concurrent builds don't race), and
+/// NON-fatal — on any failure (package not yet fetched, no network, activation
+/// error) it logs and returns so the build still surfaces the clear #492
+/// fallback error. `version` is the PINNED emsdk version (never `latest`), so
+/// activation is deterministic.
+pub fn activateFetchedEmsdk(allocator: std.mem.Allocator, build_dir: []const u8, version: []const u8) void {
+    activateFetchedEmsdkImpl(allocator, build_dir, version) catch |err| {
+        std.debug.print(
+            "labelle: emsdk auto-activation skipped ({any}); if the wasm build cannot find emcc, see labelle-assembler#492\n",
+            .{err},
+        );
+    };
+}
+
+fn activateFetchedEmsdkImpl(allocator: std.mem.Allocator, build_dir: []const u8, version: []const u8) !void {
+    // `version` reaches `emsdk install/activate <ver>` as an argument; guard it
+    // the same way `emsdk_toolchain.ensureInstalled` does.
+    if (!emsdk_toolchain.isSafeVersion(version)) return error.EmsdkInvalidVersion;
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+
+    const pkg = (try locateFetchedEmsdk(allocator, build_dir)) orelse return;
+    defer allocator.free(pkg);
+
+    const emcc_path = try std.fs.path.join(allocator, &.{ pkg, emsdk_cache.emcc_relpath });
+    defer allocator.free(emcc_path);
+    // Fast path: already activated (emcc present), no lock contention.
+    if (cwd.access(io, emcc_path, .{})) |_| return else |_| {}
+
+    // Serialize activation of the SAME package across processes with an
+    // advisory lock (mirrors `ensureInstalled`): two concurrent `labelle wasm`
+    // builds could otherwise run `emsdk install` in the same dir at once. Key
+    // the lock on a hash of the package path so distinct projects/caches don't
+    // block each other. The lock releases when the holder exits.
+    const eroot = try emsdk_cache.emsdkRoot(allocator);
+    defer allocator.free(eroot);
+    cwd.createDirPath(io, eroot) catch {};
+    const lock_path = try std.fmt.allocPrint(allocator, "{s}{c}pkg-{x}.lock", .{ eroot, std.fs.path.sep, std.hash.Wyhash.hash(0, pkg) });
+    defer allocator.free(lock_path);
+    const lock_file = cwd.createFile(io, lock_path, .{ .truncate = false, .lock = .exclusive }) catch |err| {
+        std.debug.print("labelle: could not acquire emsdk activation lock {s}: {any}\n", .{ lock_path, err });
+        return error.EmsdkInstallLockFailed;
+    };
+    defer lock_file.close(io); // releases the advisory lock
+
+    // Double-checked: another process may have finished activating while we
+    // were blocked on the lock.
+    if (cwd.access(io, emcc_path, .{})) |_| return else |_| {}
+
+    // Zig marks fetched package dirs read-only; `emsdk install` must create
+    // `upstream/`, `node/`, `.emscripten` under this tree. Make it writable +
+    // the launcher executable (both best-effort).
+    makeTreeWritable(pkg);
+    const launcher = try std.fs.path.join(allocator, &.{ pkg, emsdk_cache.emsdk_launcher_name });
+    defer allocator.free(launcher);
+    if (!is_windows) {
+        if (cwd.openFile(io, launcher, .{})) |file| {
+            defer file.close(io);
+            file.setPermissions(io, .fromMode(0o755)) catch {};
+        } else |_| {}
+    }
+
+    std.debug.print("labelle: activating fetched emsdk {s} for wasm (labelle-assembler#492)...\n", .{version});
+    std.debug.print("  {s}\n", .{pkg});
+    std.debug.print("  emsdk install {s}...\n", .{version});
+    try emsdk_toolchain.activateStep(allocator, launcher, pkg, "install", version);
+    std.debug.print("  emsdk activate {s}...\n", .{version});
+    try emsdk_toolchain.activateStep(allocator, launcher, pkg, "activate", version);
+
+    // Sanity: emcc must exist now, else the build will still fail — surface why.
+    cwd.access(io, emcc_path, .{}) catch {
+        std.debug.print("labelle: emsdk {s} activated but '{s}' is still missing under {s}\n", .{ version, emsdk_cache.emcc_relpath, pkg });
+        return error.EmsdkActivationIncomplete;
+    };
+    std.debug.print("  emcc ready ({s})\n", .{emcc_path});
+}
+
+/// Locate the fetched emsdk package dir — a directory that directly contains
+/// the emsdk launcher, i.e. the checkout `b.dependency("emsdk")` resolves to.
+/// Searches, in order:
+///   1. `<build_dir>/zig-pkg/` — the project-local vendored package dir the
+///      assembler-generated build uses.
+///   2. `<zig-global-cache>/p/` — the shared package cache fallback.
+/// Returns the first match (heap-owned; caller frees), or null when none is
+/// found (not fetched yet / unusual layout). Never errors on a missing dir.
+fn locateFetchedEmsdk(allocator: std.mem.Allocator, build_dir: []const u8) !?[]u8 {
+    {
+        const root = try std.fs.path.join(allocator, &.{ build_dir, "zig-pkg" });
+        defer allocator.free(root);
+        if (try findEmsdkUnder(allocator, root)) |p| return p;
+    }
+    if (zig_cache.globalCacheDir(allocator)) |gc| {
+        defer allocator.free(gc);
+        const root = try std.fs.path.join(allocator, &.{ gc, "p" });
+        defer allocator.free(root);
+        if (try findEmsdkUnder(allocator, root)) |p| return p;
+    } else |_| {}
+    return null;
+}
+
+/// Scan the immediate subdirs of `root` for an emsdk checkout — a dir that
+/// contains BOTH the `emsdk` launcher and `emsdk.py` (the emsdk-repo signature,
+/// so a same-named dir from another package can't false-match). Returns the
+/// first match (heap-owned), or null. A missing/unopenable `root` yields null.
+fn findEmsdkUnder(allocator: std.mem.Allocator, root: []const u8) !?[]u8 {
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+    var dir = cwd.openDir(io, root, .{ .iterate = true }) catch return null;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const cand = try std.fs.path.join(allocator, &.{ root, entry.name });
+        const launcher = try std.fs.path.join(allocator, &.{ cand, emsdk_cache.emsdk_launcher_name });
+        defer allocator.free(launcher);
+        const emsdk_py = try std.fs.path.join(allocator, &.{ cand, "emsdk.py" });
+        defer allocator.free(emsdk_py);
+        const has_launcher = !std.meta.isError(cwd.access(io, launcher, .{}));
+        const has_py = !std.meta.isError(cwd.access(io, emsdk_py, .{}));
+        if (has_launcher and has_py) return cand;
+        allocator.free(cand);
+    }
+    return null;
+}
+
+/// Best-effort: add owner rwx to `root` and every directory beneath it so an
+/// `emsdk install` can create files under Zig's read-only package tree. Only
+/// directories are touched — creating new files needs a writable PARENT dir;
+/// pre-activation regular files staying read-only doesn't block that. Never
+/// fails the caller. No-op on Windows (fetched package files aren't marked
+/// read-only via POSIX mode bits there).
+fn makeTreeWritable(root: []const u8) void {
+    if (!is_windows) {
+        const io = config.globalIo();
+        const cwd = std.Io.Dir.cwd();
+        var dir = cwd.openDir(io, root, .{ .iterate = true }) catch return;
+        defer dir.close(io);
+        dir.setPermissions(io, .fromMode(0o755)) catch {};
+        var walker = dir.walk(std.heap.page_allocator) catch return;
+        defer walker.deinit();
+        while (walker.next(io) catch null) |entry| {
+            if (entry.kind != .directory) continue;
+            entry.dir.setFilePermissions(io, entry.basename, .fromMode(0o755), .{}) catch {};
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const asm_cache = @import("asm_cache.zig");
+const DEFAULT_EMSDK_VERSION = emsdk_toolchain.DEFAULT_EMSDK_VERSION;
+
+/// Records which emsdk steps ran and, on `activate`, materializes the `emcc`
+/// file in the target dir so the post-activation sanity check + the idempotent
+/// fast path see exactly what a real activation would produce. Mirrors the
+/// recorder in `emsdk_toolchain.zig`, scoped to the in-place activation.
+const StepRecorder = struct {
+    var saw_clone: bool = false;
+    var saw_install: bool = false;
+    var saw_activate: bool = false;
+
+    fn reset() void {
+        saw_clone = false;
+        saw_install = false;
+        saw_activate = false;
+    }
+
+    fn exec(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) anyerror!emsdk_toolchain.ExecResult {
+        for (argv) |a| {
+            if (std.mem.eql(u8, a, "clone")) saw_clone = true;
+            if (std.mem.eql(u8, a, "install")) saw_install = true;
+            if (std.mem.eql(u8, a, "activate")) saw_activate = true;
+        }
+        if (saw_activate) {
+            const dir = cwd orelse return .{ .exit_code = 1 };
+            const io = config.globalIo();
+            const em_dir = try std.fs.path.join(allocator, &.{ dir, "upstream", "emscripten" });
+            defer allocator.free(em_dir);
+            std.Io.Dir.cwd().createDirPath(io, em_dir) catch {};
+            const emcc = try std.fs.path.join(allocator, &.{ em_dir, emsdk_cache.emcc_name });
+            defer allocator.free(emcc);
+            std.Io.Dir.cwd().writeFile(io, .{ .sub_path = emcc, .data = "#!/bin/sh\n" }) catch {};
+        }
+        return .{ .exit_code = 0 };
+    }
+};
+
+/// Stage a fetched-but-UNACTIVATED emsdk checkout under
+/// `<build_dir>/zig-pkg/<hash>/` (launcher + `emsdk.py`, no `upstream/`), the
+/// exact shape `locateFetchedEmsdk` looks for. Returns the owned pkg path.
+fn stageFetchedEmsdkPkg(alloc: std.mem.Allocator, build_dir: []const u8) ![]u8 {
+    const io = config.globalIo();
+    const cwd = std.Io.Dir.cwd();
+    const pkg = try std.fs.path.join(alloc, &.{ build_dir, "zig-pkg", "N-V-fakeemsdkhash" });
+    try cwd.createDirPath(io, pkg);
+    const launcher = try std.fs.path.join(alloc, &.{ pkg, emsdk_cache.emsdk_launcher_name });
+    defer alloc.free(launcher);
+    try cwd.writeFile(io, .{ .sub_path = launcher, .data = "#!/bin/sh\n" });
+    const py = try std.fs.path.join(alloc, &.{ pkg, "emsdk.py" });
+    defer alloc.free(py);
+    try cwd.writeFile(io, .{ .sub_path = py, .data = "# emsdk\n" });
+    return pkg;
+}
+
+test "activateFetchedEmsdk activates the fetched zig-package emsdk in place, idempotently" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+    const root = buf[0..n];
+
+    asm_cache.setCacheRootOverride(root);
+    defer asm_cache.clearCacheRootOverride();
+    StepRecorder.reset();
+    emsdk_toolchain.setExecOverrideForTest(StepRecorder.exec);
+    defer emsdk_toolchain.setExecOverrideForTest(null);
+
+    const build_dir = try std.fs.path.join(alloc, &.{ root, "build" });
+    defer alloc.free(build_dir);
+    const pkg = try stageFetchedEmsdkPkg(alloc, build_dir);
+    defer alloc.free(pkg);
+
+    // Not activated yet: emcc absent.
+    const emcc_path = try std.fs.path.join(alloc, &.{ pkg, emsdk_cache.emcc_relpath });
+    defer alloc.free(emcc_path);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(config.globalIo(), emcc_path, .{}));
+
+    activateFetchedEmsdk(alloc, build_dir, DEFAULT_EMSDK_VERSION);
+
+    // The #492 fix: install + activate ran IN PLACE (no clone — the package is
+    // already fetched), and emcc now exists where the build's link step looks.
+    try testing.expect(!StepRecorder.saw_clone);
+    try testing.expect(StepRecorder.saw_install);
+    try testing.expect(StepRecorder.saw_activate);
+    try std.Io.Dir.cwd().access(config.globalIo(), emcc_path, .{});
+
+    // Idempotent: a second call is a no-op fast path (emcc already present).
+    StepRecorder.reset();
+    activateFetchedEmsdk(alloc, build_dir, DEFAULT_EMSDK_VERSION);
+    try testing.expect(!StepRecorder.saw_install);
+    try testing.expect(!StepRecorder.saw_activate);
+}
+
+test "activateFetchedEmsdk is a no-op (no steps, no error) when no emsdk package is fetched" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+    const root = buf[0..n];
+
+    asm_cache.setCacheRootOverride(root);
+    defer asm_cache.clearCacheRootOverride();
+    StepRecorder.reset();
+    emsdk_toolchain.setExecOverrideForTest(StepRecorder.exec);
+    defer emsdk_toolchain.setExecOverrideForTest(null);
+
+    // build_dir has no zig-pkg/ at all — nothing to locate.
+    const build_dir = try std.fs.path.join(alloc, &.{ root, "empty-build" });
+    defer alloc.free(build_dir);
+    std.Io.Dir.cwd().createDirPath(config.globalIo(), build_dir) catch {};
+
+    activateFetchedEmsdk(alloc, build_dir, DEFAULT_EMSDK_VERSION);
+    try testing.expect(!StepRecorder.saw_install);
+    try testing.expect(!StepRecorder.saw_activate);
+}
+
+test "activateFetchedEmsdk ignores an unsafe version without running any step" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(config.globalIo(), &buf);
+    const root = buf[0..n];
+
+    asm_cache.setCacheRootOverride(root);
+    defer asm_cache.clearCacheRootOverride();
+    StepRecorder.reset();
+    emsdk_toolchain.setExecOverrideForTest(StepRecorder.exec);
+    defer emsdk_toolchain.setExecOverrideForTest(null);
+
+    const build_dir = try std.fs.path.join(alloc, &.{ root, "build" });
+    defer alloc.free(build_dir);
+    const pkg = try stageFetchedEmsdkPkg(alloc, build_dir);
+    defer alloc.free(pkg);
+
+    // Unsafe version rejected before spawning `emsdk` (guarded, non-fatal).
+    activateFetchedEmsdk(alloc, build_dir, "../../etc");
+    try testing.expect(!StepRecorder.saw_install);
+    try testing.expect(!StepRecorder.saw_activate);
+}

--- a/src/cli/emsdk_toolchain.zig
+++ b/src/cli/emsdk_toolchain.zig
@@ -437,8 +437,10 @@ pub fn ensureInstalled(allocator: std.mem.Allocator, version: []const u8) !void 
 }
 
 /// Invoke the emsdk launcher for a subcommand (`install`/`activate`) in `dir`.
-/// On Windows the launcher is a `.bat`, so it runs through `cmd /c`.
-fn activateStep(allocator: std.mem.Allocator, launcher: []const u8, dir: []const u8, subcmd: []const u8, version: []const u8) !void {
+/// On Windows the launcher is a `.bat`, so it runs through `cmd /c`. Public so
+/// `emsdk_activate.zig` can reuse it (and the shared test exec seam) to activate
+/// the FETCHED zig-package emsdk in place.
+pub fn activateStep(allocator: std.mem.Allocator, launcher: []const u8, dir: []const u8, subcmd: []const u8, version: []const u8) !void {
     if (is_windows) {
         try execStep(allocator, &.{ "cmd", "/c", launcher, subcmd, version }, dir);
     } else {


### PR DESCRIPTION
## Problem

A fresh `labelle build --platform wasm` (default edition — emsdk fetched on demand, not pre-seeded) resolves core/engine/gfx/assembler/bgfx, generates `.labelle/bgfx_wasm/`, then **dies at the emcc step**:

```
[labelle] Emscripten (emsdk) is fetched but not activated — the wasm build cannot find `emcc`.
    cd ".../zig-pkg/N-V-...emsdk.../" && ./emsdk install latest && ./emsdk activate latest
```

Root cause (verified against origin/main): the assembler-generated backend hooks (bgfx/sokol/raylib) link wasm via `b.dependency("emsdk").path("upstream/emscripten/emcc")` — the emsdk git checkout Zig fetches into the **project-local `<build_dir>/zig-pkg/<hash>/`**. That package is FETCHED but NOT ACTIVATED (`emcc` is materialized only by `emsdk install` + `emsdk activate`), so the link step hits `FileNotFound`. The managed-emsdk env wiring (`buildWasmEnv`, EMSDK/EM_CONFIG/PATH) cannot fix this — the hook resolves emcc from the fetched package, ignoring EMSDK/PATH.

**assembler#492 was closed having shipped ONLY the clear-error message (option 3).** This PR is the unshipped "auto-activate as a build step" half (option 1). The `--docker` path already does this in-container (`docker.zig`'s `activate_emsdk`); the **host** path never did.

## Fix

New `src/cli/emsdk_activate.zig`: after the fingerprint pass fetches deps and before the real `zig build`, **locate the fetched emsdk package** (`<build_dir>/zig-pkg/` then the global cache `/p`, matched by the `emsdk` launcher + `emsdk.py` signature) and run `emsdk install <PINNED ver>` + `emsdk activate <PINNED ver>` **in place** (chmod the read-only package tree writable + launcher +x first). Runs **before** the `generate` early-return so `generate --platform wasm` + manual `zig build` is covered too.

- **Deterministic:** uses the PINNED `DEFAULT_EMSDK_VERSION` (`4.0.9`), never `latest`.
- **Idempotent + cached:** skips when `upstream/emscripten/emcc` already exists.
- **Locked:** serialized behind an fs2 advisory lock keyed on the package path.
- **Non-fatal fallback:** on any failure (not fetched, no network, activation error) it logs and returns, so the build still surfaces the clear #492 message. The #492 message is untouched.

`activateStep` promoted to `pub` for reuse; the misleading "activate the managed emsdk" comment on the env-wiring path corrected.

## Verification

- `zig build`, `zig build test`, `zig fmt --check` all green on Zig 0.16.0. New files well under 1000 lines.
- New mocked-exec unit tests: activation runs install+activate in place → emcc appears at the exact path the link step uses; idempotent second call is a no-op; no-op when no package is fetched; unsafe version rejected before spawning.
- **Real end-to-end proof** on the pinned emsdk (`4.0.9`), on a copy of a genuinely fetched-but-unactivated package:
  - **BEFORE:** `upstream/emscripten/emcc` = FileNotFound, no `.emscripten` marker (reproduces #492).
  - **AFTER** the pinned `install`+`activate` in place: `upstream/emscripten/emcc` present (`-rwxr-xr-x`), `.emscripten` written, and `emcc --version` → `4.0.9`.

## Downstream release chain (unblocks labelle-studio#54)

1. Merge + tag a **labelle-cli** release (this PR bumps `build.zig.zon` to **1.52.0**; release.yml tags the binary).
2. Studio bundles the CLI **sidecar** — its pinned CLI version must be advanced to ≥1.52.0 and the bundle rebuilt.
3. **Re-stage** the acceptance AppImage so it carries the new CLI, then re-run the studio#54 Play leg. The fixture's assembler pin is unaffected (the fix is CLI-side; the generated build.zig is unchanged) — only the CLI sidecar matters.

Note: **assembler#492 should be reopened (or a new tracking issue filed)** — it was closed with only the error-message half; this completes the auto-activate half.

Do NOT merge — awaiting review.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw