### PR TITLE
feat(android): emit android.hardware.gamepad uses-feature (required=false) in manifest

### DIFF
--- a/src/cli/android/package.zig
+++ b/src/cli/android/package.zig
@@ -383,6 +383,7 @@ fn generateAndroidManifest(allocator: std.mem.Allocator, package_name: []const u
         \\
         \\    <uses-sdk android:minSdkVersion="{d}" android:targetSdkVersion="{d}" />
         \\    <uses-feature android:glEsVersion="0x00030000" android:required="true" />
+        \\    <uses-feature android:name="android.hardware.gamepad" android:required="false" />
         \\
         \\    <application android:hasCode="false" android:label="{s}">
         \\        <activity android:name="android.app.NativeActivity"
@@ -425,6 +426,14 @@ test "generateAndroidManifest adds NoTitleBar.Fullscreen theme when immersive_mo
     const theme_idx = std.mem.indexOf(u8, xml, "android:theme=") orelse
         return std.testing.expect(false);
     try std.testing.expect(theme_idx > activity_start and theme_idx < activity_open_end);
+}
+
+test "generateAndroidManifest advertises the gamepad as an optional feature" {
+    const allocator = std.testing.allocator;
+    const cfg = AndroidConfig{};
+    const xml = try generateAndroidManifest(allocator, "com.test.game", "Test", cfg);
+    defer allocator.free(xml);
+    try std.testing.expect(std.mem.indexOf(u8, xml, "<uses-feature android:name=\"android.hardware.gamepad\" android:required=\"false\" />") != null);
 }
 
 /// Find ANDROID_HOME.

--- a/src/cli/android/studio.zig
+++ b/src/cli/android/studio.zig
@@ -265,6 +265,7 @@ fn generateStudioManifest(
         \\<manifest xmlns:android="http://schemas.android.com/apk/res/android">
         \\
         \\    <uses-feature android:glEsVersion="0x00030000" android:required="true" />
+        \\    <uses-feature android:name="android.hardware.gamepad" android:required="false" />
         \\
         \\    <application android:hasCode="false" android:label="{s}">
         \\        <activity android:name="android.app.NativeActivity"
@@ -345,4 +346,12 @@ test "generateStudioManifest honours orientation and immersive_mode" {
     const immersive = try generateStudioManifest(allocator, "T", .{ .immersive_mode = true });
     defer allocator.free(immersive);
     try std.testing.expect(std.mem.indexOf(u8, immersive, "Theme.NoTitleBar.Fullscreen") != null);
+}
+
+test "generateStudioManifest advertises the gamepad as an optional feature" {
+    const allocator = std.testing.allocator;
+    const cfg = AndroidConfig{};
+    const out = try generateStudioManifest(allocator, "Test", cfg);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "<uses-feature android:name=\"android.hardware.gamepad\" android:required=\"false\" />") != null);
 }


### PR DESCRIPTION
Closes #246

## What

The generated Android manifest never advertised the gamepad feature, so controllers weren't declared. This adds:

```xml
<uses-feature android:name="android.hardware.gamepad" android:required="false" />
```

right after the existing `glEsVersion` line, marking the gamepad as **optional** — the app stays installable on TVs/devices without a controller and remains D-pad navigable, and Play Store install is not restricted.

## Where

Both manifest emitters:
- `src/cli/android/package.zig` — `generateAndroidManifest`
- `src/cli/android/studio.zig` — `generateStudioManifest`

## Tests

Extended the existing manifest tests in both files to assert the `uses-feature` line is present with `required="false"`. `zig build test` passes (exit 0).

Part of the controller-support epic labelle-toolkit/labelle-engine#609.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw