### PR TITLE
fix(migrate): micro-opts + stat-accuracy fixes (#241)

### DIFF
--- a/src/cli/audit.zig
+++ b/src/cli/audit.zig
@@ -996,7 +996,16 @@ fn walkLegacyComponentsWrapper(
     switch (value) {
         .object => |obj| {
             const has_components = obj.get("components") != null;
-            const has_prefab = obj.get("prefab") != null;
+            // A `prefab:` sibling only marks this entry as a reference
+            // (handled by `walkLegacyComponentsOnRef`, which requires a
+            // STRING prefab) when the prefab value IS a string. A
+            // malformed non-string `prefab` must NOT suppress the inline-
+            // components-wrapper finding — otherwise the dry-run audit
+            // count would diverge from what `migrate` actually lifts,
+            // whose `treeHasInlineComponentsWrapper` / byte scanner also
+            // key off a string prefab (cli #241 item 6).
+            const prefab_v = obj.get("prefab");
+            const has_prefab = prefab_v != null and prefab_v.? == .string;
             if (has_components and !has_prefab) {
                 const ptr = if (path_buf.items.len == 0)
                     try arena.dupe(u8, "/")
@@ -2170,6 +2179,48 @@ pub const RunAuditOnSpec = struct {
             };
             try expect.equal(n_wrapper, @as(usize, 0));
             try expect.equal(n_on_ref, @as(usize, 1));
+        }
+
+        test "malformed non-string prefab: dry-run audit count matches apply count (cli #241)" {
+            // codex P2 on cli #304: a malformed `{ "prefab": <non-string>,
+            // "components": {...} }` is NOT a real prefab ref. The migrator
+            // treats it as an inline-components entity and LIFTS it, so the
+            // dry-run audit must ALSO flag it (as legacy_components_wrapper)
+            // — otherwise `migrate --dry-run` reports fewer edits than
+            // `migrate` applies. This test pins the two counts together.
+            const src =
+                \\[ { "prefab": 123, "components": { "Position": { "x": 0, "y": 0 } } } ]
+            ;
+
+            // Audit (dry-run) side.
+            var p = TmpProject{ .tmp = std.testing.tmpDir(.{}) };
+            defer p.deinit();
+            try p.write("scenes/main.jsonc", src);
+            const result = try runAuditForTest(&p);
+            defer freeAuditResult(result);
+
+            var audit_wrapper: usize = 0;
+            var audit_on_ref: usize = 0;
+            for (result.report.findings.items) |f| switch (f) {
+                .legacy_components_wrapper => audit_wrapper += 1,
+                .legacy_components_on_ref => audit_on_ref += 1,
+                else => {},
+            };
+            // Non-string prefab does not count as a ref-wrapper.
+            try expect.equal(audit_on_ref, @as(usize, 0));
+            try expect.equal(audit_wrapper, @as(usize, 1));
+
+            // Apply side — run the real migrate transform pipeline.
+            const migrate_helpers = @import("migrate/tests_helpers.zig");
+            const migrate_pipeline = @import("migrate/pipeline.zig");
+            var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+            defer arena.deinit();
+            var counts = migrate_pipeline.FileCounts{};
+            _ = try migrate_helpers.applyAllFullCounts(arena.allocator(), src, "main", &counts);
+            try expect.equal(counts.components_lifts, @as(usize, 1));
+
+            // The audit dry-run wrapper count matches what apply lifts.
+            try expect.equal(audit_wrapper, counts.components_lifts);
         }
     };
 

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -241,6 +241,7 @@ const tests_rfc596 = @import("migrate/tests_rfc596.zig");
 pub const TransformLiftOverridesSpec = tests_rfc596.TransformLiftOverridesSpec;
 pub const TransformLiftComponentsSpec = tests_rfc596.TransformLiftComponentsSpec;
 pub const TransformNameFieldSpec = tests_rfc596.TransformNameFieldSpec;
+pub const PrefabGuardConsistencySpec = tests_rfc596.PrefabGuardConsistencySpec;
 pub const TransformFileAsArraySpec = tests_rfc596.TransformFileAsArraySpec;
 pub const TransformDirectivesToMetaHeaderSpec = tests_rfc596.TransformDirectivesToMetaHeaderSpec;
 pub const Rfc596IdempotencySpec = tests_rfc596.Rfc596IdempotencySpec;

--- a/src/cli/migrate/pipeline.zig
+++ b/src/cli/migrate/pipeline.zig
@@ -28,7 +28,7 @@ const stripJsoncToJson = scanner.stripJsoncToJson;
 ///   audit.legacy_overrides_wrapper ↔ summary.overrides_lifts
 ///   audit.legacy_components_wrapper ↔ summary.components_lifts
 ///   audit.legacy_file_object_no_root ↔ summary.file_as_array_collapses
-///   audit.legacy_name_field         ↔ summary.name_field_drops + summary.name_field_meta_moves
+///   audit.legacy_name_field         ↔ summary.name_field_drops + summary.name_field_divergent_drops + summary.name_field_meta_moves
 pub const Summary = struct {
     files_scanned: usize = 0,
     files_modified: usize = 0,
@@ -42,6 +42,7 @@ pub const Summary = struct {
     components_lifts: usize = 0,
     file_as_array_collapses: usize = 0,
     name_field_drops: usize = 0,
+    name_field_divergent_drops: usize = 0,
     name_field_meta_moves: usize = 0,
     name_field_xref_warnings: usize = 0,
     directives_to_meta_moves: usize = 0,
@@ -97,6 +98,11 @@ pub const Summary = struct {
             if (self.name_field_drops == 1) "" else "s",
             dropped,
         });
+        std.debug.print("  {d} divergent 'name' field{s} {s} (meta already present — merge manually)\n", .{
+            self.name_field_divergent_drops,
+            if (self.name_field_divergent_drops == 1) "" else "s",
+            dropped,
+        });
         std.debug.print("  {d} divergent 'name' field{s} {s} into 'meta.name'\n", .{
             self.name_field_meta_moves,
             if (self.name_field_meta_moves == 1) "" else "s",
@@ -129,6 +135,7 @@ pub const FileCounts = struct {
     components_lifts: usize = 0,
     file_as_array_collapses: usize = 0,
     name_field_drops: usize = 0,
+    name_field_divergent_drops: usize = 0,
     name_field_meta_moves: usize = 0,
     name_field_xref_warnings: usize = 0,
     directives_to_meta_moves: usize = 0,
@@ -142,6 +149,7 @@ pub const FileCounts = struct {
             self.components_lifts +
             self.file_as_array_collapses +
             self.name_field_drops +
+            self.name_field_divergent_drops +
             self.name_field_meta_moves +
             self.directives_to_meta_moves;
     }
@@ -326,13 +334,20 @@ pub fn transformBytes(
                             counts.name_field_drops += 1;
                         }
                     } else {
-                        // Divergent — move to meta.name. If `meta:`
-                        // already exists, merge into it; otherwise rename
-                        // the `name:` key and wrap its value in `{}`.
+                        // Divergent. If `meta:` already exists we can't
+                        // safely byte-merge, so `moveNameToMeta` drops the
+                        // bare `name:` (audit re-fires for manual merge) —
+                        // count that as a divergent DROP, not a move.
+                        // Otherwise the `name:` key is renamed to
+                        // `meta.name` — a genuine move.
                         const has_meta = parsed.value.object.get("meta") != null;
-                        if (transforms_meta.moveNameToMeta(arena, current, name, has_meta)) |out| {
+                        if (transforms_meta.moveNameToMeta(arena, current, has_meta)) |out| {
                             current = out;
-                            counts.name_field_meta_moves += 1;
+                            if (has_meta) {
+                                counts.name_field_divergent_drops += 1;
+                            } else {
+                                counts.name_field_meta_moves += 1;
+                            }
                             if (ctx.xrefs.contains(name)) {
                                 counts.name_field_xref_warnings += 1;
                                 std.debug.print(

--- a/src/cli/migrate/tests_helpers.zig
+++ b/src/cli/migrate/tests_helpers.zig
@@ -29,10 +29,22 @@ pub fn applyAllFull(arena: std.mem.Allocator, src: []const u8, basename: []const
 }
 
 pub fn applyImpl(arena: std.mem.Allocator, src: []const u8, basename: []const u8, rfc596: bool) ![]u8 {
+    var counts = FileCounts{};
+    return applyImplCounts(arena, src, basename, rfc596, &counts);
+}
+
+/// Like `applyImpl` but writes the per-file transform counts into
+/// `counts` so stat-accuracy specs can assert on them.
+pub fn applyImplCounts(
+    arena: std.mem.Allocator,
+    src: []const u8,
+    basename: []const u8,
+    rfc596: bool,
+    counts: *FileCounts,
+) ![]u8 {
     const stripped = try stripJsoncToJson(arena, src);
     var parsed = try std.json.parseFromSlice(std.json.Value, arena, stripped, .{});
     defer parsed.deinit();
-    var counts = FileCounts{};
     var xrefs: std.StringHashMap(void) = .init(arena);
     const ctx = TransformCtx{
         .basename = basename,
@@ -40,7 +52,18 @@ pub fn applyImpl(arena: std.mem.Allocator, src: []const u8, basename: []const u8
         .rel_path = "<test>",
         .rfc596 = rfc596,
     };
-    return try transformBytes(arena, src, parsed.value, ctx, &counts);
+    return try transformBytes(arena, src, parsed.value, ctx, counts);
+}
+
+/// Run every transform (RFC #596 included) and return the resulting
+/// per-file counts alongside the transformed buffer.
+pub fn applyAllFullCounts(
+    arena: std.mem.Allocator,
+    src: []const u8,
+    basename: []const u8,
+    counts: *FileCounts,
+) ![]u8 {
+    return applyImplCounts(arena, src, basename, true, counts);
 }
 
 /// Convenience for tests — runs `applyAll` (legacy 1-4 only) against an

--- a/src/cli/migrate/tests_rfc596.zig
+++ b/src/cli/migrate/tests_rfc596.zig
@@ -8,6 +8,8 @@
 const std = @import("std");
 const scanner = @import("scanner.zig");
 const walk = @import("walk.zig");
+const pipeline = @import("pipeline.zig");
+const transforms = @import("transforms.zig");
 const helpers = @import("tests_helpers.zig");
 
 const expect = @import("zspec").expect;
@@ -15,6 +17,8 @@ const expect = @import("zspec").expect;
 const stripJsoncToJson = scanner.stripJsoncToJson;
 const scanPrefabRefs = walk.scanPrefabRefs;
 const applyAllArenaFull = helpers.applyAllArenaFull;
+const applyAllFullCounts = helpers.applyAllFullCounts;
+const FileCounts = pipeline.FileCounts;
 
 
 // ─────────────────────────────────────────────────────────────────────
@@ -284,6 +288,94 @@ pub const TransformNameFieldSpec = struct {
         var parsed = try std.json.parseFromSlice(std.json.Value, arena.allocator(), stripped, .{});
         defer parsed.deinit();
         try std.testing.expect(parsed.value == .array);
+    }
+
+    test "divergent name WITHOUT existing meta counts as a move" {
+        // Stat-accuracy (cli #241): a divergent `name:` on a file with no
+        // `meta:` block is genuinely renamed to `meta.name` — count it as
+        // a move, not a divergent drop.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const src =
+            "{\n" ++
+            "    \"name\": \"Production Demo\",\n" ++
+            "    \"children\": []\n" ++
+            "}\n";
+        var counts = FileCounts{};
+        _ = try applyAllFullCounts(arena.allocator(), src, "demo_scene", &counts);
+        try std.testing.expectEqual(@as(usize, 1), counts.name_field_meta_moves);
+        try std.testing.expectEqual(@as(usize, 0), counts.name_field_divergent_drops);
+    }
+
+    test "divergent name WITH existing meta counts as a drop, not a move" {
+        // Stat-accuracy (cli #241): when a `meta:` block already exists we
+        // conservatively DROP the bare divergent `name:` (byte-merging is
+        // unsafe). The summary must report this as a divergent drop, NOT a
+        // move into meta.name — the value never made it into meta.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const src =
+            "{\n" ++
+            "    \"name\": \"Production Demo\",\n" ++
+            "    \"meta\": { \"author\": \"kb\" },\n" ++
+            "    \"children\": []\n" ++
+            "}\n";
+        var counts = FileCounts{};
+        const out = try applyAllFullCounts(arena.allocator(), src, "demo_scene", &counts);
+        // Reported accurately: a divergent drop, not a meta.name move.
+        try std.testing.expectEqual(@as(usize, 1), counts.name_field_divergent_drops);
+        try std.testing.expectEqual(@as(usize, 0), counts.name_field_meta_moves);
+        // The bare divergent name really was dropped — it is NOT present
+        // in the existing meta (no merge happened).
+        const stripped = try stripJsoncToJson(arena.allocator(), out);
+        var parsed = try std.json.parseFromSlice(std.json.Value, arena.allocator(), stripped, .{});
+        defer parsed.deinit();
+        // Header-bundle: first element's meta preserves the ORIGINAL meta
+        // (author) but does not gain a `name` from the dropped field.
+        try std.testing.expect(parsed.value == .array);
+        const header = parsed.value.array.items[0].object;
+        const meta = header.get("meta").?.object;
+        try std.testing.expect(meta.get("name") == null);
+        try std.testing.expect(meta.get("author") != null);
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// RFC #596 — prefab-guard consistency (cli #241 item 6)
+// ─────────────────────────────────────────────────────────────────────
+
+pub const PrefabGuardConsistencySpec = struct {
+    fn treeSays(json_src: []const u8) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        var parsed = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json_src, .{});
+        defer parsed.deinit();
+        return transforms.treeHasInlineComponentsWrapper(parsed.value);
+    }
+
+    test "string prefab sibling suppresses the inline-components gate" {
+        // A real prefab ref carrying a `components:` object is handled by
+        // the overrides pass — the inline-components gate must skip it.
+        try std.testing.expect(!try treeSays(
+            "{ \"prefab\": \"x\", \"components\": { \"Position\": {} } }",
+        ));
+    }
+
+    test "no prefab sibling — inline-components gate fires" {
+        try std.testing.expect(try treeSays(
+            "{ \"components\": { \"Position\": {} } }",
+        ));
+    }
+
+    test "non-string prefab does NOT suppress the gate (matches byte scanner)" {
+        // Regression for cli #241 item 6: the tree gate previously treated
+        // ANY `prefab` key as a prefab ref, while the byte scanner only
+        // keys off a STRING prefab. A malformed non-string `prefab` must
+        // therefore NOT suppress the inline-components lift, so both paths
+        // agree.
+        try std.testing.expect(try treeSays(
+            "{ \"prefab\": 123, \"components\": { \"Position\": {} } }",
+        ));
     }
 };
 

--- a/src/cli/migrate/transforms.zig
+++ b/src/cli/migrate/transforms.zig
@@ -461,7 +461,16 @@ pub fn treeHasWrapperOnRef(value: std.json.Value, wrapper: []const u8) bool {
 pub fn treeHasInlineComponentsWrapper(value: std.json.Value) bool {
     switch (value) {
         .object => |obj| {
-            const has_prefab = obj.get("prefab") != null;
+            // A `prefab:` sibling only counts as a prefab-ref when it is a
+            // string — matching both `treeHasWrapperOnRef` above and the
+            // byte scanner `objectHasWrapper` (which keys off
+            // `prefab_is_string`). A malformed non-string `prefab` must
+            // NOT suppress the inline-components lift, or the tree gate and
+            // the byte scanner would disagree.
+            const has_prefab = blk: {
+                const v = obj.get("prefab") orelse break :blk false;
+                break :blk v == .string;
+            };
             if (!has_prefab) {
                 if (obj.get("components")) |cv| {
                     if (cv == .object) return true;

--- a/src/cli/migrate/transforms_meta.zig
+++ b/src/cli/migrate/transforms_meta.zig
@@ -37,8 +37,7 @@ const deleteTopLevelKey = transforms.deleteTopLevelKey;
 ///   2. No `meta:` — rename the `name:` key in place to `meta`, and
 ///      wrap its string value `"<X>"` as `{ "name": "<X>" }`. Cheap and
 ///      preserves the original line structure.
-pub fn moveNameToMeta(arena: std.mem.Allocator, src: []const u8, name_value: []const u8, has_meta: bool) ?[]u8 {
-    _ = name_value;
+pub fn moveNameToMeta(arena: std.mem.Allocator, src: []const u8, has_meta: bool) ?[]u8 {
     if (has_meta) {
         // Conservative: leave the existing `meta:` block alone (merging
         // is structurally risky to do byte-level). Just drop the bare
@@ -353,6 +352,18 @@ pub fn collapseFileToArray(arena: std.mem.Allocator, src: []const u8, parsed_val
     const arr_start = loc.value_start;
     const arr_end = loc.value_end;
 
+    // Outer indent = the column of the `"children":` key (its line's
+    // leading-space run). Computed ONCE here and reused by both the
+    // comment-harvest dedent and the array-body dedent below — the
+    // wrapping `{` added exactly this many spaces to every inner line,
+    // and post-collapse the `[` lands at column 0.
+    const outer_indent = blk: {
+        var w: usize = 0;
+        var q0 = loc.line_start;
+        while (q0 < loc.key_start and src[q0] == ' ') : (q0 += 1) w += 1;
+        break :blk w;
+    };
+
     // Leading content (BEFORE the outer `{`) — kept verbatim.
     const pre_header = src[0..file_start];
 
@@ -387,13 +398,6 @@ pub fn collapseFileToArray(arena: std.mem.Allocator, src: []const u8, parsed_val
             // Comment line — keep, dedented by the outer indent
             // (matches the `[` of the array, which lives at column 0
             // post-collapse).
-            // The outer indent equals the column of `"children":`.
-            const outer_indent = blk: {
-                var w: usize = 0;
-                var q = loc.line_start;
-                while (q < loc.key_start and src[q] == ' ') : (q += 1) w += 1;
-                break :blk w;
-            };
             var stripped: usize = 0;
             while (stripped < outer_indent and stripped < s) : (stripped += 1) {}
             harvested.appendSlice(arena, line[stripped..]) catch return null;
@@ -406,13 +410,9 @@ pub fn collapseFileToArray(arena: std.mem.Allocator, src: []const u8, parsed_val
     const header = pre_header;
 
     // Body: dedent the array by one indent level if the inner body uses
-    // a non-zero indent (the wrapping `{` added 4 spaces to every line).
-    // We measure by looking at the column of `[` in the `children:`
-    // line and shifting every line of the array's interior by that
-    // amount minus the file's base indent (0 — top level).
-    var dedent: usize = 0;
-    var q: usize = loc.line_start;
-    while (q < loc.key_start and src[q] == ' ') : (q += 1) dedent += 1;
+    // a non-zero indent (the wrapping `{` added `outer_indent` spaces to
+    // every line). Reuse the cached `outer_indent` computed above.
+    const dedent = outer_indent;
 
     // Build dedented array.
     var body = src[arr_start..arr_end];

--- a/src/cli/migrate/walk.zig
+++ b/src/cli/migrate/walk.zig
@@ -245,6 +245,7 @@ fn migrateFile(
     summary.components_lifts += counts.components_lifts;
     summary.file_as_array_collapses += counts.file_as_array_collapses;
     summary.name_field_drops += counts.name_field_drops;
+    summary.name_field_divergent_drops += counts.name_field_divergent_drops;
     summary.name_field_meta_moves += counts.name_field_meta_moves;
     summary.name_field_xref_warnings += counts.name_field_xref_warnings;
     summary.directives_to_meta_moves += counts.directives_to_meta_moves;


### PR DESCRIPTION
Follow-up polish from PR #240's re-review (RFC #596 migrator). Pure cleanup + counter accuracy — no byte-output change for the transforms.

## Micro-optimizations
1-3. **`collapseFileToArray` — `outer_indent` recomputed** — the column of the `"children":` key was derived twice (comment-harvest dedent + array-body dedent). Now computed once at function entry and reused.
4. **xrefs dedup** — already addressed in #240's fix push (`StringHashMap` + `!xrefs.contains` guard). No change needed.
7. **`moveNameToMeta` unused `name_value` param** (issue comment) — the parameter was immediately discarded (`_ = name_value`) and the `has_meta = false` branch re-derives the value via `findTopLevelKey`. Removed the param + updated the sole caller.

## Stat accuracy
5. **`name_field_meta_moves` miscounted on `has_meta` drop** — when a file already has a `meta:` block and a divergent `name:`, the migrator conservatively DROPS the bare `name:` (byte-merge is unsafe) but the caller still incremented `name_field_meta_moves`, so the summary reported "moved into meta.name" when it was actually dropped. Added a `name_field_divergent_drops` counter; the summary now reports the drop and the move separately, and only the true rename path increments `name_field_meta_moves`.
6. **Prefab guard inconsistency** — `treeHasInlineComponentsWrapper` skipped ANY object with a `prefab` key regardless of value type, while the byte scanner `objectHasWrapper` only keys off a STRING prefab (`prefab_is_string`). Normalized the tree gate to require a string `prefab`, matching `treeHasWrapperOnRef` and the byte scanner. A malformed non-string prefab no longer diverges between the two paths.

## Tests
- New count-accuracy specs for the divergent-name with/without existing `meta:` cases (via a counts-returning test helper).
- New prefab-guard consistency spec covering the non-string `prefab` edge.
- `zig build test`: 439/439 pass (Zig 0.16).

Closes #241

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw