### PR TITLE
feat(update): machine-readable update checks — `update/upgrade --check [--json]` (#276)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -11,8 +11,8 @@
 ///   labelle install [pkg] [ver]         — fetch packages into cache
 ///   labelle install assembler <ver>    — download and cache an assembler binary
 ///   labelle assembler list             — list cached assembler versions
-///   labelle upgrade [dir] [pkg] [ver]   — bump versions in project.labelle
-///   labelle update [ver]                — self-update the CLI
+///   labelle upgrade [dir] [pkg] [ver] [--check] [--json]  — bump versions in project.labelle; `--check`/`--json` report pins vs latest read-only (labelle-cli#276)
+///   labelle update [ver] [--check] [--json]  — self-update the CLI; `--check`/`--json` report installed vs latest read-only (labelle-cli#276)
 ///   labelle clean [--dry-run]           — prune unused package versions
 ///   labelle test [dir] [--verbose]      — run inline `test` blocks across the project source tree
 ///   labelle check [dir]                 — lint packs for §6 convention violations (Packs RFC)
@@ -26,6 +26,7 @@ const add = @import("cli/add.zig");
 const install = @import("cli/install.zig");
 const upgrade = @import("cli/upgrade.zig");
 const update = @import("cli/update.zig");
+const update_check = @import("cli/update_check.zig");
 const clean = @import("cli/clean.zig");
 const test_cmd_mod = @import("cli/test.zig");
 const config = @import("cli/config.zig");
@@ -748,8 +749,22 @@ pub fn main(proc_init: std.process.Init) !void {
             try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "upgrade")) {
             parsed_args.command = .upgrade_cmd;
-            if (args.next()) |next_arg| {
-                if (std.mem.eql(u8, next_arg, "core") or
+            // Grammar: `upgrade [dir] [flags] [<subcommand> [args...]]`.
+            // Flags (`--check`/`--json`/`--force`/`-f`) may appear anywhere;
+            // the first bare non-subcommand token is the project dir; once a
+            // subcommand is seen, the remaining tokens are its args. A
+            // leading-dash token must NEVER be captured as the project dir —
+            // otherwise `upgrade --check` would send `--check` to
+            // readProjectConfig and bail before the check runs (this also
+            // fixes the same latent bug for a leading `--force`).
+            var seen_subcommand = false;
+            var dir_set = false;
+            while (args.next()) |next_arg| {
+                if (std.mem.startsWith(u8, next_arg, "-")) {
+                    try appendExtraArg(&parsed_args, next_arg);
+                } else if (seen_subcommand) {
+                    try appendExtraArg(&parsed_args, next_arg);
+                } else if (std.mem.eql(u8, next_arg, "core") or
                     std.mem.eql(u8, next_arg, "engine") or
                     std.mem.eql(u8, next_arg, "gfx") or
                     std.mem.eql(u8, next_arg, "cli") or
@@ -758,11 +773,14 @@ pub fn main(proc_init: std.process.Init) !void {
                     std.mem.eql(u8, next_arg, "all"))
                 {
                     try appendExtraArg(&parsed_args, next_arg);
-                } else {
+                    seen_subcommand = true;
+                } else if (!dir_set) {
                     parsed_args.project_dir = next_arg;
+                    dir_set = true;
+                } else {
+                    try appendExtraArg(&parsed_args, next_arg);
                 }
             }
-            try collectExtraArgs(&args, &parsed_args);
         } else if (std.mem.eql(u8, first, "update")) {
             parsed_args.command = .update_cmd;
             try collectExtraArgs(&args, &parsed_args);
@@ -1871,6 +1889,14 @@ pub const MigrateDeleteTopLevelKeyBlockCommentSpec = migrate.DeleteTopLevelKeyBl
 // Surface the check-command spec namespace so `zspec.runAll(@This())`
 // walks into it (mirrors the audit/migrate re-exports above).
 pub const CheckParseCheckArgsSpec = check.ParseCheckArgsSpec;
+
+// Surface the machine-readable update/upgrade `--check`/`--json` specs
+// (labelle-cli#276) so `zspec.runAll(@This())` walks into them.
+pub const UpdateCheckCliStatusSpec = update_check.CliStatusSpec;
+pub const UpdateCheckPackageStatusSpec = update_check.PackageStatusSpec;
+pub const UpdateCheckExitCodeSpec = update_check.ExitCodeSpec;
+pub const UpdateCheckJsonShapeSpec = update_check.JsonShapeSpec;
+pub const UpdateParseArgsSpec = update.ParseUpdateArgsSpec;
 
 // Surface the build-progress feed specs (cli#284) so
 // `zspec.runAll(@This())` walks into them: the phase state machine,

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -20,8 +20,8 @@ pub fn printHelp() void {
         \\  install [pkg] [ver]  Fetch packages into cache
         \\  install assembler <ver>  Download and cache an assembler binary
         \\  assembler list       List cached assembler versions
-        \\  upgrade [dir] [pkg] [ver]  Bump versions in project.labelle (pkg: core, engine, gfx, cli, assembler, all)
-        \\  update [ver] [--no-path]  Update the labelle CLI itself
+        \\  upgrade [dir] [pkg] [ver] [--check] [--json]  Bump versions in project.labelle (pkg: core, engine, gfx, cli, assembler, all); `--check` reports pins vs latest WITHOUT writing (exit 2 = updates available), `--json` emits a machine-readable report (implies --check)
+        \\  update [ver] [--no-path] [--check] [--json]  Update the labelle CLI itself; `--check` reports installed vs latest WITHOUT installing (exit 2 = update available), `--json` emits a machine-readable report (implies --check)
         \\  clean [--dry-run] [--project=dir]  Remove unused cached package versions
         \\  test [dir] [--verbose] [--no-libs]  Run inline `test` blocks across the project source tree
         \\  audit unification [dir]  Pre-flight check for the unified scene/prefab loader (RFC #560)
@@ -59,6 +59,10 @@ pub fn printHelp() void {
         \\  labelle run -- --preview-mode 127.0.0.1:54321
         \\  labelle install 0.2.0
         \\  labelle upgrade core 0.2.0
+        \\  labelle update --check
+        \\  labelle update --check --json
+        \\  labelle upgrade --check
+        \\  labelle upgrade --check --json
         \\  labelle test
         \\  labelle test ../my-game --verbose
         \\  labelle test --no-libs

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -24,7 +24,7 @@ const UpdateArgs = struct {
     }
 };
 
-fn parseUpdateArgs(cmd_args: []const []const u8) UpdateArgs {
+fn parseUpdateArgs(cmd_args: []const []const u8) !UpdateArgs {
     var out = UpdateArgs{};
     for (cmd_args) |arg| {
         if (std.mem.eql(u8, arg, "--no-path")) {
@@ -33,6 +33,16 @@ fn parseUpdateArgs(cmd_args: []const []const u8) UpdateArgs {
             out.check = true;
         } else if (std.mem.eql(u8, arg, "--json")) {
             out.json = true;
+        } else if (std.mem.startsWith(u8, arg, "--")) {
+            // Reject unknown flags instead of silently treating them as the
+            // target version. Critical: a typo like `--chek` — especially
+            // `--chek 1.60.0`, where the good version would overwrite the
+            // dropped typo — must NEVER slip past the read-only `--check`
+            // guard into the binary-replacing install path (CodeRabbit,
+            // PR #299). Mirrors the `labelle status` unknown-flag convention.
+            std.debug.print("labelle update: unknown flag '{s}'\n", .{arg});
+            std.debug.print("  usage: labelle update [ver] [--no-path] [--check] [--json]\n", .{});
+            return error.InvalidArguments;
         } else {
             out.version_arg = arg;
         }
@@ -98,7 +108,7 @@ fn cmdUpdateCheck(allocator: std.mem.Allocator, version_arg: ?[]const u8, json: 
 
 /// Self-update the CLI binary by downloading from the release server.
 pub fn cmdUpdate(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
-    const parsed = parseUpdateArgs(cmd_args);
+    const parsed = try parseUpdateArgs(cmd_args);
 
     // Read-only reporting mode: never mutate/install (labelle-cli#276).
     if (parsed.reportOnly()) {
@@ -445,41 +455,60 @@ pub const ParseUpdateArgsSpec = struct {
     const testing = std.testing;
 
     test "bare update: install mode, no version, keeps PATH setup" {
-        const a = parseUpdateArgs(&.{});
+        const a = try parseUpdateArgs(&.{});
         try testing.expect(!a.reportOnly());
         try testing.expect(!a.skip_path);
         try testing.expect(a.version_arg == null);
     }
 
     test "--no-path is still recognized and stays install mode" {
-        const a = parseUpdateArgs(&.{"--no-path"});
+        const a = try parseUpdateArgs(&.{"--no-path"});
         try testing.expect(a.skip_path);
         try testing.expect(!a.reportOnly());
     }
 
     test "--check selects read-only report mode (not json)" {
-        const a = parseUpdateArgs(&.{"--check"});
+        const a = try parseUpdateArgs(&.{"--check"});
         try testing.expect(a.check);
         try testing.expect(!a.json);
         try testing.expect(a.reportOnly());
     }
 
     test "--json implies report-only (never mutates)" {
-        const a = parseUpdateArgs(&.{"--json"});
+        const a = try parseUpdateArgs(&.{"--json"});
         try testing.expect(a.json);
         try testing.expect(a.reportOnly());
     }
 
     test "--check --json together" {
-        const a = parseUpdateArgs(&.{ "--check", "--json" });
+        const a = try parseUpdateArgs(&.{ "--check", "--json" });
         try testing.expect(a.check);
         try testing.expect(a.json);
         try testing.expect(a.reportOnly());
     }
 
     test "explicit version arg is captured alongside --check" {
-        const a = parseUpdateArgs(&.{ "--check", "1.99.0" });
+        const a = try parseUpdateArgs(&.{ "--check", "1.99.0" });
         try testing.expect(a.reportOnly());
         try testing.expectEqualStrings("1.99.0", a.version_arg.?);
+    }
+
+    test "unknown flag is rejected, not treated as a version" {
+        // Without the reject branch this returns version_arg="--jso" and
+        // proceeds to the mutating install path — CodeRabbit PR #299.
+        try testing.expectError(error.InvalidArguments, parseUpdateArgs(&.{"--jso"}));
+    }
+
+    test "typo'd flag before a real version is rejected (never mutates)" {
+        // The safety-critical exploit: `--chek 1.60.0` — the dropped typo
+        // leaves 1.60.0 as version_arg and INSTALLS it. Reject on the
+        // unknown flag before the version is ever considered.
+        try testing.expectError(error.InvalidArguments, parseUpdateArgs(&.{ "--chek", "1.60.0" }));
+    }
+
+    test "a bare non-dash token is still a valid version positional" {
+        const a = try parseUpdateArgs(&.{"1.2.3"});
+        try testing.expect(!a.reportOnly());
+        try testing.expectEqualStrings("1.2.3", a.version_arg.?);
     }
 };

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -3,20 +3,110 @@ const project_config = @import("project_config.zig");
 const asm_cache = @import("asm_cache.zig");
 const util = @import("util.zig");
 const config = @import("config.zig");
+const update_check = @import("update_check.zig");
+
+/// Release server that hosts the CLI binaries + `latest.txt`.
+const r2_base_url = "https://releases.labelle.games/cli";
+
+/// Parsed `update` flags. `--check`/`--json` select the read-only,
+/// machine-readable reporting mode (labelle-cli#276); `--json` implies
+/// `--check` so a tool asking for JSON never triggers a mutating install.
+const UpdateArgs = struct {
+    skip_path: bool = false,
+    check: bool = false,
+    json: bool = false,
+    version_arg: ?[]const u8 = null,
+
+    /// True when the invocation is a read-only version check rather than a
+    /// self-update install.
+    fn reportOnly(self: UpdateArgs) bool {
+        return self.check or self.json;
+    }
+};
+
+fn parseUpdateArgs(cmd_args: []const []const u8) UpdateArgs {
+    var out = UpdateArgs{};
+    for (cmd_args) |arg| {
+        if (std.mem.eql(u8, arg, "--no-path")) {
+            out.skip_path = true;
+        } else if (std.mem.eql(u8, arg, "--check")) {
+            out.check = true;
+        } else if (std.mem.eql(u8, arg, "--json")) {
+            out.json = true;
+        } else {
+            out.version_arg = arg;
+        }
+    }
+    return out;
+}
+
+/// Fetch the newest published CLI version from the R2 release server.
+/// Returns an owned, trimmed version string (leading `v` stripped), or
+/// `null` on any failure (curl missing, network error, HTTP error, empty
+/// body). Read-only — never downloads a binary.
+fn fetchLatestCliVersion(allocator: std.mem.Allocator) ?[]u8 {
+    const latest_url = r2_base_url ++ "/latest.txt";
+    const result = util.runCmd(allocator, &.{ "curl", "-s", "-f", latest_url }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+
+    var latest = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
+    if (std.mem.startsWith(u8, latest, "v")) latest = latest[1..];
+    if (latest.len == 0) return null;
+    return allocator.dupe(u8, latest) catch null;
+}
+
+/// `labelle update --check [--json]` (labelle-cli#276): report the running
+/// CLI version vs the newest published release WITHOUT installing anything.
+/// Emits `{ "cli": {...}, "packages": [] }` under `--json` (studio#7) or a
+/// human line otherwise. Exits 2 when an update is available, else 0.
+fn cmdUpdateCheck(allocator: std.mem.Allocator, version_arg: ?[]const u8, json: bool) !void {
+    // `latest` is either an explicit version arg (borrowed from argv) or a
+    // fetched owned string; track ownership so we free only what we alloc.
+    var latest_owned: ?[]u8 = null;
+    defer if (latest_owned) |l| allocator.free(l);
+    const latest: ?[]const u8 = version_arg orelse blk: {
+        latest_owned = fetchLatestCliVersion(allocator);
+        break :blk latest_owned;
+    };
+
+    const cli = update_check.cliStatus(project_config.CLI_VERSION, latest);
+    const report = update_check.Report{ .cli = cli };
+
+    var out_buf: [4096]u8 = undefined;
+    var w = std.Io.File.stdout().writerStreaming(config.globalIo(), &out_buf);
+    if (json) {
+        update_check.writeJson(&w.interface, report) catch {};
+    } else {
+        update_check.writeHumanCli(&w.interface, cli) catch {};
+    }
+    w.interface.flush() catch {};
+
+    const code = update_check.exitCode(report);
+    if (code != 0) {
+        // std.process.exit skips defers — free before leaving.
+        if (latest_owned) |l| allocator.free(l);
+        latest_owned = null;
+        std.process.exit(code);
+    }
+}
 
 /// Self-update the CLI binary by downloading from the release server.
 pub fn cmdUpdate(allocator: std.mem.Allocator, cmd_args: []const []const u8) !void {
-    const r2_base_url = "https://releases.labelle.games/cli";
+    const parsed = parseUpdateArgs(cmd_args);
 
-    var skip_path = false;
-    var version_arg: ?[]const u8 = null;
-    for (cmd_args) |arg| {
-        if (std.mem.eql(u8, arg, "--no-path")) {
-            skip_path = true;
-        } else {
-            version_arg = arg;
-        }
+    // Read-only reporting mode: never mutate/install (labelle-cli#276).
+    if (parsed.reportOnly()) {
+        return cmdUpdateCheck(allocator, parsed.version_arg, parsed.json);
     }
+
+    const skip_path = parsed.skip_path;
+    const version_arg = parsed.version_arg;
 
     std.debug.print("labelle: checking for updates...\n", .{});
     std.debug.print("  current version: {s}\n\n", .{project_config.CLI_VERSION});
@@ -28,31 +118,11 @@ pub fn cmdUpdate(allocator: std.mem.Allocator, cmd_args: []const []const u8) !vo
     if (version_arg) |ver| {
         target_version = ver;
     } else {
-        const latest_url = r2_base_url ++ "/latest.txt";
-        const result = util.runCmd(allocator, &.{ "curl", "-s", "-f", latest_url }) catch {
-            std.debug.print("labelle: could not check for updates (is curl installed?)\n", .{});
+        target_version_owned = fetchLatestCliVersion(allocator) orelse {
+            std.debug.print("labelle: could not check for updates (is curl installed / are you online?)\n", .{});
             printManualUpdateInstructions("latest");
             return;
         };
-        defer allocator.free(result.stdout);
-        defer allocator.free(result.stderr);
-
-        switch (result.term) {
-            .exited => |code| if (code != 0) {
-                std.debug.print("labelle: could not fetch latest version from release server\n", .{});
-                printManualUpdateInstructions("latest");
-                return;
-            },
-            else => {
-                std.debug.print("labelle: curl terminated abnormally\n", .{});
-                return;
-            },
-        }
-
-        var latest = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
-        if (std.mem.startsWith(u8, latest, "v")) latest = latest[1..];
-
-        target_version_owned = try allocator.dupe(u8, latest);
         target_version = target_version_owned.?;
     }
 
@@ -298,7 +368,7 @@ fn setupPath(allocator: std.mem.Allocator, bin_dir: []const u8) void {
 
 fn setupPathWindows(allocator: std.mem.Allocator, bin_dir: []const u8) void {
     const get_result = util.runCmd(allocator, &.{
-        "powershell", "-NoProfile", "-Command",
+        "powershell",                                            "-NoProfile", "-Command",
         "[Environment]::GetEnvironmentVariable('Path', 'User')",
     }) catch {
         std.debug.print("  could not read current PATH — add {s} to your PATH manually\n\n", .{bin_dir});
@@ -362,3 +432,54 @@ fn printManualUpdateInstructions(version: []const u8) void {
     std.debug.print("    git clone https://github.com/labelle-toolkit/labelle-cli.git\n", .{});
     std.debug.print("    zig build -Doptimize=ReleaseSafe\n", .{});
 }
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+/// Flag parsing for `labelle update` (labelle-cli#276). Re-exported into
+/// cli.zig so `zspec.runAll` walks into it under `zig build test`.
+pub const ParseUpdateArgsSpec = struct {
+    const testing = std.testing;
+
+    test "bare update: install mode, no version, keeps PATH setup" {
+        const a = parseUpdateArgs(&.{});
+        try testing.expect(!a.reportOnly());
+        try testing.expect(!a.skip_path);
+        try testing.expect(a.version_arg == null);
+    }
+
+    test "--no-path is still recognized and stays install mode" {
+        const a = parseUpdateArgs(&.{"--no-path"});
+        try testing.expect(a.skip_path);
+        try testing.expect(!a.reportOnly());
+    }
+
+    test "--check selects read-only report mode (not json)" {
+        const a = parseUpdateArgs(&.{"--check"});
+        try testing.expect(a.check);
+        try testing.expect(!a.json);
+        try testing.expect(a.reportOnly());
+    }
+
+    test "--json implies report-only (never mutates)" {
+        const a = parseUpdateArgs(&.{"--json"});
+        try testing.expect(a.json);
+        try testing.expect(a.reportOnly());
+    }
+
+    test "--check --json together" {
+        const a = parseUpdateArgs(&.{ "--check", "--json" });
+        try testing.expect(a.check);
+        try testing.expect(a.json);
+        try testing.expect(a.reportOnly());
+    }
+
+    test "explicit version arg is captured alongside --check" {
+        const a = parseUpdateArgs(&.{ "--check", "1.99.0" });
+        try testing.expect(a.reportOnly());
+        try testing.expectEqualStrings("1.99.0", a.version_arg.?);
+    }
+};

--- a/src/cli/update_check.zig
+++ b/src/cli/update_check.zig
@@ -1,0 +1,366 @@
+//! Read-only, machine-readable "what's outdated?" reporting shared by
+//! `labelle update --check [--json]` and `labelle upgrade --check [--json]`
+//! (labelle-cli#276).
+//!
+//! Unblocks labelle-studio#7: studio wants to surface "CLI x.y.z available"
+//! and per-project pin-vs-latest WITHOUT parsing human output and WITHOUT
+//! mutating anything. So this module is a pure reporting layer — it computes
+//! a status document from versions supplied by the caller and serializes it;
+//! the network fetch (CLI latest) and project.labelle read live in the two
+//! command wrappers (`update.zig` / `upgrade.zig`).
+//!
+//! Schema (stable; additive changes only — studio consumes it). Both
+//! commands emit the SAME top-level shape; each populates only its half:
+//!
+//!   { "cli": { "installed": "1.55.1", "latest": "1.56.0"|null,
+//!              "update_available": bool, "checked": bool,
+//!              "error": "..."|null } | null,
+//!     "packages": [ { "name": "core", "pinned": "1.21.0"|null,
+//!                     "latest": "1.21.0"|null, "update_available": bool,
+//!                     "checked": bool, "error": "..."|null }, ... ] }
+//!
+//!   - `update --check`  → cli populated (binary vs published), packages [].
+//!   - `upgrade --check` → cli null, packages populated (pins vs the bundled
+//!                         compatible set).
+//!
+//! `checked`/`error` distinguish "up to date" from "couldn't determine"
+//! (offline for the CLI fetch; no-known-latest / local-path override for a
+//! pin). All keys are always present (`null` when unknown) so a typed
+//! consumer gets a stable shape — the same convention as the `--progress`
+//! NDJSON feed (see progress.zig).
+
+const std = @import("std");
+const util = @import("util.zig");
+
+/// A pin the CLI has no bundled "latest" for (an arbitrary plugin): the pin
+/// is reported, but `checked` is false and `latest` is null.
+pub const err_unknown_latest = "no known latest version for this package";
+/// A `local:<path>` (or `@<path>`) override cannot be version-compared.
+pub const err_local_override = "local path override — not version-comparable";
+/// The CLI-latest fetch failed (curl missing / network / HTTP error).
+pub const err_offline = "could not reach the release server";
+
+/// Running CLI binary vs the newest published release. Emitted under "cli".
+pub const CliStatus = struct {
+    installed: []const u8,
+    latest: ?[]const u8 = null,
+    update_available: bool = false,
+    checked: bool = false,
+    @"error": ?[]const u8 = null,
+};
+
+/// One project.labelle pin vs the version this CLI targets. Emitted in the
+/// "packages" array.
+pub const PackageStatus = struct {
+    name: []const u8,
+    pinned: ?[]const u8 = null,
+    latest: ?[]const u8 = null,
+    update_available: bool = false,
+    checked: bool = false,
+    @"error": ?[]const u8 = null,
+};
+
+/// The stable top-level document.
+pub const Report = struct {
+    cli: ?CliStatus = null,
+    packages: []const PackageStatus = &.{},
+};
+
+/// True for `local:<path>` / `@<path>` version strings — a dev override that
+/// points at a sibling checkout rather than a released version.
+fn isLocal(v: []const u8) bool {
+    return std.mem.startsWith(u8, v, "local:") or std.mem.startsWith(u8, v, "@");
+}
+
+/// Build a `CliStatus` from the installed version and an optional fetched
+/// latest (`null` = the fetch failed / offline).
+pub fn cliStatus(installed: []const u8, latest: ?[]const u8) CliStatus {
+    const l = latest orelse return .{
+        .installed = installed,
+        .checked = false,
+        .@"error" = err_offline,
+    };
+    return .{
+        .installed = installed,
+        .latest = l,
+        .update_available = util.parseVersion(installed) < util.parseVersion(l),
+        .checked = true,
+    };
+}
+
+/// Build a `PackageStatus`. `pinned`/`latest` may be `null`:
+///   - a `local:` pin is reported unchecked (can't compare a path to a
+///     version),
+///   - a `null` latest (no bundled target — e.g. an arbitrary plugin) is
+///     reported unchecked,
+///   - a `null` pin WITH a latest means "unpinned → uses the CLI default",
+///     so it's on the default already: checked, no update.
+pub fn packageStatus(name: []const u8, pinned: ?[]const u8, latest: ?[]const u8) PackageStatus {
+    if (pinned) |p| {
+        if (isLocal(p)) return .{
+            .name = name,
+            .pinned = p,
+            .latest = latest,
+            .checked = false,
+            .@"error" = err_local_override,
+        };
+    }
+    if (latest == null) return .{
+        .name = name,
+        .pinned = pinned,
+        .checked = false,
+        .@"error" = err_unknown_latest,
+    };
+    const p = pinned orelse return .{
+        .name = name,
+        .pinned = null,
+        .latest = latest,
+        .checked = true,
+    };
+    return .{
+        .name = name,
+        .pinned = p,
+        .latest = latest,
+        .update_available = util.parseVersion(p) < util.parseVersion(latest.?),
+        .checked = true,
+    };
+}
+
+/// True when any surface (the CLI or a pin) has a newer version available.
+pub fn anyUpdateAvailable(report: Report) bool {
+    if (report.cli) |c| {
+        if (c.update_available) return true;
+    }
+    for (report.packages) |p| {
+        if (p.update_available) return true;
+    }
+    return false;
+}
+
+/// Process exit code: 0 = nothing known to be outdated (includes offline /
+/// unknown — we can't assert an update), 2 = at least one update available.
+/// The cheap-scripting contract from issue #276.
+pub fn exitCode(report: Report) u8 {
+    return if (anyUpdateAvailable(report)) 2 else 0;
+}
+
+/// Serialize `report` as a single JSON line (trailing newline) to `w`. All
+/// keys always present (`null` when unknown) for a stable typed shape.
+pub fn writeJson(w: *std.Io.Writer, report: Report) !void {
+    try std.json.Stringify.value(report, .{}, w);
+    try w.writeByte('\n');
+}
+
+/// Human-readable one/two-line CLI report (`update --check`, no `--json`).
+pub fn writeHumanCli(w: *std.Io.Writer, cli: CliStatus) !void {
+    if (!cli.checked) {
+        try w.print("labelle: could not check for CLI updates (offline?) — current {s}\n", .{cli.installed});
+        return;
+    }
+    if (cli.update_available) {
+        try w.print("labelle: CLI update available: {s} -> {s}\n", .{ cli.installed, cli.latest.? });
+        try w.writeAll("  run `labelle update` to install it\n");
+    } else {
+        try w.print("labelle: CLI is up to date ({s})\n", .{cli.installed});
+    }
+}
+
+/// Human-readable pin report (`upgrade --check`, no `--json`).
+pub fn writeHumanPackages(w: *std.Io.Writer, dir: []const u8, packages: []const PackageStatus) !void {
+    try w.print("labelle: checking project pins in '{s}'...\n", .{dir});
+    var updates: usize = 0;
+    for (packages) |p| {
+        const pinned = p.pinned orelse "(unset)";
+        if (p.update_available) {
+            updates += 1;
+            try w.print("  {s}: {s} -> {s}  (update available)\n", .{ p.name, pinned, p.latest.? });
+        } else if (!p.checked) {
+            try w.print("  {s}: {s}  ({s})\n", .{ p.name, pinned, p.@"error" orelse "not checked" });
+        } else {
+            try w.print("  {s}: {s}  up to date\n", .{ p.name, pinned });
+        }
+    }
+    if (updates == 0) {
+        try w.writeAll("all pins up to date\n");
+    } else {
+        try w.print("{d} update(s) available — run `labelle upgrade all` to apply\n", .{updates});
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+const testing = std.testing;
+
+/// Parse `line` as JSON and return the owned Parsed value (caller deinits).
+fn parseJson(line: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+}
+
+pub const CliStatusSpec = struct {
+    test "up to date: same version, no update, checked, no error" {
+        const s = cliStatus("1.55.1", "1.55.1");
+        try testing.expect(!s.update_available);
+        try testing.expect(s.checked);
+        try testing.expect(s.@"error" == null);
+        try testing.expectEqualStrings("1.55.1", s.latest.?);
+    }
+
+    test "update available: installed older than latest" {
+        const s = cliStatus("1.55.1", "1.56.0");
+        try testing.expect(s.update_available);
+        try testing.expect(s.checked);
+    }
+
+    test "installed newer than latest is not an update" {
+        const s = cliStatus("2.0.0", "1.56.0");
+        try testing.expect(!s.update_available);
+        try testing.expect(s.checked);
+    }
+
+    test "offline: null latest → unchecked, error set, no update" {
+        const s = cliStatus("1.55.1", null);
+        try testing.expect(!s.checked);
+        try testing.expect(!s.update_available);
+        try testing.expect(s.latest == null);
+        try testing.expectEqualStrings(err_offline, s.@"error".?);
+    }
+};
+
+pub const PackageStatusSpec = struct {
+    test "up to date pin: checked, no update" {
+        const p = packageStatus("core", "1.21.0", "1.21.0");
+        try testing.expect(!p.update_available);
+        try testing.expect(p.checked);
+        try testing.expect(p.@"error" == null);
+    }
+
+    test "outdated pin: update available" {
+        const p = packageStatus("engine", "1.64.0", "1.65.0");
+        try testing.expect(p.update_available);
+        try testing.expect(p.checked);
+    }
+
+    test "unpinned with a known latest → on default, checked, no update" {
+        const p = packageStatus("assembler", null, "0.40.0");
+        try testing.expect(p.pinned == null);
+        try testing.expect(!p.update_available);
+        try testing.expect(p.checked);
+    }
+
+    test "no known latest (plugin) → unchecked, error, pin still reported" {
+        const p = packageStatus("myplugin", "1.0.0", null);
+        try testing.expect(!p.checked);
+        try testing.expect(!p.update_available);
+        try testing.expectEqualStrings("1.0.0", p.pinned.?);
+        try testing.expectEqualStrings(err_unknown_latest, p.@"error".?);
+    }
+
+    test "local override pin → unchecked, not comparable" {
+        const p = packageStatus("engine", "local:../labelle-engine", "1.65.0");
+        try testing.expect(!p.checked);
+        try testing.expect(!p.update_available);
+        try testing.expectEqualStrings(err_local_override, p.@"error".?);
+    }
+};
+
+pub const ExitCodeSpec = struct {
+    test "all up to date → exit 0" {
+        const pkgs = [_]PackageStatus{
+            packageStatus("core", "1.21.0", "1.21.0"),
+            packageStatus("engine", "1.65.0", "1.65.0"),
+        };
+        try testing.expectEqual(@as(u8, 0), exitCode(.{ .packages = &pkgs }));
+    }
+
+    test "one pin outdated → exit 2" {
+        const pkgs = [_]PackageStatus{
+            packageStatus("core", "1.21.0", "1.21.0"),
+            packageStatus("engine", "1.64.0", "1.65.0"),
+        };
+        try testing.expectEqual(@as(u8, 2), exitCode(.{ .packages = &pkgs }));
+    }
+
+    test "CLI outdated → exit 2" {
+        try testing.expectEqual(@as(u8, 2), exitCode(.{ .cli = cliStatus("1.0.0", "1.1.0") }));
+    }
+
+    test "offline CLI is not treated as an update → exit 0" {
+        try testing.expectEqual(@as(u8, 0), exitCode(.{ .cli = cliStatus("1.0.0", null) }));
+    }
+};
+
+pub const JsonShapeSpec = struct {
+    test "update report: cli populated, packages empty, all keys present" {
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try writeJson(&w, .{ .cli = cliStatus("1.55.1", "1.56.0") });
+        const line = w.buffered();
+
+        // Single JSON line.
+        try testing.expect(std.mem.indexOfScalar(u8, line[0 .. line.len - 1], '\n') == null);
+
+        const parsed = try parseJson(line);
+        defer parsed.deinit();
+        const root = parsed.value.object;
+        const cli = root.get("cli").?.object;
+        try testing.expectEqualStrings("1.55.1", cli.get("installed").?.string);
+        try testing.expectEqualStrings("1.56.0", cli.get("latest").?.string);
+        try testing.expect(cli.get("update_available").?.bool);
+        try testing.expect(cli.get("checked").?.bool);
+        // Stable shape: error key present as explicit null.
+        try testing.expect(cli.get("error").? == .null);
+        // packages key always present.
+        try testing.expectEqual(@as(usize, 0), root.get("packages").?.array.items.len);
+    }
+
+    test "offline update report: cli.latest null, error string present" {
+        var buf: [1024]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try writeJson(&w, .{ .cli = cliStatus("1.55.1", null) });
+        const parsed = try parseJson(w.buffered());
+        defer parsed.deinit();
+        const cli = parsed.value.object.get("cli").?.object;
+        try testing.expect(cli.get("latest").? == .null);
+        try testing.expect(!cli.get("checked").?.bool);
+        try testing.expectEqualStrings(err_offline, cli.get("error").?.string);
+    }
+
+    test "upgrade report: cli null, packages carry name/pinned/latest/flags" {
+        const pkgs = [_]PackageStatus{
+            packageStatus("core", "1.21.0", "1.22.0"),
+            packageStatus("assembler", null, "0.40.0"),
+            packageStatus("myplugin", "1.0.0", null),
+        };
+        var buf: [2048]u8 = undefined;
+        var w = std.Io.Writer.fixed(&buf);
+        try writeJson(&w, .{ .packages = &pkgs });
+        const parsed = try parseJson(w.buffered());
+        defer parsed.deinit();
+        const root = parsed.value.object;
+        try testing.expect(root.get("cli").? == .null);
+
+        const arr = root.get("packages").?.array.items;
+        try testing.expectEqual(@as(usize, 3), arr.len);
+
+        const core = arr[0].object;
+        try testing.expectEqualStrings("core", core.get("name").?.string);
+        try testing.expectEqualStrings("1.21.0", core.get("pinned").?.string);
+        try testing.expectEqualStrings("1.22.0", core.get("latest").?.string);
+        try testing.expect(core.get("update_available").?.bool);
+
+        // Unpinned pin serializes `pinned` as explicit null.
+        const asm_pkg = arr[1].object;
+        try testing.expect(asm_pkg.get("pinned").? == .null);
+        try testing.expect(asm_pkg.get("checked").?.bool);
+
+        // Unknown-latest plugin: latest null, checked false, error present.
+        const plugin = arr[2].object;
+        try testing.expect(plugin.get("latest").? == .null);
+        try testing.expect(!plugin.get("checked").?.bool);
+        try testing.expectEqualStrings(err_unknown_latest, plugin.get("error").?.string);
+    }
+};

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -60,6 +60,15 @@ fn parseUpgradeArgs(allocator: std.mem.Allocator, cmd_args: []const []const u8) 
             check = true;
         } else if (std.mem.eql(u8, a, "--json")) {
             json = true;
+        } else if (std.mem.startsWith(u8, a, "--")) {
+            // Reject unknown flags rather than treating them as a package /
+            // version positional — a typo like `--chek` must not slip past
+            // the read-only `--check` guard into the mutating upgrade path
+            // (CodeRabbit, PR #299). Symmetric with parseUpdateArgs; the
+            // errdefer above frees `positionals` on this early return.
+            std.debug.print("labelle upgrade: unknown flag '{s}'\n", .{a});
+            std.debug.print("  usage: labelle upgrade [dir] [pkg] [ver] [--check] [--json] [--force]\n", .{});
+            return error.InvalidArguments;
         } else {
             try positionals.append(allocator, a);
         }
@@ -387,4 +396,16 @@ test "parseUpgradeArgs: --force is independent of report-only" {
     defer parsed.deinit(testing.allocator);
     try testing.expect(parsed.force);
     try testing.expect(!parsed.reportOnly());
+}
+
+test "parseUpgradeArgs rejects an unknown flag instead of taking it as a positional" {
+    // Without the reject branch `--jso` becomes a positional and the
+    // command proceeds to the mutating path — CodeRabbit PR #299.
+    try testing.expectError(error.InvalidArguments, parseUpgradeArgs(testing.allocator, &.{"--jso"}));
+}
+
+test "parseUpgradeArgs rejects an unknown flag even before a valid subcommand" {
+    // `--chek all` must not run the mutating `upgrade all`; the typo is
+    // rejected before the subcommand is ever reached.
+    try testing.expectError(error.InvalidArguments, parseUpgradeArgs(testing.allocator, &.{ "--chek", "all" }));
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -4,6 +4,7 @@ const assembler = @import("assembler.zig");
 const config = @import("config.zig");
 const assembler_proc = @import("assembler_proc.zig");
 const util = @import("util.zig");
+const update_check = @import("update_check.zig");
 
 /// Bump version fields in project.labelle.
 ///
@@ -22,6 +23,18 @@ const UpgradeArgs = struct {
     /// than what the project currently pins (downgrades are skipped
     /// without it).
     force: bool,
+    /// `--check` — report current pins vs latest WITHOUT touching
+    /// project.labelle (labelle-cli#276).
+    check: bool,
+    /// `--json` — machine-readable output; implies `--check` (a tool asking
+    /// for JSON must never trigger a mutating upgrade).
+    json: bool,
+
+    /// True when the invocation is a read-only pin check rather than a
+    /// version bump.
+    fn reportOnly(self: UpgradeArgs) bool {
+        return self.check or self.json;
+    }
 
     fn deinit(self: *UpgradeArgs, allocator: std.mem.Allocator) void {
         self.positionals.deinit(allocator);
@@ -38,14 +51,20 @@ fn parseUpgradeArgs(allocator: std.mem.Allocator, cmd_args: []const []const u8) 
     var positionals: std.ArrayList([]const u8) = .empty;
     errdefer positionals.deinit(allocator);
     var force = false;
+    var check = false;
+    var json = false;
     for (cmd_args) |a| {
         if (std.mem.eql(u8, a, "--force") or std.mem.eql(u8, a, "-f")) {
             force = true;
+        } else if (std.mem.eql(u8, a, "--check")) {
+            check = true;
+        } else if (std.mem.eql(u8, a, "--json")) {
+            json = true;
         } else {
             try positionals.append(allocator, a);
         }
     }
-    return .{ .positionals = positionals, .force = force };
+    return .{ .positionals = positionals, .force = force, .check = check, .json = json };
 }
 
 pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: project_config.ProjectConfig, cmd_args: []const []const u8) !void {
@@ -53,6 +72,13 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: pr
     defer parsed_args.deinit(allocator);
     const args = parsed_args.positionals.items;
     const force = parsed_args.force;
+
+    // Read-only pin check (labelle-cli#276): report current pins vs the
+    // versions this CLI targets WITHOUT rewriting project.labelle. `--json`
+    // implies `--check`, so a machine consumer never triggers a mutation.
+    if (parsed_args.reportOnly()) {
+        return cmdUpgradeCheck(allocator, project_dir, cfg, parsed_args.json);
+    }
 
     // Subcommand is the first positional (flags already stripped), so
     // `--force` may appear before or after it.
@@ -128,6 +154,64 @@ pub fn cmdUpgrade(allocator: std.mem.Allocator, project_dir: []const u8, cfg: pr
 
     std.debug.print("labelle: project.labelle updated\n", .{});
     std.debug.print("  run 'labelle generate' to regenerate build files\n", .{});
+}
+
+/// `labelle upgrade [dir] --check [--json]` (labelle-cli#276): report the
+/// project's current pins vs the versions this CLI targets (its bundled
+/// compatible set — the same set `upgrade all` would apply) WITHOUT touching
+/// project.labelle. This is a read-only mode over what `upgrade` already
+/// knows; no network is required.
+///
+/// `latest` sources (all baked into this CLI at build time):
+///   - core/engine/gfx → versions.zon (`project_config.*_VERSION`)
+///   - labelle         → this CLI's own version (`CLI_VERSION`)
+///   - assembler       → `DEFAULT_ASSEMBLER_VERSION`
+///   - plugins         → unknown (the CLI has no plugin-latest registry); the
+///                       pin is still reported so studio can display it.
+///
+/// Emits `{ "cli": null, "packages": [...] }` under `--json` (studio#7).
+/// Exits 2 when any pin is behind its target, else 0.
+fn cmdUpgradeCheck(
+    allocator: std.mem.Allocator,
+    project_dir: []const u8,
+    cfg: project_config.ProjectConfig,
+    json: bool,
+) !void {
+    var packages: std.ArrayList(update_check.PackageStatus) = .empty;
+    errdefer packages.deinit(allocator);
+
+    // Order mirrors the issue: core/engine/gfx/assembler/labelle + plugins.
+    try packages.append(allocator, update_check.packageStatus("core", cfg.core_version, project_config.CORE_VERSION));
+    try packages.append(allocator, update_check.packageStatus("engine", cfg.engine_version, project_config.ENGINE_VERSION));
+    try packages.append(allocator, update_check.packageStatus("gfx", cfg.gfx_version, project_config.GFX_VERSION));
+    try packages.append(allocator, update_check.packageStatus("labelle", cfg.labelle_version, project_config.CLI_VERSION));
+    try packages.append(allocator, update_check.packageStatus("assembler", cfg.assembler_version, assembler.DEFAULT_ASSEMBLER_VERSION));
+    for (cfg.plugins) |p| {
+        // Empty version string → not pinned to a specific version.
+        const pinned: ?[]const u8 = if (p.version.len > 0) p.version else null;
+        // The CLI can't resolve a plugin's latest offline, so `latest` is
+        // null (checked=false); the pin is still surfaced for studio.
+        var status = update_check.packageStatus(p.name, pinned, null);
+        // A `local:`/`@` plugin repo is a dev override — flag it distinctly
+        // so studio can tell "local checkout" from "remote, latest unknown".
+        if (p.isLocal()) status.@"error" = update_check.err_local_override;
+        try packages.append(allocator, status);
+    }
+
+    const report = update_check.Report{ .cli = null, .packages = packages.items };
+
+    var out_buf: [8192]u8 = undefined;
+    var w = std.Io.File.stdout().writerStreaming(config.globalIo(), &out_buf);
+    if (json) {
+        update_check.writeJson(&w.interface, report) catch {};
+    } else {
+        update_check.writeHumanPackages(&w.interface, project_dir, packages.items) catch {};
+    }
+    w.interface.flush() catch {};
+
+    const code = update_check.exitCode(report);
+    packages.deinit(allocator); // free before a possible std.process.exit
+    if (code != 0) std.process.exit(code);
 }
 
 /// Resolve the version to apply for one field of `upgrade all`.
@@ -270,4 +354,37 @@ test "pickTarget guards assembler_version downgrade" {
     // Regression: `upgrade all` must route assembler_version through the
     // same guard so a newer assembler pin is not silently downgraded.
     try testing.expectEqualStrings("0.40.0", pickTarget("assembler_version", "0.40.0", assembler.DEFAULT_ASSEMBLER_VERSION, false));
+}
+
+test "parseUpgradeArgs strips --check and reports report-only mode" {
+    var parsed = try parseUpgradeArgs(testing.allocator, &.{"--check"});
+    defer parsed.deinit(testing.allocator);
+    try testing.expect(parsed.check);
+    try testing.expect(!parsed.json);
+    try testing.expect(parsed.reportOnly());
+    try testing.expectEqual(@as(usize, 0), parsed.positionals.items.len);
+}
+
+test "parseUpgradeArgs: --json implies report-only" {
+    var parsed = try parseUpgradeArgs(testing.allocator, &.{"--json"});
+    defer parsed.deinit(testing.allocator);
+    try testing.expect(parsed.json);
+    try testing.expect(parsed.reportOnly());
+}
+
+test "parseUpgradeArgs strips --check/--json but keeps subcommand positional" {
+    // `upgrade all --check --json` must leave `all` as the sole positional
+    // so the (short-circuited) subcommand path never sees the flags.
+    var parsed = try parseUpgradeArgs(testing.allocator, &.{ "all", "--check", "--json" });
+    defer parsed.deinit(testing.allocator);
+    try testing.expect(parsed.check and parsed.json);
+    try testing.expectEqual(@as(usize, 1), parsed.positionals.items.len);
+    try testing.expectEqualStrings("all", parsed.positionals.items[0]);
+}
+
+test "parseUpgradeArgs: --force is independent of report-only" {
+    var parsed = try parseUpgradeArgs(testing.allocator, &.{"--force"});
+    defer parsed.deinit(testing.allocator);
+    try testing.expect(parsed.force);
+    try testing.expect(!parsed.reportOnly());
 }


### PR DESCRIPTION
Closes #276. Unblocks **labelle-studio#7** — studio can now ask "what's outdated?" without parsing human output and without mutating anything.

## What

Two read-only, non-mutating reporting modes over the versions the CLI already knows:

- **`labelle update --check [--json]`** — running CLI binary vs the newest published release (`releases.labelle.games/cli/latest.txt`). Never downloads/installs.
- **`labelle upgrade [dir] --check [--json]`** — `project.labelle` pins (`core`/`engine`/`gfx`/`labelle`/`assembler` + plugins) vs the bundled compatible set this CLI targets (the same set `upgrade all` would apply). Never rewrites `project.labelle`. Fully offline — a "read-only mode over what `upgrade` already queries," as the issue asks.

Contract:
- **`--json` implies `--check`** — a tool asking for machine output can never accidentally trigger a mutating install/upgrade.
- **Exit codes** (issue's cheap-scripting ask): `0` = up to date, `2` = at least one update available. Offline/unknown is **not** counted as an update (exit `0`); the `checked`/`error` fields carry that nuance.

## JSON schema (stable — studio consumes this)

Adopts the concrete sketch from #278 that @apotema endorsed in the issue thread: `{cli:{installed,latest,update_available}, packages:[{name,pinned,latest,update_available}]}`, plus a per-entry `checked`/`error` to distinguish "up to date" from "offline / no-known-latest". Both commands emit the **same top-level shape**; each fills only its half. All keys are always present (`null` when unknown) for a stable typed shape — the same convention as the `--progress=json` NDJSON feed.

```jsonc
{
  "cli": {                       // update --check → populated; upgrade --check → null
    "installed": "1.55.1",
    "latest": "1.56.0",          // null when the fetch failed
    "update_available": true,
    "checked": true,             // false = couldn't determine (offline)
    "error": null                // string when checked=false
  },
  "packages": [                  // upgrade --check → populated; update --check → []
    { "name": "core",      "pinned": "1.20.0", "latest": "1.21.0", "update_available": true,  "checked": true,  "error": null },
    { "name": "engine",    "pinned": "1.65.0", "latest": "1.65.0", "update_available": false, "checked": true,  "error": null },
    { "name": "assembler", "pinned": null,     "latest": "0.40.0", "update_available": false, "checked": true,  "error": null },  // unpinned → on CLI default
    { "name": "my-plugin", "pinned": "4.0.1",  "latest": null,     "update_available": false, "checked": false, "error": "no known latest version for this package" },
    { "name": "local-dep", "pinned": "0.1.0",  "latest": null,     "update_available": false, "checked": false, "error": "local path override — not version-comparable" }
  ]
}
```

- `update --check --json` → `{"cli":{…},"packages":[]}`
- `upgrade --check --json` → `{"cli":null,"packages":[…]}`

Studio composes the two: `update --check` answers "is the installed CLI stale?" (network); `upgrade --check` answers "are this project's pins behind?" (offline). The CLI has no plugin-version registry, so plugin `latest` is `null`/`checked:false` — the pin is still surfaced so studio can display it.

## Real output

```
$ labelle upgrade --check --json .   # exit 2
{"cli":null,"packages":[{"name":"core","pinned":"1.20.0","latest":"1.21.0","update_available":true,"checked":true,"error":null}, …]}

$ labelle update --check 2.0.0       # exit 2
labelle: CLI update available: 1.55.1 -> 2.0.0
  run `labelle update` to install it
```

## Implementation

- New pure, unit-tested module `src/cli/update_check.zig` — status model, JSON/human serialization, exit-code logic (no network, no fs; all inputs supplied by the callers).
- `update.zig` / `upgrade.zig` are thin wrappers: the CLI-latest fetch and the `project.labelle` read live there and feed the pure core.
- Fixes a latent `upgrade` dispatch bug where a leading `--check`/`--force` token was captured as the project dir (would have sent `--check` to `readProjectConfig`).
- Help text + usage doc-comments updated.

## Tests

`zig build test` → **425/425 passed**. New coverage: status computation (up-to-date / outdated / offline / unpinned / unknown-latest / local-override), exit codes, and JSON shape assertions (both report variants, null-key stability); flag parsing for both commands (incl. `--json`-implies-`--check`). Non-mutation verified by hashing `project.labelle` before/after `--check`.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j