### PR TITLE
fix(release): drop pip-installed awscli (v1) for preinstalled aws v2 + R2 compat (#297)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,18 +191,34 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # R2's S3 API needs a region for the AWS CLI to initialise (#297).
+          AWS_DEFAULT_REGION: auto
+          # aws v2 (the preinstalled CLI) sends integrity checksums that R2
+          # rejects; `when_required` restricts them to operations that
+          # actually need them. Without these, dropping the pip v1 install
+          # below swaps a PEP-668 failure for a checksum-rejection failure.
+          # Same settings labelle-studio's working R2 upload uses.
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
-          pip install awscli
+          # Use the aws CLI preinstalled on ubuntu-latest (v2). NOT
+          # `pip install awscli` — that installs v1 into the system Python
+          # and fails on PEP-668 (externally-managed-environment) once the
+          # runner image enforces it, breaking the release before any
+          # upload runs (#297). Higher-stakes than the assembler's mirror
+          # of this bug: studio has no GitHub fallback for the CLI sidecar,
+          # so a CLI R2 outage is user-visible in every bundle build.
           VERSION=${GITHUB_REF#refs/tags/}
-          
+
           for dir in artifacts/*/; do
             name=$(basename "$dir")
-            file=$(ls "$dir")
-            aws s3 cp "$dir$file" "s3://$R2_BUCKET/cli/$VERSION/$name" \
-              --endpoint-url $R2_ENDPOINT
+            for file in "$dir"*; do
+              aws s3 cp "$file" "s3://$R2_BUCKET/cli/$VERSION/$name" \
+                --endpoint-url "$R2_ENDPOINT"
+            done
           done
-          
+
           echo "$VERSION" | aws s3 cp - "s3://$R2_BUCKET/cli/latest.txt" \
-            --endpoint-url $R2_ENDPOINT
-          
+            --endpoint-url "$R2_ENDPOINT"
+
           echo "Released $VERSION to R2"


### PR DESCRIPTION
## The bug
The `Upload to R2` job runs `pip install awscli` → aws **v1** in the system Python. Once the `ubuntu-latest` image enforces **PEP 668** (externally-managed-environment) for that pip, the install fails **before any upload runs**, and CLI R2 publishing silently stops. It works today (`cli/latest.txt = v1.55.1`), so it's a latent time-bomb.

**Why higher-stakes than the assembler's identical bug** (fixed in assembler#559): studio's `fetch-sidecars.mjs` has a GitHub fallback for the *assembler* sidecar but **none for the CLI** — so a CLI R2 outage is **user-visible in every studio bundle build**, not a silent degradation.

## The fix
Use the aws **v2** preinstalled on `ubuntu-latest`. v2 sends integrity checksums R2 rejects, so this adds the compat settings studio's working upload already uses — they're **load-bearing**, not cosmetic: without them, removing the pip install just swaps a PEP-668 failure for a checksum-rejection failure.
```yaml
AWS_DEFAULT_REGION: auto
AWS_REQUEST_CHECKSUM_CALCULATION: when_required
AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
```
Also tidied `file=$(ls "$dir")` → a glob loop and quoted `$R2_ENDPOINT` (SC2012/SC2086).

## Decisions (discussed)
- **Left ungated.** Unlike assembler/studio's skip-green-when-secrets-absent, publishing *is* the point of a CLI release — it should hard-fail if it can't upload.
- **Findings 1 & 4 from #559 N/A here:** the CLI hardcodes `R2_ENDPOINT`/`R2_BUCKET` (no malformed-endpoint risk) and triggers on `push: tags:` only (no `workflow_dispatch` backfill path to regress `cli/latest.txt`).

## Validation note (important)
The `Upload to R2` job runs **only on push tags**, so it does **not** execute on this PR — the PR's CI covers the other jobs (build/test) but not the R2 upload. The definitive validation is the **next release tag**. The one edge to watch there: the `latest.txt` upload is a **streamed stdin** `aws s3 cp -`, a slightly different path than studio's proven file uploads; `when_required` disables the aws-chunked trailing checksum that R2 rejects, so it should cover the streaming case too, but the first real tag is the confirmation. Merging is net risk-DOWN regardless: it removes the PEP-668 time-bomb that would otherwise break the same job.

Closes #297

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j