### PR TITLE
fix(ios): detect iOS-simulator ARM NEON/SIMD build failure (#4, #5)

### DIFF
--- a/src/cli/ios.zig
+++ b/src/cli/ios.zig
@@ -341,8 +341,63 @@ fn printIosHelp() void {
     , .{});
 }
 
+/// Detect the known iOS-simulator ARM NEON/SIMD compile failure (labelle-cli#4, #5).
+///
+/// The `aarch64-ios-simulator` target compiles ARM SIMD (NEON) intrinsics that
+/// require CPU features the simulator toolchain does not enable, producing
+/// `zig cc`/clang errors like:
+///
+///   always_inline function 'vdupq_n_u64' requires target feature 'altnzcv',
+///   but would be inlined into function ... compiled without support for 'altnzcv'
+///
+/// The durable fix lives in the plugins that compile ARM SIMD — they must select
+/// their scalar fallback for the simulator triple (`os == .ios and abi ==
+/// .simulator`), e.g. Box2D's `BOX2D_DISABLE_SIMD` and Clay's non-NEON hash path.
+/// The CLI cannot influence those C compiles directly (it only invokes `zig build`
+/// on the generated project), so it recognises this failure signature and points
+/// the user at the fix instead of dumping a wall of intrinsic errors.
+///
+/// Returns true when `stderr` carries the feature-mismatch signature paired with a
+/// NEON marker (so a generic "requires target feature" is not mistaken for this).
+fn isSimdFeatureBuildError(stderr: []const u8) bool {
+    if (std.mem.indexOf(u8, stderr, "requires target feature") == null) return false;
+    const neon_markers = [_][]const u8{
+        "altnzcv", // ARMv8.5 FEAT_FlagM2 — the feature the intrinsics demand
+        "vdupq_n_", "vld1", "vst1", "vmulq_", "vaddq_", // common NEON intrinsics
+        "arm_neon.h", "neon", "NEON",
+    };
+    for (neon_markers) |marker| {
+        if (std.mem.indexOf(u8, stderr, marker) != null) return true;
+    }
+    return false;
+}
+
+/// Print an actionable hint for the iOS-simulator NEON/SIMD build failure.
+fn printSimdBuildHint() void {
+    std.debug.print(
+        \\
+        \\labelle: this looks like the iOS-simulator ARM NEON/SIMD compile failure
+        \\  (labelle-cli#4 / #5). The aarch64-ios-simulator target compiles NEON
+        \\  intrinsics that its toolchain does not enable.
+        \\
+        \\  A plugin that compiles ARM SIMD must fall back to scalar for the
+        \\  simulator triple (os == .ios and abi == .simulator). In the plugin's
+        \\  build.zig, gate its SIMD-disable on that target:
+        \\
+        \\    Box2D: add `BOX2D_DISABLE_SIMD=1` (like the existing emscripten branch)
+        \\    Clay:  compile the non-NEON hash path
+        \\
+        \\  Building for a physical device (`labelle ios build --device`) avoids
+        \\  this, as does upgrading the toolchain past the 0.15.2-era clang bug.
+        \\
+    , .{});
+}
+
 /// Build the iOS target (simulator or device).
 fn iosBuild(allocator: std.mem.Allocator, target_dir: []const u8, device: bool, release: bool) !void {
+    // Simulator is the default target; `--device` switches to the physical-device
+    // arm64 build. The NEON/SIMD failure below only affects the simulator triple.
+    const simulator = !device;
     const target_label: []const u8 = if (device) "iOS device (arm64)" else "iOS simulator (arm64)";
     const config_label: []const u8 = if (release) "Release" else "Debug";
     std.debug.print("labelle: building for {s} ({s})...\n", .{ target_label, config_label });
@@ -374,6 +429,7 @@ fn iosBuild(allocator: std.mem.Allocator, target_dir: []const u8, device: bool, 
     switch (result.term) {
         .exited => |code| if (code != 0) {
             std.debug.print("labelle: build failed:\n{s}\n", .{result.stderr});
+            if (simulator and isSimdFeatureBuildError(result.stderr)) printSimdBuildHint();
             return error.BuildFailed;
         },
         else => {
@@ -736,4 +792,38 @@ fn generateLaunchScreen(allocator: std.mem.Allocator, app_name: []const u8) ![]c
         \\</document>
         \\
     , .{app_name});
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "isSimdFeatureBuildError: detects the altnzcv NEON signature" {
+    const stderr =
+        \\clay.h:1449:21: error: always_inline function 'vdupq_n_u64' requires target feature 'altnzcv',
+        \\but would be inlined into function 'Clay__HashData' that is compiled without support for 'altnzcv'
+    ;
+    try std.testing.expect(isSimdFeatureBuildError(stderr));
+}
+
+test "isSimdFeatureBuildError: detects the box2d vdupq_n_f32 signature" {
+    const stderr =
+        \\error: always_inline function 'vdupq_n_f32' requires target feature 'altnzcv',
+        \\but would be inlined into function that is compiled without support for 'altnzcv'
+    ;
+    try std.testing.expect(isSimdFeatureBuildError(stderr));
+}
+
+test "isSimdFeatureBuildError: ignores unrelated feature-mismatch errors" {
+    // A "requires target feature" error with no NEON marker must not trip the hint.
+    const stderr =
+        \\error: always_inline function 'foo' requires target feature 'avx512f',
+        \\but would be inlined into function 'bar' that is compiled without support for 'avx512f'
+    ;
+    try std.testing.expect(!isSimdFeatureBuildError(stderr));
+}
+
+test "isSimdFeatureBuildError: ignores ordinary build failures" {
+    const stderr = "error: unable to find 'game.zig'\n";
+    try std.testing.expect(!isSimdFeatureBuildError(stderr));
 }


### PR DESCRIPTION
## What & why

Building for the iOS **simulator** (`aarch64-ios-simulator`) can fail while compiling plugins that use ARM NEON/SIMD intrinsics — Clay UI (#4) and Box2D (#5):

```
always_inline function 'vdupq_n_u64' requires target feature 'altnzcv',
but would be inlined into a function compiled without support for 'altnzcv'
```

Both issues are the **same root cause**: the simulator target compiles NEON intrinsics that its toolchain doesn't enable, so one PR covers both.

## Scope: where the fix actually lives

The CLI only invokes `zig build` on the **assembler-generated** project — it does not own the iOS `build.zig` and cannot override CPU features or C-compile defines for the plugins. Passing a new undeclared `-D` flag to that build hard-errors, and the issues' own repro (`zig build -Dtarget=aarch64-ios-simulator ...`) bypasses the CLI entirely. So the **durable fix is downstream self-detection** in each plugin's `build.zig` (they already receive the resolved `ios_target` from the template):

- **`labelle-box2d/build.zig`** — extend the existing `BOX2D_DISABLE_SIMD` gate (today `.emscripten`-only, lines ~44-65) to also fire for `target.result.os.tag == .ios and target.result.abi == .simulator`, on both `box2d_lib.root_module` and `mod`.
- **`labelle-assembler/gui/clay/build.zig`** (+ its `zclay` dep) — compile Clay's non-NEON hash path for the same simulator triple.

These live in other repos and are flagged for dispatch (see the report).

## What this PR changes (CLI side)

Since the CLI orchestrates the build, it now **recognises this failure class on the simulator path and guides the user** instead of dumping a wall of intrinsic errors:

- `isSimdFeatureBuildError()` — matches `"requires target feature"` paired with a NEON marker (`altnzcv` / `vdupq_n_` / `vld1` / `arm_neon.h` / `neon`), so a generic feature-mismatch (e.g. `avx512`) does **not** trip it.
- `printSimdBuildHint()` — printed only for the **simulator** build path on failure, pointing at the Box2D/Clay scalar-fallback fix.
- Explicit simulator-vs-device split in `iosBuild`.
- Unit tests: both issue signatures + two negatives.

## Verification

- **box2d compiles cleanly** for `aarch64-ios-simulator` (generic + `apple_a14` CPU) on **Zig 0.16.0** — the issues were filed against 0.15.2, and the underlying clang altnzcv bug appears resolved on the current toolchain. The downstream guard remains valuable as defense-in-depth across Zig versions/CPU models.
- **Clay could not be re-verified**: `zclay 0.2.2` (pinned `#v0.2.2+0.14`) uses a Zig 0.14 build API (`Compile.addIncludePath`) and fails to build on 0.16 for *any* target — a separate, unrelated breakage that must be resolved before the Clay simulator path can be validated.
- Host `zig build` and `zig build test` pass (426 tests, incl. the 4 new ones).

Closes #4
Closes #5

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw